### PR TITLE
BATS tests Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+dist

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -12,6 +12,7 @@ ENV PATH="/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin
 
 WORKDIR /src
 
+# Build and Install Linode CLI
 RUN git clone https://github.com/linode/linode-cli.git \
     && cd linode-cli \
     && git submodule init \
@@ -23,6 +24,7 @@ RUN git clone https://github.com/linode/linode-cli.git \
     && pip install --user $(ls) \
     && echo -n "[DEFAULT]\ntoken = ${TOKEN}" > /root/.linode-cli
 
+# Install BATS testing framework
 RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && ./install.sh /usr/local

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -1,0 +1,30 @@
+FROM python:2
+
+ARG SPEC=https://developers.linode.com/openapi.yaml
+ARG TOKEN
+
+RUN apt-get update && apt-get install -y python3 python3-pip bats
+RUN pip install requests terminaltables colorclass PyYAML enum34
+RUN pip3 install requests terminaltables colorclass PyYAML enum34
+
+ENV PYTHONPATH=.
+ENV PATH="/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
+
+WORKDIR /src
+
+RUN git clone https://github.com/linode/linode-cli.git \
+    && cd linode-cli \
+    && git submodule init \
+    && git submodule update \
+    && make requirements \
+    && make build SPEC=${SPEC} \
+    && make install SPEC=${SPEC} \
+    && cd dist \
+    && pip install --user $(ls) \
+    && echo -n "[DEFAULT]\ntoken = ${TOKEN}" > /root/.linode-cli
+
+RUN git clone https://github.com/bats-core/bats-core.git \
+    && cd bats-core \
+    && ./install.sh /usr/local
+
+CMD bats /src/linode-cli/test/linodes

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -10,23 +10,24 @@ RUN pip3 install requests terminaltables colorclass PyYAML enum34
 ENV PYTHONPATH=.
 ENV PATH="/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
 
-WORKDIR /src
+WORKDIR /src/linode-cli
+
+COPY . .
 
 # Build and Install Linode CLI
-RUN git clone https://github.com/linode/linode-cli.git \
-    && cd linode-cli \
-    && git submodule init \
+RUN git submodule init \
     && git submodule update \
-    && make requirements \
     && make build SPEC=${SPEC} \
     && make install SPEC=${SPEC} \
     && cd dist \
     && pip install --user $(ls) \
     && echo -n "[DEFAULT]\ntoken = ${TOKEN}" > /root/.linode-cli
 
+WORKDIR /src
+
 # Install BATS testing framework
 RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && ./install.sh /usr/local
 
-CMD bats /src/linode-cli/test/linodes
+CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains

--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,15 @@ Running the tests is simple. The only requirement is that you have a .linode-cli
 
    ./test/test-runner.sh
 
+**Running Tests via Docker**
+
+Run the following command to build the tests container:
+
+   docker build -f Dockerfile-bats -t linode-cli-tests --build-arg TOKEN=$INSERT_YOUR_TOKEN_HERE .
+
+Run the following command to run the test
+
+   docker run --rm linode-cli-tests
 
 Contributing
 ------------


### PR DESCRIPTION
* Adds Dockerfile to run BATS tests
* Adds dockerignore file so that builds/dist files are ignored when creating the docker image

* This PR was based off the domains test branch, I will rebase once that PR is merged. The main files of concern here are `Dockerfile-bats` `.dockerignore` and `README.rst`

## Testing

***Please remember these TESTS **WILL DELETE ALL RESOURCES** (linodes/volumes/domains/nodebalancers/etc/etc) associated with your linode account!***

* Follow the instructions for running via docker in the README

cc. @Dorthu 