### PR TITLE
fix '400/linode busy' on rebuild

### DIFF
--- a/linodecli/resources/linode.py
+++ b/linodecli/resources/linode.py
@@ -317,7 +317,6 @@ location: {}
 
         l.rebuild(args.distribution, root_pass=password, authorized_keys=args.pubkey_file,
                 stackscript=args.stackscript, stackscript_data=stackscript_data)
-        l.boot()
 
         if args.wait:
             _wait_for_state(args.wait, l, 'running')


### PR DESCRIPTION
similar to this commit:
https://github.com/linode/linode-cli/commit/26a4801a5cd4713912656f5ff781c58e95d8a948

there was an extra boot command that was causing the 400 error.
pre-edit:

~/github/linode-cli -> linode-cli rebuild rebuild-test
Root Password:
Error: 400: Linode busy.;
~/github/linode-cli ->

post-edit:

~/github/linode-cli -> linode-cli rebuild rebuild-test
Root Password:
~/github/linode-cli ->