### PR TITLE
linode: specify a default for stackscriptjson

### DIFF
--- a/linodecli/resources/linode.py
+++ b/linodecli/resources/linode.py
@@ -101,7 +101,7 @@ class Linode:
                 help="the public key file to install at `/root/.ssh/authorized_keys` when creating this Linode")
         parser.add_argument('-S', '--stackscript', metavar='STACKSCRIPT_ID', type=int,
                 help="the personal or public StackScript ID to use for deployment")
-        parser.add_argument('-J', '--stackscriptjson', metavar='STACKSCRIPT_JSON', type=str,
+        parser.add_argument('-J', '--stackscriptjson', metavar='STACKSCRIPT_JSON', type=str, default='{}'
                 help="The JSON encoded name/value pairs, answering the StackScript's User Defined Fields (UDFs).")
         parser.add_argument('-b', '--with-backups', action='store_true',
                 help="If true, enable backups on the new Linode")
@@ -276,7 +276,7 @@ location: {}
                 help="the public key file to install at `/root/.ssh/authorized_keys` when creating this Linode")
         parser.add_argument('-S', '--stackscript', metavar='STACKSCRIPT_ID', type=int,
                 help="the personal or public StackScript ID to use for deployment")
-        parser.add_argument('-J', '--stackscriptjson', metavar='STACKSCRIPT_JSON', type=str,
+        parser.add_argument('-J', '--stackscriptjson', metavar='STACKSCRIPT_JSON', type=str, default='{}'
                 help="The JSON encoded name/value pairs, answering the StackScript's User Defined Fields (UDFs).")
         parser.add_argument('-w', '--wait', metavar='TIME', type=int, nargs='?', const=5,
             help="The amount of minutes to wait for boot.  If given with no argument, defaults to 5")


### PR DESCRIPTION
Prevents the API from getting bad values.