### PR TITLE
Suppress `print_help` from being called prematurely

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -70,8 +70,6 @@ def main():
 
     args, unparsed = parser.parse_known_args()
     sys.argv = sys.argv[:1] # clean up sys.argv so future parsers works as expected
-    if add_help:
-        unparsed.insert(0, '-h')
 
     if args.command == 'configure':
         config.configure(username=args.username)

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -16,15 +16,23 @@ def preparse():
 
     args = sys.argv
     held_help = False
-    if '-h' in args:
-        if len(args) > 1 and args[1] in avail_resources:
-            held_help = True
-            args.remove('-h')
 
+    if len(args) == 1:
+        return args, held_help
+
+    # Print main CLI help
+    if len(args) == 2 and args[1] in ('-h', '--help'):
+        held_help = True
+        return args, held_help
+
+    # Otherwise, delegate help to resource
+    if '-h' in args or '--help' in args:
+        held_help = False
+
+    # Default to "linode" resource
     if len(args) > 1:
         if args[1] not in avail_resources:
             args.insert(1, 'linode')
-            return args, held_help
 
     return args, held_help
 
@@ -45,7 +53,7 @@ def main():
     sys.argv, add_help = preparse()
 
     parser = argparse.ArgumentParser(description="Command Line Interface for Linode API v4",
-            add_help=False)
+            add_help=add_help)
     parser.add_argument('object', metavar='TYPE', type=str,
             help="the type of object to act on (linode if omitted)", default='linode')
     parser.add_argument('command', metavar='CMD', type=str,

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -44,7 +44,8 @@ def main():
 
     sys.argv, add_help = preparse()
 
-    parser = argparse.ArgumentParser(description="Command Line Interface for Linode API v4")
+    parser = argparse.ArgumentParser(description="Command Line Interface for Linode API v4",
+            add_help=False)
     parser.add_argument('object', metavar='TYPE', type=str,
             help="the type of object to act on (linode if omitted)", default='linode')
     parser.add_argument('command', metavar='CMD', type=str,


### PR DESCRIPTION
This addresses issue https://github.com/linode/linode-cli/issues/9

Here is the new output after suppressing `print_help`:
```
JohnsMacBook$ python3 linodecli/cli.py create -h -t <TOKEN>

usage: cli.py [-h] [-l LABEL] [-L LOCATION] [-d DISTRIBUTION] [-p PLAN]
              [-P PASSWORD] [-g GROUP] [-K KEYFILE] [-S STACKSCRIPT_ID]
              [-J STACKSCRIPT_JSON] [-b] [-B BACKUP_ID] [-w [TIME]]

CLI Linode Manipulation

optional arguments:
  -h, --help            show this help message and exit
  -l LABEL, --label LABEL
                        the label for the Linode
  -L LOCATION, --location LOCATION
                        the location for deployment.
  -d DISTRIBUTION, --distribution DISTRIBUTION
                        the Distribution label to deploy
  -p PLAN, --plan PLAN  the plan to deploy.
  -P PASSWORD, --password PASSWORD
                        the root password for the new deployment
  -g GROUP, --group GROUP
                        the group to deploy the new Linode to
  -K KEYFILE, --pubkey-file KEYFILE
                        the public key file to install at
                        `/root/.ssh/authorized_keys` when creating this Linode
  -S STACKSCRIPT_ID, --stackscript STACKSCRIPT_ID
                        the personal or public StackScript ID to use for
                        deployment
  -J STACKSCRIPT_JSON, --stackscriptjson STACKSCRIPT_JSON
                        The JSON encoded name/value pairs, answering the
                        StackScript's User Defined Fields (UDFs).
  -b, --with-backups    If true, enable backups on the new Linode
  -B BACKUP_ID, --restore-backup BACKUP_ID
                        The Backup to restore to the new Linode.
  -w [TIME], --wait [TIME]
                        The amount of minutes to wait for boot. If given with
                        no argument, defaults to 5
```

~~If you think this makes sense, I can work through some of the other code in `cli.py` that may be affected by this change and add it too this PR.~~