### PR TITLE
Added Markdown output format

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -42,6 +42,8 @@ def main():
                         help="The delimiter when displaying raw output.")
     parser.add_argument('--json', action='store_true',
                         help="Display output as JSON")
+    parser.add_argument('--markdown', action='store_true',
+                        help="Display output in Markdown format.")
     parser.add_argument('--pretty', action='store_true',
                         help="If set, pretty-print JSON output")
     parser.add_argument('--no-headers', action='store_true',
@@ -71,6 +73,8 @@ def main():
         cli.output_handler.mode = OutputMode.delimited
     elif parsed.json:
         cli.output_handler.mode = OutputMode.json
+    elif parsed.markdown:
+        cli.output_handler.mode = OutputMode.markdown
     if parsed.delimiter:
         cli.output_handler.delimiter = parsed.delimiter
     if parsed.pretty:

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -159,7 +159,7 @@ class OutputHandler:
             content=data
         else:
             for model in data:
-                content.append([attr.render_value(model) for attr in columns])
+                content.append([attr.render_value(model, colorize=False) for attr in columns])
 
         if header:
             print('| ' + ' | '.join([str(c) for c in header]) + ' |')

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -10,6 +10,7 @@ class OutputMode(Enum):
     table=1
     delimited=2
     json=3
+    markdown=4
 
 
 class OutputHandler:
@@ -46,6 +47,8 @@ class OutputHandler:
             self._delimited_output(header, data, columns, to)
         elif self.mode == OutputMode.json:
             self._json_output(header, data, to)
+        elif self.mode == OutputMode.markdown:
+            self._markdown_output(header, data, columns, to)
 
     def _get_columns(self, response_model):
         """
@@ -144,3 +147,23 @@ class OutputHandler:
                 if v:
                     ret[k] = v
         return ret
+
+    def _markdown_output(self, header, data, columns, to):
+        """
+        Pretty-prints data in a Markdown-formatted table.  This uses github's
+        flavor of Markdown
+        """
+        content = []
+
+        if isinstance(columns[0], str):
+            content=data
+        else:
+            for model in data:
+                content.append([attr.render_value(model) for attr in columns])
+
+        if header:
+            print('| ' + ' | '.join([str(c) for c in header]) + ' |')
+            print('|---' * len(header) + '|')
+
+        for row in content:
+            print('| ' + ' | '.join([str(c) for c in row]) + ' |')

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -29,7 +29,7 @@ class ModelAttr:
 
         return value
 
-    def render_value(self, model):
+    def render_value(self, model, colorize=True):
         """
         Given the model returned from the API, returns the correctly- rendered
         version of it.  This can transform text based on various rules
@@ -45,7 +45,7 @@ class ModelAttr:
         if isinstance(value, list):
             value = ', '.join([str(c) for c in value])
 
-        if self.color_map is not None:
+        if colorize and self.color_map is not None:
             # apply colors
             value = str(value) # just in case
             color = self.color_map.get(value) or self.color_map['default_']


### PR DESCRIPTION
Closes #67

As requested, prints out output in a github-styled markdown format.

Example usage: `linode-cli regions list --markdown` outputs this:

| id | country |
|---|---|
| us-central | us |
| us-west | us |
| us-southeast | us |
| us-east | us |
| eu-west | uk |
| ap-south | sg |
| eu-central | de |
| ap-northeast | jp |
| ap-northeast-1a | jp |