### PR TITLE
Add tags tests, refactor existing tests

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -4,9 +4,9 @@ ARG SPEC=https://developers.linode.com/api/v4/openapi.yaml
 ARG API_OVERRIDE=api.linode.com
 ARG TOKEN
 
-RUN apt-get update && apt-get install -y python3 python3-pip bats
-RUN pip install requests terminaltables colorclass PyYAML enum34
-RUN pip3 install requests terminaltables colorclass PyYAML enum34
+RUN apt-get update && apt-get install -y python3 python3-pip bats \
+    && pip install requests terminaltables colorclass PyYAML enum34 \
+    && pip3 install requests terminaltables colorclass PyYAML enum34
 
 ENV PYTHONPATH=.
 ENV PATH="/usr/local/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.local/bin"

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -43,4 +43,4 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && ./install.sh /usr/local
 
 
-CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes /src/linode-cli/test/tags
+CMD bats $(ls /src/linode-cli/test/**/*.bats  | egrep  -v 'bats-')

--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -43,4 +43,4 @@ RUN git clone https://github.com/bats-core/bats-core.git \
     && ./install.sh /usr/local
 
 
-CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes
+CMD bats /src/linode-cli/test/linodes /src/linode-cli/test/domains /src/linode-cli/test/volumes /src/linode-cli/test/tags

--- a/test/common.bash
+++ b/test/common.bash
@@ -1,3 +1,18 @@
+# Get an available image and set it as an env variable
+if [ -z "$test_image" ]; then
+    export test_image=$(linode-cli images list --format id --text --no-header | egrep "linode\/.*" | head -n 1)
+fi
+
+# Random pass to use persistently thorough test run
+if [  -z "$random_pass" ]; then
+    export random_pass=$(openssl rand -base64 32)
+fi
+
+# A Unique tag to use in tag related tests
+if [ -z "$uniqueTag" ]; then
+    export uniqueTag="$(date +%s)-tag"
+fi
+
 createLinode() {
     local linode_type=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
     run bash -c "linode-cli linodes create --type=$linode_type --region us-east --image=$test_image --root_pass=$random_pass"
@@ -47,11 +62,6 @@ removeVolumes() {
     done
 }
 
-# Get an available image and set it as an env variable
-if [ -z "$test_image" ]; then
-    export test_image=$(linode-cli images list --format id --text --no-header | egrep "linode\/.*" | head -n 1)
-fi
-
-if [  -z "$random_pass" ]; then
-	export random_pass=$(openssl rand -base64 32)
-fi
+removeUniqueTag() {
+    run bash -c "linode-cli tags delete $uniqueTag"
+}

--- a/test/domains/domain-records.bats
+++ b/test/domains/domain-records.bats
@@ -4,36 +4,71 @@ load '../test_helper/bats-support/load'
 load '../test_helper/bats-assert/load'
 load '../common'
 
-export domainId=$(linode-cli domains list --format="id" --text --no-header)
+setup() {
+    export domainId=$(linode-cli domains list --format="id" --text --no-header)
+}
 
 @test "it should create a domain" {
-    export timestamp=$(date +%s)
-    run linode-cli domains create --type master --domain "$timestamp-example.com" --soa_email="pthiel@linode.com" --text --no-header
+    timestamp=$(date +%s)
+
+    run linode-cli domains create \
+        --type master \
+        --domain "$timestamp-example.com" \
+        --soa_email="pthiel@linode.com" \
+        --text \
+        --no-header
+
     assert_success
 }
 
 @test "it should create a domain SRV record" {
-    run linode-cli domains records-create --protocol=tcp --type=SRV --port=23 --priority=4 --service=telnet --target=8.8.8.8 --weight=4 $domainId --text --no-header --delimiter=","
+    run linode-cli domains records-create \
+        --protocol=tcp \
+        --type=SRV \
+        --port=23 \
+        --priority=4 \
+        --service=telnet \
+        --target=8.8.8.8 \
+        --weight=4 $domainId \
+        --text \
+        --no-header \
+        --delimiter=","
+
     assert_success
     assert_output --regexp "[0-9]+,SRV,_telnet.tcp._tcp,8.8.8.8,0,4,4"
 }
 
 @test "it should list the SRV record" {
-    run linode-cli domains records-list $domainId --text --no-header --delimiter=","
+    run linode-cli domains records-list $domainId \
+        --text \
+        --no-header \
+        --delimiter=","
+
     assert_success
     assert_output --regexp "[0-9]+,SRV,_telnet.tcp._tcp,8.8.8.8,0,4,4"
 }
 
 @test "it should view domain record" {
     recordId=$(linode-cli domains records-list $domainId --text --no-header --format="id")
-    run linode-cli domains records-view $domainId $recordId --text --no-header --delimiter=","
+    run linode-cli domains records-view $domainId $recordId \
+        --text \
+        --no-header \
+        --delimiter=","
+
     assert_success
     assert_output --regexp "[0-9]+,SRV,_telnet.tcp._tcp,8.8.8.8,0,4,4"
 }
 
 @test "it should update a domain record" {
+    skip "BUG 969"
+
     recordId=$(linode-cli domains records-list $domainId --text --no-header --format="id")
-    run linode-cli domains records-update $domainId $recordId --target="8.8.4.4" --text --no-header --delimiter=","
+    run linode-cli domains records-update $domainId $recordId \
+        --target="8.8.4.4" \
+        --text \
+        --no-header \
+        --delimiter=","
+
     assert_success
     assert_output --regexp "[0-9]+,SRV,_telnet.tcp._tcp,8.8.4.4,0,4,4"
 }
@@ -41,6 +76,7 @@ export domainId=$(linode-cli domains list --format="id" --text --no-header)
 @test "it should delete a domain record" {
     recordId=$(linode-cli domains records-list $domainId --text --no-header --format="id")
     run linode-cli domains records-delete $domainId $recordId
+
     assert_success
 }
 

--- a/test/domains/domains-tags.bats
+++ b/test/domains/domains-tags.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "it should fail to create a master domain with invalid tags" {
-    skip "Fails due to a known issue"
+    skip "BUG 943"
 
     badTag="*"
     timestamp=$(date +%s)
@@ -32,7 +32,7 @@ teardown() {
 }
 
 @test "it should fail to create a slave domain with invalid tags" {
-    skip "Fails due to a known issue"
+    skip "BUG 943"
 
     badTag="*2"
     run linode-cli domains create \

--- a/test/domains/domains-tags.bats
+++ b/test/domains/domains-tags.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+setup() {
+    export timestamp=$(date +%s)
+}
+
+teardown() {
+    unset timestamp
+}
+
+@test "it should fail to create a master domain with invalid tags" {
+    skip "Fails due to a known issue"
+
+    badTag="*"
+    timestamp=$(date +%s)
+    run linode-cli domains create \
+        --type master \
+        --soa_email="pthiel+$timestamp@linode.com" \
+        --domain "$timestamp-example.com" \
+        --tags "$badTag" \
+        --text \
+        --no-header \
+        --delimiter ","
+        --format="id,domain,type,status,soa_email,tags" \
+        --suppress-warnings
+
+    assert_failure
+}
+
+@test "it should fail to create a slave domain with invalid tags" {
+    skip "Fails due to a known issue"
+
+    badTag="*2"
+    run linode-cli domains create \
+        --type slave \
+        --soa_email="pthiel345@linode.com" \
+        --domain "$timestamp-example.com" \
+        --tags "$badTag" \
+        --text \
+        --no-header \
+        --delimiter "," \
+        --format="id,domain,type,status,soa_email,tags"
+
+    assert_failure
+}
+
+@test "it should create a master domain with tags" {
+    tag="foo"
+    email="pthiel+$timestamp@linode.com"
+    run linode-cli domains create \
+        --type master \
+        --soa_email="$email" \
+        --domain "$timestamp-example.com" \
+        --tags "$uniqueTag" \
+        --format="id,domain,type,status,tags" \
+        --suppress-warnings \
+        --text \
+        --no-header \
+        --delimiter=","
+
+    assert_success
+    assert_output --regexp "[0-9]+,[0-9]+-example.com,master,active,${uniqueTag}"
+}
+
+@test "it should cleanup domains and tags" {
+    run removeDomains
+    run removeUniqueTag
+}

--- a/test/domains/master-domains.bats
+++ b/test/domains/master-domains.bats
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "it should fail to create a master domain without a SOA email" {
-	run linode-cli domains create
+	run linode-cli domains create \
 		--type master \
 		--domain "$timestamp-example.com" \
 		--text \
@@ -37,7 +37,7 @@ teardown() {
 }
 
 @test "it should create a master domain" {
-	run linode-cli domains create
+	run linode-cli domains create \
 		--type master \
 		--soa_email="pthiel+$timestamp@linode.com" \
 		--domain "$timestamp-example.com" \

--- a/test/domains/master-domains.bats
+++ b/test/domains/master-domains.bats
@@ -4,48 +4,90 @@ load '../test_helper/bats-support/load'
 load '../test_helper/bats-assert/load'
 load '../common'
 
+setup() {
+	export timestamp=$(date +%s)
+}
+
+teardown() {
+	unset timestamp
+}
+
 @test "it should fail to create a domain without specifying a type" {
-	timestamp=$(date +%s)
-	run linode-cli domains create --domain "$timestamp-example.com" --soa_email="pthiel+$timestamp@linode.com" --text --no-header
+	run linode-cli domains create \
+		--domain "$timestamp-example.com" \
+		--soa_email="pthiel+$timestamp@linode.com" \
+		--text \
+		--no-header
+
 	assert_failure
 	assert_output --partial "Request failed: 400"
-	assert_output --partial "type	type is required"
+	assert_output --partial "type	type is not valid"
 }
 
 @test "it should fail to create a master domain without a SOA email" {
-	timestamp=$(date +%s)
-	run linode-cli domains create --type master --domain "$timestamp-example.com" --text --no-header
+	run linode-cli domains create
+		--type master \
+		--domain "$timestamp-example.com" \
+		--text \
+		--no-header
+
 	assert_failure
 	assert_output --partial "Request failed: 400"
 	assert_output --partial "soa_email	SOA_Email required when type=master"
 }
 
 @test "it should create a master domain" {
-	timestamp=$(date +%s)
-	run linode-cli domains create --type master --soa_email="pthiel+$timestamp@linode.com" --domain "$timestamp-example.com" --text --no-header --delimiter "," --format="id,domain,type,status,soa_email"
+	run linode-cli domains create
+		--type master \
+		--soa_email="pthiel+$timestamp@linode.com" \
+		--domain "$timestamp-example.com" \
+		--text \
+		--no-header \
+		--delimiter "," \
+		--format="id,domain,type,status,soa_email"
+
 	assert_success
 	assert_output --regexp "[0-9]+,$timestamp-example.com,master,active,pthiel\+$timestamp@linode.com"
 }
 
 @test "it should update the master domain soa_email" {
+	# Remove --master_ips param when 872 is resolved
 	newSoaEmail='pthiel@linode.com'
-	run linode-cli domains update $(linode-cli domains list --text --no-header --format="id") --soa_email $newSoaEmail --format="soa_email" --text --no-header
+
+	run linode-cli domains update $(linode-cli domains list --text --no-header --format="id") \
+		--type master \
+		--master_ips 8.8.8.8 \
+		--soa_email $newSoaEmail \
+		--format="soa_email" \
+		--text \
+		--no-header
+
 	assert_success
 	assert_output --partial $newSoaEmail
 }
 
 @test "it should list master domains" {
-	run linode-cli domains list --format="id,domain,type,status" --text --no-header --delimiter=","
+	run linode-cli domains list \
+		--format="id,domain,type,status" \
+		--text \
+		--no-header \
+		--delimiter=","
+
 	assert_success
 	assert_output --regexp "[0-9]+,[0-9]+-example.com,master,active"
 }
 
 @test "it should show domain detail" {
-	run linode-cli domains view $(linode-cli domains list --text --no-header --format="id") --text --no-header --delimiter="," --format="id,domain,type,status,soa_email"
+	run linode-cli domains view $(linode-cli domains list --text --no-header --format="id") \
+		--text \
+		--no-header \
+		--delimiter="," \
+		--format="id,domain,type,status,soa_email"
+
 	assert_success
 	assert_output --regexp "[0-9]+,[0-9]+-example.com,master,active"
 }
 
-@test "it should delete all slave domains" {
+@test "it should delete all master domains" {
     run removeDomains
 }

--- a/test/domains/master-domains.bats
+++ b/test/domains/master-domains.bats
@@ -21,7 +21,7 @@ teardown() {
 
 	assert_failure
 	assert_output --partial "Request failed: 400"
-	assert_output --partial "type	type is not valid"
+	assert_output --partial "type	type is required"
 }
 
 @test "it should fail to create a master domain without a SOA email" {

--- a/test/domains/slave-domains.bats
+++ b/test/domains/slave-domains.bats
@@ -24,12 +24,13 @@ domainTimeStamp=0
     assert_output --partial "$domainTimeStamp-example.com"
 }
 
-# @test "it should fail to update domain without a type" {
-#     slaveId=$(linode-cli domains list --domain "$domainTimeStamp-example.com" --format "id" --text --no-header)
-#     run linode-cli domains update $slaveId --master_ips 8.8.8.8 --text --no-header --deleteimiter "," --format "id,domain,type,status"
-#     assert_failure
-#     # assert_output --partial
-# }
+@test "it should fail to update domain without a type" {
+    skip "BUG 872"
+    slaveId=$(linode-cli domains list --domain "$domainTimeStamp-example.com" --format "id" --text --no-header)
+    run linode-cli domains update $slaveId --master_ips 8.8.8.8 --text --no-header --deleteimiter "," --format "id,domain,type,status"
+    assert_failure
+    # assert_output --partial
+}
 
 @test "it should update a slave domain" {
     slaveId=$(linode-cli domains list --domain $domainTimeStamp-example.com --format "id" --text --no-header)

--- a/test/linodes/linodes.bats
+++ b/test/linodes/linodes.bats
@@ -10,31 +10,68 @@ load '../common'
 ##################################################################
 
 @test "it should create linodes with a label" {
-    run linode-cli linodes create --type g6-standard-2 --region us-east --image $test_image --label cli-1 --root_pass $random_pass --text --delimiter "," --no-headers --format 'label,region,type,image' --no-defaults
+    run linode-cli linodes create \
+        --type g6-standard-2 \
+        --region us-east \
+        --image $test_image \
+        --label cli-1 \
+        --root_pass $random_pass \
+        --text \
+        --delimiter "," \
+        --no-headers \
+        --format 'label,region,type,image' \
+        --no-defaults
+
     assert_output --regexp "cli-1,us-east,g6-standard-2,$test_image"
 }
 
 @test "it should view the linode configuration" {
     linode_id="$(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs)"
-    run linode-cli linodes view "$linode_id" --text --delimiter "," --no-headers --format 'id,label,region,type,image' --no-defaults
+    run linode-cli linodes view "$linode_id" \
+        --text \
+        --delimiter "," \
+        --no-headers \
+        --format 'id,label,region,type,image' \
+        --no-defaults
+
     assert_output --regexp "$linode_id,cli-1,us-east,g6-standard-2,$test_image"
 }
 
 @test "it should create a linode with the minimum required props" {
-    run linode-cli linodes create --type g6-standard-2 --region us-east --root_pass $random_pass --no-defaults --text --delimiter "," --no-headers --format 'id,region,type'
+    run linode-cli linodes create \
+        --type g6-standard-2 \
+        --region us-east \
+        --root_pass $random_pass \
+        --no-defaults \
+        --text \
+        --delimiter "," \
+        --no-headers \
+        --format 'id,region,type'
+
     assert_output --regexp "[0-9]+,us-east,g6-standard-2"
 }
 
 @test "it should fail to create a linode without a root_pass" {
-    run linode-cli linodes create --type g6-standard-2 --region us-east --image $test_image --no-defaults --text --no-headers
+    run linode-cli linodes create \
+        --type g6-standard-2 \
+        --region us-east \
+        --image $test_image \
+        --no-defaults \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial 'Request failed: 400'
     assert_output --partial 'root_pass	root_pass is required'
 }
 
 @test "it should list linodes" {
-    run bash -c "linode-cli linodes list --no-headers --format 'label' --text | grep cli-1"
-    assert_output 'cli-1'
+    run linode-cli linodes list \
+        --no-headers \
+        --format 'label' \
+        --text
+
+    assert_output --partial 'cli-1'
 }
 
 @test "it should remove all linodes" {

--- a/test/linodes/linodes.bats
+++ b/test/linodes/linodes.bats
@@ -74,6 +74,22 @@ load '../common'
     assert_output --partial 'cli-1'
 }
 
+@test "it should add a tag a linode" {
+    linode_id="$(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs)"
+    set -- $linode_id
+    LINODE=$1
+
+    run linode-cli linodes update $LINODE \
+        --tags=$uniqueTag \
+        --format 'tags' \
+        --text \
+        --no-headers
+
+    assert_success
+    assert_output $uniqueTag
+}
+
 @test "it should remove all linodes" {
     run removeLinodes
+    run removeUniqueTag
 }

--- a/test/tags/tags.bats
+++ b/test/tags/tags.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-assert/load'
+load '../common'
+
+@test "it should display tags" {
+    run linode-cli tags list
+    assert_success
+}
+
+@test "it should create a tag" {
+    run linode-cli tags create \
+        --label $uniqueTag \
+        --text \
+        --no-headers
+    assert_success
+}
+
+@test "it should view the unique tag" {
+    run linode-cli tags list \
+        --text \
+        --no-headers
+
+    assert_success
+    assert_output --partial "$uniqueTag"
+}
+
+@test "it should fail to create a tag shorter than 3 characters" {
+    run linode-cli tags create \
+        --label "ba" \
+        --text \
+        --no-headers
+
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "label	Length must be 3-25 characters"
+}
+
+@test "it should remove a tag" {
+    run linode-cli tags delete $uniqueTag
+    assert_success
+}

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -8,7 +8,7 @@ then
     if [[ ! $REPLY =~ ^[Yy]$ ]]
     then
     	echo "Phew, that was a close one!"
-        exit 1
+        exit 0
     fi
 
     testsWorkingDir=$(echo $PWD | grep test)
@@ -23,5 +23,5 @@ else
     echo -e "\n ####WARNING!#### \n"
     echo -e  "Running the Linode CLI tests requires removing all resources on your account\n"
     echo -e "Run this command with the --allow-delete-resources flag to accept this fate\n"
-    exit 0
+    exit 1
 fi

--- a/test/volumes/create-volumes.bats
+++ b/test/volumes/create-volumes.bats
@@ -9,44 +9,85 @@ load '../common'
 #  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
 ##################################################################
 
+setup() {
+    export timestamp=$(date +%s)
+}
+
+teardown() {
+    unset timestamp
+}
+
 @test "it should fail to create a volume under 10gb" {
-    timestamp=$(date +%s)
-    run linode-cli volumes create --label "A$timestmap" --region us-east --size 5 --text --no-headers
+    run linode-cli volumes create \
+        --label "A$timestmap" \
+        --region us-east \
+        --size 5 \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "size	Must be 10-10240"
 }
 
 @test "it should fail to create a volume without a region" {
-	run linode-cli volumes create --label "A$timestamp" --size 10 --text --no-headers
+	run linode-cli volumes create \
+        --label "A$timestamp" \
+        --size 10 \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
-    assert_output --partial "Must provide a region or a Linode ID"
+    assert_output --partial "region	region is not valid"
 }
 
 @test "it should fail to create a volume without a label" {
-	run linode-cli volumes create --size 10 --region us-east --text --no-headers
+	run linode-cli volumes create \
+        --size 10 \
+        --region us-east \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "label	label is required"
 }
 
 @test "it should fail to create a volume over 10240gb in size" {
-	run linode-cli volumes create --size 10241 --label "A$timestamp" --region us-east --text --no-headers
+	run linode-cli volumes create \
+        --size 10241 \
+        --label "A$timestamp" \
+        --region us-east \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "size	Must be 10-10240"
 }
 
 @test "it should fail to create a volume with an all numeric label" {
-	run linode-cli volumes create --label "9200900" --region us-east --size 10 --text --no-headers
+	run linode-cli volumes create \
+        --label "9200900" \
+        --region us-east \
+        --size 10 \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "label	Must begin with a letter"
 }
 
 @test "it should create an unattached volume" {
-	timestamp=$(date +%s)
-	run linode-cli volumes create --label "A$timestamp" --region us-east --size 10 --text --no-headers --delimiter ","
+	run linode-cli volumes create \
+        --label "A$timestamp" \
+        --region us-east \
+        --size 10 \
+        --text \
+        --no-headers \
+        --delimiter ","
+
 	assert_success
 	assert_output --regexp "[0-9]+,A[0-9]+,creating,10,us-east"
 }

--- a/test/volumes/create-volumes.bats
+++ b/test/volumes/create-volumes.bats
@@ -38,7 +38,7 @@ teardown() {
 
     assert_failure
     assert_output --partial "Request failed: 400"
-    assert_output --partial "region	region is not valid"
+    assert_output --partial "Must provide a region or a Linode ID"
 }
 
 @test "it should fail to create a volume without a label" {

--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -9,35 +9,82 @@ load '../common'
 #  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
 ##################################################################
 
+setup() {
+    export volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id" )
+}
+
+teardown() {
+    unset volume_id
+}
+
 @test "it should list volumes" {
     run createVolume
-    run linode-cli volumes list --text --no-headers --delimiter=","
+    run linode-cli volumes list \
+        --text \
+        --no-headers \
+        --delimiter=","
+
     assert_success
     assert_output --regexp "[0-9]+,A[0-9]+,(creating|active),10,us-east"
 }
 
 @test "it should view a single volume" {
-    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
-    run linode-cli volumes view $volume_id --text --no-headers --delimiter="," --format="id,label,size,region"
+    run linode-cli volumes view $volume_id \
+        --text \
+        --no-headers \
+        --delimiter="," \
+        --format="id,label,size,region"
+
     assert_success
     assert_output --regexp "$volume_id,A[0-9]+,10,us-east"
 }
 
 @test "it should update a volume label" {
-    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
-    run linode-cli volumes update --label=A-NewLabel-2 $volume_id --text --no-headers --format="label"
+    run linode-cli volumes update \
+        --label=A-NewLabel-2 $volume_id \
+        --text \
+        --no-headers \
+        --format="label"
+
     assert_success
     assert_output "A-NewLabel-2"
 }
 
+@test "it should add a new tag to a volume" {
+    run linode-cli volumes update $volume_id \
+        --tags=$uniqueTag \
+        --format="tags" \
+        --text \
+        --no-headers
+
+    assert_success
+    assert_output "$uniqueTag"
+}
+
+@test "it should view tags attached to the volume" {
+    run linode-cli volumes view $volume_id \
+        --tags "" \
+        --format="tags" \
+        --text \
+        --no-headers
+
+    assert_output "$uniqueTag"
+    assert_success
+}
+
 @test "it should fail to update volume size" {
-    volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
-    run linode-cli volumes update --size=15 $volume_id --text --no-headers --format="size"
+    run linode-cli volumes update \
+        --size=15 $volume_id \
+        --text \
+        --no-headers \
+        --format="size"
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "size	size is not an editable field"
 }
 
-@test "it should remove all volumes" {
+@test "it should remove all volumes and unique tags" {
     run removeVolumes
+    run removeUniqueTag
 }

--- a/test/volumes/resize-volumes.bats
+++ b/test/volumes/resize-volumes.bats
@@ -12,7 +12,11 @@ load '../common'
 @test "it should fail to resize a volume smaller" {
     createVolume
     volume_id=$(linode-cli volumes list --text --no-headers --format="id")
-    run linode-cli volumes resize $volume_id --size=5 --text --no-headers
+    run linode-cli volumes resize $volume_id \
+        --size=5 \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "Storage volumes can only be resized up"
@@ -20,7 +24,11 @@ load '../common'
 
 @test "it should fail to resize a volume greater than 10240gb" {
     volume_id=$(linode-cli volumes list --text --no-headers --format="id")
-    run linode-cli volumes resize $volume_id --size=1024893405 --text --no-headers
+    run linode-cli volumes resize $volume_id \
+        --size=1024893405 \
+        --text \
+        --no-headers
+
     assert_failure
     assert_output --partial "Request failed: 400"
     assert_output --partial "Storage volumes cannot be resized larger than 10240 gigabytes"
@@ -28,9 +36,18 @@ load '../common'
 
 @test "it should resize a volume" {
     volume_id=$(linode-cli volumes list --text --no-headers --format="id")
-    run linode-cli volumes resize $volume_id --size=11 --text --no-headers
+    run linode-cli volumes resize $volume_id \
+        --size=11 \
+        --text \
+        --no-headers
+
     assert_success
-    run linode-cli volumes view $volume_id --format="size" --text --no-headers
+
+    run linode-cli volumes view $volume_id \
+        --format="size" \
+        --text \
+        --no-headers
+
     assert_success
     assert_output "11"
 }


### PR DESCRIPTION
* Adds tests for Tags
* Adds tests for adding tags to Volumes/Domains/Linodes
*  Broke out the `run linode-cli` commands to new lines for each param for better readability.
* Updated assertion text
* Disabled a few tests due to known bugs, recorded the bug numbers as the params for the skip method
* Added tags tests to docker entrypoint command

## To Test

```bash
bats test/domains test/linodes test/volumes test/tags
```