### PR TITLE
feat: Support access token in LINODE_TOKEN environment variable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ linode-cli.sh
 data-2
 data-3
 .DS_STORE
+Pipfile*
 


### PR DESCRIPTION
Following the discussion in #52, I've made this pull request which adds basic support for a `LINODE_TOKEN` environment variable which stores the OAuth token.

This is rudimentary and will break support for multiple profiles (only when using LINODE_TOKEN), although it's technically feasible with a pattern like `LINODE_<USER>_TOKEN` which can be supported quite easily. (I've added a warning to `configure` if LINODE_TOKEN is detected.)

I'm not too sure how I feel about sensitive data in environment variables, but given that this is how a lot of cloud providers do it, and given that this most likely runs on single user systems, I think it should be fairly safe.

If you feel like it's needed, I can quickly add the multiple profile support for environment variables.

I'm also considering adding some kind of `--crypt` mechanism to encrypt the tokens with a passphrase-derived symmetric key, but this would be a bit more work and require a mechanism to persist the key across commands, otherwise I can see it becoming very clunky to use. Let me know how you feel about this idea.

Cheers,

PS: Closes #52 

