### PR TITLE
ARB-771 - Nodebalancers BATS Smoke Tests

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -17,11 +17,13 @@ WORKDIR /src/linode-cli
 
 COPY . .
 
-# Preserve the original cli.py file
 RUN mv linodecli/cli.py linodecli/original-cli.py
 
+# Preserve the original cli.py file with a same name file ending in .backup
+# Modify the cli.py to suppress version warnings by default
 # Modify the cli.py to no longer verify certs and suppress warnings (allows running tests on custom environments)
-RUN sed 's/data=body/data=body,verify=False/' linodecli/original-cli.py > linodecli/cli.py \
+RUN sed -i .backup 's/data=body/data=body,verify=False/' linodecli/cli.py \
+    && sed -i= 's/suppress_warnings = False/suppress_warnings = True/' linodecli/cli.py \
     && echo "from requests.packages.urllib3.exceptions import InsecureRequestWarning\nrequests.packages.urllib3.disable_warnings(InsecureRequestWarning)" >> /src/linode-cli/linodecli/cli.py
 
 # Build and Install the Linode CLI

--- a/test/common.bash
+++ b/test/common.bash
@@ -62,6 +62,15 @@ removeVolumes() {
     done
 }
 
+removeAll() {
+    local entity_ids="( $(linode-cli $1 list --text --no-headers --format="id" | xargs) )"
+    local id
+
+    for id in $entity_ids ; do
+        run bash -c "linode-cli $1 delete $id"
+    done
+}
+
 removeUniqueTag() {
     run bash -c "linode-cli tags delete $uniqueTag"
 }

--- a/test/nodebalancers/nodebalancers.bats
+++ b/test/nodebalancers/nodebalancers.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-assert/load'
+load '../test_helper/bats-support/load'
+load '../common'
+
+export nodebalancerCreated="[0-9]+,balancer[0-9]+,us-east,nb-[0-9]+-[0-9]+-[0-9]+-[0-9]+.newark.nodebalancer.linode.com,0"
+
+@test "it should fail to create a nodebalancer without specifying a region" {
+    run linode-cli nodebalancers create \
+    	--text \
+    	--no-headers
+    assert_failure
+    assert_output --partial "Request failed: 400"
+    assert_output --partial "region	region is not valid"
+}
+
+
+@test "it should create a nodebalancer with a default configuration" {
+	run linode-cli nodebalancers create \
+		--region us-east \
+		--text \
+		--delimiter "," \
+		--format="id,label,region,hostname,client_conn_throttle"
+
+	assert_success
+	assert_output --regexp $nodebalancerCreated
+}
+
+@test "it should list the available nodebalancers and output their status" {
+	run linode-cli nodebalancers list \
+		--text \
+		--no-headers \
+		--delimiter "," \
+		--format="id,label,region,hostname,client_conn_throttle"
+
+	assert_success
+	assert_output --regexp $nodebalancerCreated
+}
+
+@test "it should display the public ipv4 for the nodebalancer" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+
+	run linode-cli nodebalancers view $nodebalancerId \
+		--format="ipv4" \
+		--text \
+		--no-headers
+	assert_success
+	assert_output --regexp "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"
+}
+
+@test "it should fail to view a nodebalancer with an invalid nodebalancer id" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+
+	run linode-cli nodebalancers view 535\
+		--text \
+		--no-headers
+	assert_failure
+	assert_output --partial "Request failed: 404"
+	assert_output --partial "Not found"
+}
+
+@test "it should create a standard configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+
+	run linode-cli nodebalancers config-create $nodebalancerId \
+		--delimiter "," \
+		--text \
+		--no-headers
+
+	assert_success
+	assert_output --regexp "[0-9]+,80,http,roundrobin,none,True,recommended,,"
+}
+
+@test "it should view the configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+	configId=$(linode-cli nodebalancers configs-list $nodebalancerId --text --no-headers --format=id)
+
+	run linode-cli nodebalancers config-view $nodebalancerId $configId \
+		--text \
+		--no-headers \
+		--delimiter ","
+
+	assert_success
+	assert_output --regexp "[0-9]+,80,http,roundrobin,none,True,recommended,,"
+}
+
+@test "it should add a node to the configuration profile" {
+	nodeIp=$(linode-cli linodes create \
+	     --root_pass aComplex@Password \
+	     --booted true \
+	     --region us-east \
+	     --type g6-standard-2 \
+	     --private_ip true \
+	     --image linode/arch \
+	     --text \
+	     --no-headers \
+	     --format "ip_address" | egrep -o "192.168.[0-9]{1,3}.[0-9]{1,3}")
+	nodeLabel="testnode1"
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+	configId=$(linode-cli nodebalancers configs-list $nodebalancerId --text --no-headers --format=id)
+
+	run linode-cli nodebalancers node-create \
+		--address $nodeIp:80 \
+		--label $nodeLabel \
+		--weight "100" \
+		--text \
+		--no-headers \
+		--delimiter "," \
+		$nodebalancerId \
+		$configId
+
+	assert_success
+	assert_output --regexp "[0-9]+,$nodeLabel,$nodeIp:80,Unknown,100,accept"
+}
+
+@test "it should remove a node from a configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+	configId=$(linode-cli nodebalancers configs-list $nodebalancerId --text --no-headers --format=id)
+	nodeId=$(linode-cli nodebalancers nodes-list $nodebalancerId $configId --text --no-headers --format=id)
+
+	run linode-cli nodebalancers node-delete $nodebalancerId $configId $nodeId
+	assert_success
+}
+
+@test "it should update the port of a configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+	configId=$(linode-cli nodebalancers configs-list $nodebalancerId --text --no-headers --format=id)
+
+	run linode-cli nodebalancers config-update \
+		--port 10700 \
+		--protocol tcp \
+		$nodebalancerId \
+		$configId \
+		--text \
+		--no-headers \
+		--delimiter ","
+
+	assert_success
+	assert_output --regexp "[0-9]+,10700,tcp,roundrobin,none,True,recommended,,"
+
+}
+
+@test "it should add an additional configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+
+	run linode-cli nodebalancers config-create $nodebalancerId \
+		--delimiter "," \
+		--text \
+		--no-headers
+
+	assert_success
+	assert_output --regexp "[0-9]+,80,http,roundrobin,none,True,recommended,,"
+}
+
+@test "it should list multiple configuration profiles" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+
+	run linode-cli nodebalancers configs-list $nodebalancerId \
+		--delimiter "," \
+		--text \
+		--no-headers
+
+	assert_success
+	assert_output --regexp "[0-9]+,80,http,roundrobin,none,True,recommended,,"
+	assert_output --regexp "[0-9]+,10700,tcp,roundrobin,none,True,recommended,,"
+}
+
+@test "it should delete all nodebalancers" {
+	run removeAll "nodebalancers"
+	run removeAll "linodes"
+}

--- a/test/nodebalancers/nodebalancers.bats
+++ b/test/nodebalancers/nodebalancers.bats
@@ -166,6 +166,18 @@ export nodebalancerCreated="[0-9]+,balancer[0-9]+,us-east,nb-[0-9]+-[0-9]+-[0-9]
 	assert_output --regexp "[0-9]+,10700,tcp,roundrobin,none,True,recommended,,"
 }
 
+@test "it should remove a configuration profile" {
+	nodebalancerId=$(linode-cli nodebalancers list --format=id --text --no-headers)
+	configurationIds=$(linode-cli nodebalancers configs-list $nodebalancerId --text --no-headers --format=id)
+
+	set -- $configurationIds
+	configId=$1
+
+	run linode-cli nodebalancers config-delete $nodebalancerId $configId
+
+	assert_success
+}
+
 @test "it should delete all nodebalancers" {
 	run removeAll "nodebalancers"
 	run removeAll "linodes"


### PR DESCRIPTION
*Fair **warning**, running the automated CLI tests will remove all entities on your account. Please update your CLI configuration profile to a test user before running!*

* Added tests for nodebalancer creation, creating a nodebalancer configuration profile, adding a node to the nodebalancer, editing an existing profile, adding an additional profile, removing a profile
* Updated the CLI tests dockerfile to suppress warnings about API versions by default
* Added removeAll utility method (will potentially refactor existing tests to use this instead of specific "removeLinodes" "removeDomains" etc methods.

## To Test:

* Assumes you have the bats framework installed locally (`brew install bats-core`)
```bash
 bats test/nodebalancers/nodebalancers.bats
```

* and plz read the test code