### PR TITLE
Testing - API Base Url Override

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -1,6 +1,7 @@
 FROM python:2
 
 ARG SPEC=https://developers.linode.com/openapi.yaml
+ARG API_OVERRIDE=api.linode.com
 ARG TOKEN
 
 RUN apt-get update && apt-get install -y python3 python3-pip bats
@@ -9,16 +10,27 @@ RUN pip3 install requests terminaltables colorclass PyYAML enum34
 
 ENV PYTHONPATH=.
 ENV PATH="/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"
+ENV DEFAULT_API="url: https://api.linode.com/v4"
+ENV API_ENV="url: https://${API_OVERRIDE}/v4"
 
 WORKDIR /src/linode-cli
 
 COPY . .
 
-# Build and Install Linode CLI
-RUN git submodule init \
+# Preserve the original cli.py file
+RUN mv linodecli/cli.py linodecli/original-cli.py
+
+# Modify the cli.py to no longer verify certs and suppress warnings (allows running tests on custom environments)
+RUN sed 's/data=body/data=body,verify=False/' linodecli/original-cli.py > linodecli/cli.py \
+    && echo "from requests.packages.urllib3.exceptions import InsecureRequestWarning\nrequests.packages.urllib3.disable_warnings(InsecureRequestWarning)" >> /src/linode-cli/linodecli/cli.py
+
+# Build and Install the Linode CLI
+RUN curl -o /src/linode-cli/openapi.yaml ${SPEC} \
+    && sed -n "s|${DEFAULT_API}|${API_ENV}|g;w cli-tests.yaml" /src/linode-cli/openapi.yaml \
+    && git submodule init \
     && git submodule update \
-    && make build SPEC=${SPEC} \
-    && make install SPEC=${SPEC} \
+    && make build SPEC=cli-tests.yaml \
+    && make install SPEC=cli-tests.yaml \
     && cd dist \
     && pip install --user $(ls) \
     && echo -n "[DEFAULT]\ntoken = ${TOKEN}" > /root/.linode-cli


### PR DESCRIPTION
* Allows overriding the api url provided by the `openapi.yaml` file. This will allow running the bats tests on non-default environments
* This does assume a default api url in the openapi spec of `https://api.linode.com/v4`.. @Dorthu  we can change this to be dynamic and call it `ORIGINAL_API_ROUTE` or something like it, should we need to make this more robust.

# To Test:

```bash
docker build -f Dockerfile-bats -t linode-cli --no-cache --build-arg SPEC="https://some-custom-path.com/openapi.yaml" --build-arg TOKEN=ENTER-YOUR-TOKEN-HERE --build-arg API_OVERRIDE="some-custom-path.myAPI.com" .

docker run --rm linode-cli
```
