### PR TITLE
[WIP] ssh-into plugin

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -180,14 +180,16 @@ def main():
         cli.bake_completions()
 
     # check for plugin invocation
-    if parsed.command not in cli.ops and parsed.command in plugins.available:
+    plugin_command = parsed.command.replace('-', '_')
+
+    if parsed.command not in cli.ops and plugin_command in plugins.available:
         context = plugins.PluginContext(cli.token, cli)
 
         # reconstruct arguments to send to the plugin
         plugin_args = argv[1:] # don't include the program name
         plugin_args.remove(parsed.command) # don't include the plugin name tho
 
-        plugins.invoke(parsed.command, plugin_args, context)
+        plugins.invoke(plugin_command, plugin_args, context)
         exit(0)
 
     if parsed.command not in cli.ops and parsed.command not in plugins.available:

--- a/linodecli/plugins/ssh_into.py
+++ b/linodecli/plugins/ssh_into.py
@@ -9,6 +9,7 @@ Invoke as follows::
    USERNAME - the user to ssh into the Linode as.  Defaults to root
 """
 import argparse
+import subprocess
 from sys import exit
 
 
@@ -58,4 +59,13 @@ def call(args, context):
             break
 
     
-    print("sshing in as {}@{}".format(parsed.username, public_ip))
+    # do it
+    code = 0
+    try:
+        subprocess.check_call(['ssh', '{}@{}'.format(parsed.username, public_ip)])
+    except subprocess.CalledProcessError as e:
+        # ssh exited with non-zero status code
+        code = e.returncode
+
+    # exit with the same code as ssh
+    exit(code)

--- a/linodecli/plugins/ssh_into.py
+++ b/linodecli/plugins/ssh_into.py
@@ -10,13 +10,19 @@ Invoke as follows::
 """
 import argparse
 import subprocess
-from sys import exit
+from sys import exit, platform
 
 
 def call(args, context):
     """
     Invokes this plugin
     """
+    if platform == 'win32':
+        print('This plugin is not currently supported in Windows.  For more '
+              'information or to suggest a fix, please visit '
+              'https://github.com/linode/linode-cli')
+        exit(1)
+
     parser = argparse.ArgumentParser("linode-cli ssh-into", add_help=True)
     parser.add_argument('label', metavar='LABEL', nargs='?', type=str,
                         help="The label of the Linode to ssh into")

--- a/linodecli/plugins/ssh_into.py
+++ b/linodecli/plugins/ssh_into.py
@@ -1,0 +1,61 @@
+"""
+The ssh-into plugin allows sshing into Linodes by label or ID
+
+Invoke as follows::
+
+   linode-cli ssh-into LINODE_LABEL [--user USERNAME]
+
+   LINODE_LABEL - the label of the Linode to ssh into
+   USERNAME - the user to ssh into the Linode as.  Defaults to root
+"""
+import argparse
+from sys import exit
+
+
+def call(args, context):
+    """
+    Invokes this plugin
+    """
+    parser = argparse.ArgumentParser("linode-cli ssh-into", add_help=True)
+    parser.add_argument('label', metavar='LABEL', nargs='?', type=str,
+                        help="The label of the Linode to ssh into")
+    parser.add_argument('--username', metavar='USERNAME', default='root',
+                        help="The user to ssh as.  Defaults to 'root'")
+
+    parsed = parser.parse_args(args)
+
+    result, potential_matches = context.client.call_operation(
+            "linodes", "list", ['--label', parsed.label])
+
+    if result != 200:
+        # TODO
+        print('Something went wrong')
+        exit(2)
+
+    potential_matches = potential_matches['data']
+    exact_match = None
+
+    # see if we got a match
+    for match in potential_matches:
+        if match['label'] == parsed.label:
+            exact_match = match
+            break
+
+    if exact_match is None:
+        # no match - stop
+        print("No Linode found for label {}".format(parsed.label))
+
+        if potential_matches:
+            print('Did you mean {}?'.format(
+                '], '.join([p['label'] for p in potential_matches])))
+        exit(1)
+
+    # find a public IP Address to use
+    public_ip = None
+    for ip in exact_match['ipv4']:
+        if not ip.startswith('192.168'):
+            public_ip = ip
+            break
+
+    
+    print("sshing in as {}@{}".format(parsed.username, public_ip))


### PR DESCRIPTION
The intended goal of this plugin is to allow the following command to
work: `linode-cli ssh-into my-linode`.  This plugin will use the CLI to
query the API for information about the linode by label and execute an
ssh command into that Linode if found.

Remaining work:
- [ ] Should this accept IDs in addition to/instead of labels?
- [x] Make this "work" (or fail with reasonable errors) on Windows
- [ ] Confirm the ssh approach is secure and sane