### PR TITLE
WIP: Started implementing a better spec parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorclass
 requests
 PyYAML
 enum34
+openapi3

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     url="https://developers.linode.com/api/v4",
     packages=['linodecli'],
     license="BSD 3-Clause License",
-    install_requires=["terminaltables","colorclass","requests","PyYAML","enum34"],
+    install_requires=["terminaltables","colorclass","requests","PyYAML","enum34", "openapi3"],
     entry_points={
         "console_scripts": [
             "linode-cli = linodecli:main",


### PR DESCRIPTION
Pivoting from the spec parser provided here (which was fragile and based
on the Linode OpenAPI specification) to a [more robust parser](https://github.com/dorthu/openapi3) based on
the OpenAPI 3 Standard.

This is currently a work in progress, and doesn't work yet.  More coming
soon.  This change should be transparent to the end user.