### PR TITLE
Couple of ideas to further improve the builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,6 @@ check-prerequisites:
 
 .PHONY: clean
 clean:
-	rm linodecli/data-*
-	rm linode-cli.sh
+	rm -f linodecli/data-*
+	rm -f linode-cli.sh
 	rm -f dist/*

--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,22 @@ SPEC ?= https://developers.linode.com/openapi.yaml
 
 ifeq ($(PYTHON), 3)
 	PYCMD=python3
+	PIPCMD=pip3
 else
 	PYCMD=python
+	PIPCMD=pip
 endif
 
 install: check-prerequisites requirements build
-	$(PYCMD) setup.py install
+	ls dist/ | xargs -I{} $(PIPCMD) install --force dist/{}
 
 .PHONY: build
-build: common
-	$(PYCMD) setup.py bdist_wheel --universal
-
-.PHONY: common
-common:
+build: clean
 	python -m linodecli bake ${SPEC} --skip-config
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-2 linodecli/
 	cp data-3 linodecli/
+	$(PYCMD) setup.py bdist_wheel --universal
 
 .PHONY: requirements
 requirements:
@@ -36,3 +35,9 @@ check-prerequisites:
 	@ pip3 -v >/dev/null
 	@ python -V >/dev/null
 	@ python3 -V >/dev/null
+
+.PHONY: clean
+clean:
+	rm linodecli/data-*
+	rm linode-cli.sh
+	rm -f dist/*


### PR DESCRIPTION
I really like what @ginkgomzd with the build process - I'm not going to
lie, this is my first Makefile, and I appreciate the cleanup.  I had a
few ideas looking it over:

If we're going to build a package during the install process,
why not install the package that we just built?  I think that works
better anyway - once you test the package that was installed, you can
confidently distribute it knowing that it is the same code you just ran.

I also  added a clean step to delete all of the generated files
(linodecli/data-* and linode-cli.sh along with the contents of dist/) to
make sure everything's fresh with each build.