### PR TITLE
Add Volumes tests to test Dockerfile command

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -43,4 +43,4 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && ./install.sh /usr/local
 
 
-CMD bats $(ls test/*/*.bats)
+CMD bats $(ls /src/linode-cli/test/*/*.bats)

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -42,4 +42,4 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && ./install.sh /usr/local
 
-CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains
+CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -42,4 +42,5 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && cd bats-core \
     && ./install.sh /usr/local
 
-CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes
+
+CMD bats $(ls test/*/*.bats)

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -33,7 +33,7 @@ RUN curl -o /src/linode-cli/openapi.yaml ${SPEC} \
     && make install SPEC=cli-tests.yaml \
     && cd dist \
     && pip install --user $(ls) \
-    && echo -n "[DEFAULT]\ntoken = ${TOKEN}" > /root/.linode-cli
+    && echo -n "[DEFAULT]\ntoken = ${TOKEN}\n" > /root/.linode-cli
 
 WORKDIR /src
 
@@ -43,4 +43,4 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && ./install.sh /usr/local
 
 
-CMD bats $(ls /src/linode-cli/test/*/*.bats)
+CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -18,7 +18,7 @@ then
         cd $PWD/test
     fi
 
-    bats linodes domains volumes
+    bats $(ls */*.bats)
 else
     echo -e "\n ####WARNING!#### \n"
     echo -e  "Running the Linode CLI tests requires removing all resources on your account\n"

--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -13,7 +13,7 @@ load '../common'
     run createVolume
     run linode-cli volumes list --text --no-headers --delimiter=","
     assert_success
-    assert_output --regexp "[0-9]+,A[0-9]+,creating,10,us-east"
+    assert_output --regexp "[0-9]+,A[0-9]+,(creating|active),10,us-east"
 }
 
 @test "it should view a single volume" {


### PR DESCRIPTION
* Adds the volumes tests directory to the BATS dockerfile start command 
* Updates the test runner to look for `.bats` files in the test directory
* updates the assertion for the list volumes test to accept `creating` or `active` response from the API, because volume creation is quick! apparently. 