### PR TITLE
Volumes BATS tests

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -1,10 +1,30 @@
+createLinode() {
+    local linode_type=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
+    run bash -c "linode-cli linodes create --type=$linode_type --region us-east --image=$test_image --root_pass=$random_pass"
+    assert_success
+}
+
+createVolume() {
+    timestamp=$(date +%s)
+    run bash -c "linode-cli volumes create --label=A$timestamp --size=10 --region=us-east"
+    assert_success
+}
+
+shutdownLinodes() {
+    local linode_ids="( $(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs) )"
+    local id
+
+    for id in $linode_ids ; do
+        run bash -c "linode-cli linodes shutdown $id"
+    done
+}
+
 removeLinodes() {
     local linode_ids="( $(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs) )"
     local id
 
     for id in $linode_ids ; do
         run bash -c "linode-cli linodes delete $id"
-        [ "$status" -eq 0 ]
     done
 }
 
@@ -15,6 +35,15 @@ removeDomains() {
     for id in $domain_ids ; do
         run bash -c "linode-cli domains delete $id"
         [ "$status" -eq 0 ]
+    done
+}
+
+removeVolumes() {
+    local volume_ids="( $(linode-cli volumes list --text --no-headers --format="id" | xargs) )"
+    local id
+
+    for id in $volume_ids ; do
+        run bash -c "linode-cli volumes delete $id"
     done
 }
 

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -18,7 +18,7 @@ then
         cd $PWD/test
     fi
 
-    bats linodes domains
+    bats linodes domains volumes
 else
     echo -e "\n ####WARNING!#### \n"
     echo -e  "Running the Linode CLI tests requires removing all resources on your account\n"

--- a/test/volumes/attach-detach-volumes.bats
+++ b/test/volumes/attach-detach-volumes.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+# THESE TESTS HAVE BEEN DISABLED UNTIL ARB-763 IS ADDRESSED
+
+# load '../test_helper/bats-support/load'
+# load '../test_helper/bats-assert/load'
+# load '../common'
+
+# ##################################################################
+# #  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+# #  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+# ##################################################################
+
+# @test "it should attach volume to a linode during volume creation" {
+#     createLinode
+    
+#     linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
+
+#     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
+#         echo 'still provisioning'
+#     done
+
+#     linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
+#     run linode-cli volumes create --label="attachedVolume" --size=10 --linode_id=$linode_id --text --no-headers --delimiter="," --format="id,label,size,region,linode_id"
+#     assert_success
+#     assert_output --regexp "[0-9]+,attachedVolume,10,us-east,$linode_id"
+# }
+
+# @test "it should detach from linode" {
+#     attached_volume_id=$(linode-cli volumes list --label="attachedVolume" --format="id" --text --no-headers)
+#     run linode-cli volumes detach $attached_volume_id --text --no-headers
+#     assert_success
+#     run linode-cli volumes view $attached_volume_id --text --no-headers --delimiter="," --format="id,label,size,region,linode_id"
+#     assert_success
+#     assert_output --regexp "$attached_volume_id,attachedVolume,10,us-east,"
+# }
+
+# @test "it should attach to a linode" {
+#     volume_id=$(linode-cli volumes list --format="id" --text --no-headers)
+#     linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
+#     run linode-cli volumes attach --linode_id=$linode_id $volume_id --text --no-headers --delimiter="," --format="id,label,size,region,linode_id"
+#     assert_success
+#     assert_output --regexp "$volume_id,attachedVolume,10,us-east,$linode_id"
+# }
+
+# @test "it should fail to remove while attached" {
+#     attached_volume=$(linode-cli volumes list --format="id" --text --no-headers)
+#     run linode-cli volumes delete $attached_volume --text --no-headers
+#     assert_failure
+#     assert_output --partial "Request failed: 400"
+#     assert_output --partial "This volume must be detached before it can be deleted."
+# }
+
+# @test "it should fail to attach to a linode that does not belong to the user" {
+#     unattached_volume=$(linode-cli volumes create --label="unattachedVolume" --region="us-east" --size=10 --text --no-headers --format="id")
+#     run linode-cli volumes attach --linode_id=1 $unattached_volume --text --no-headers
+#     assert_failure
+#     assert_output --partial "Request failed: 403"
+#     assert_output --partial "linode_id	You do not have permission to access this Linode"
+# }
+
+# @test "it should remove all volumes" {
+#     run shutdownLinodes
+# 	run removeLinodes
+# 	run removeVolumes
+# }

--- a/test/volumes/attach-detach-volumes.bats
+++ b/test/volumes/attach-detach-volumes.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# THESE TESTS HAVE BEEN DISABLED UNTIL ARB-763 IS ADDRESSED
+# THESE TESTS HAVE BEEN DISABLED UNTIL A BUG IS ADDRESSED
 
 # load '../test_helper/bats-support/load'
 # load '../test_helper/bats-assert/load'

--- a/test/volumes/create-volumes.bats
+++ b/test/volumes/create-volumes.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+##################################################################
+#  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+#  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+##################################################################
+
+@test "it should fail to create a volume under 10gb" {
+    timestamp=$(date +%s)
+    run linode-cli volumes create --label "A$timestmap" --region us-east --size 5 --text --no-headers
+    assert_failure
+    assert_output --partial "size	Must be 10-10240"
+}
+
+@test "it should fail to create a volume without a region" {
+	run linode-cli volumes create --label "A$timestamp" --size 10 --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "Must provide a region or a Linode ID"
+}
+
+@test "it should fail to create a volume without a label" {
+	run linode-cli volumes create --size 10 --region us-east --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "label	label is required"
+}
+
+@test "it should fail to create a volume over 10240gb in size" {
+	run linode-cli volumes create --size 10241 --label "A$timestamp" --region us-east --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "size	Must be 10-10240"
+}
+
+@test "it should fail to create a volume with an all numeric label" {
+	run linode-cli volumes create --label "9200900" --region us-east --size 10 --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "label	Must begin with a letter"
+}
+
+@test "it should create an unattached volume" {
+	timestamp=$(date +%s)
+	run linode-cli volumes create --label "A$timestamp" --region us-east --size 10 --text --no-headers --delimiter ","
+	assert_success
+	assert_output --regexp "[0-9]+,A[0-9]+,creating,10,us-east"
+}
+
+# @test "it should create volume attached to a linode" {
+# 	timestamp=$(date +%s)
+# 	linode_id=$(linode-cli linodes list --text --no-headers --format "id")
+# 	run linode-cli volumes create --label "A$timestamp" --region us-east --size 10 --linode_id=$linode_id --text --no-headers --delimiter ","
+# 	assert_success
+# 	assert_output --regexp "[0-9]+,A$timestamp,creating,10,us-east,$linode_id"
+# }
+
+@test "it should remove all volumes" {
+	run removeLinodes
+	run removeVolumes
+}

--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+##################################################################
+#  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+#  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+##################################################################
+
+@test "it should list volumes" {
+    run createVolume
+    run linode-cli volumes list --text --no-headers --delimiter=","
+    assert_success
+    assert_output --regexp "[0-9]+,A[0-9]+,creating,10,us-east"
+}
+
+@test "it should view a single volume" {
+    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
+    run linode-cli volumes view $volume_id --text --no-headers --delimiter="," --format="id,label,size,region"
+    assert_success
+    assert_output --regexp "$volume_id,A[0-9]+,10,us-east"
+}
+
+@test "it should update a volume label" {
+    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
+    run linode-cli volumes update --label=A-NewLabel-2 $volume_id --text --no-headers --format="label"
+    assert_success
+    assert_output "A-NewLabel-2"
+}
+
+@test "it should fail to update volume size" {
+    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
+    run linode-cli volumes update --size=15 $volume_id --text --no-headers --format="size"
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "size	size is not an editable field"
+}
+
+@test "it should remove all volumes" {
+    run removeVolumes
+}

--- a/test/volumes/resize-volumes.bats
+++ b/test/volumes/resize-volumes.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+##################################################################
+#  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+#  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+##################################################################
+
+@test "it should fail to resize a volume smaller" {
+    createVolume
+    volume_id=$(linode-cli volumes list --text --no-headers --format="id")
+    run linode-cli volumes resize $volume_id --size=5 --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "Storage volumes can only be resized up"
+}
+
+@test "it should fail to resize a volume greater than 10240gb" {
+    volume_id=$(linode-cli volumes list --text --no-headers --format="id")
+    run linode-cli volumes resize $volume_id --size=1024893405 --text --no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "Storage volumes cannot be resized larger than 10240 gigabytes"
+}
+
+@test "it should resize a volume" {
+    volume_id=$(linode-cli volumes list --text --no-headers --format="id")
+    run linode-cli volumes resize $volume_id --size=11 --text --no-headers
+    assert_success
+    run linode-cli volumes view $volume_id --format="size" --text --no-headers
+    assert_success
+    assert_output "11"
+}
+
+@test "it should remove all volumes" {
+    run removeVolumes
+}


### PR DESCRIPTION
* Added BATS tests for volumes
* Disabled tests for attaching/detaching volumes because they seem to be problematic due to ARB-763. 

## Running the Tests
* Ensure your `~/.linode-cli` config uses a test user token, running the tests removes all resources associated with the test account. YOU HAVE BEEN WARNED.
* From the base of the repo:

```bash
./test/test-runner.sh
```