### PR TITLE
Added support for secure password input

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,11 +60,11 @@ List Linodes in a Region::
 
 Make a Linode::
 
-   linode-cli linodes create --type g5-standard-2 --region us-east --image linode/debian9 --label cli-1 --root_pass hunter7
+   linode-cli linodes create --type g5-standard-2 --region us-east --image linode/debian9 --label cli-1 --root_pass
 
 Make a Linode using Default Settings::
 
-   linode-cli linodes create --label cli-2 --root_pass hunter7
+   linode-cli linodes create --label cli-2 --root_pass
 
 Reboot a Linode::
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -104,6 +104,7 @@ class CLI:
                 "type": info.get('type') or 'string',
                 "desc": info.get('description') or '',
                 "name": arg,
+                "format": info.get('format', None),
             }
             # handle input lists
             if args[path]['type'] == 'array' and 'items' in info:
@@ -207,7 +208,8 @@ class CLI:
                     cli_args = []
 
                     for arg, info in args.items():
-                        new_arg = CLIArg(info['name'], info['type'], info['desc'].split('.')[0]+'.', arg)
+                        new_arg = CLIArg(info['name'], info['type'], info['desc'].split('.')[0]+'.',
+                                         arg, info['format'])
 
                         if arg in required_fields:
                             new_arg.required = True


### PR DESCRIPTION
Typing passwords on the command line is no good, so now passwords may be
entered through a password prompt if desired.  If you're automating the
creation of Linodes of other actions that require passwords, you may
still specify the password on the command line as you used to.