### PR TITLE
Don't define blank values in config when the user declines optional defaults

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -147,9 +147,10 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
             self.config.add_section(username)
 
         for k, v in config.items():
-            self.config.set(username, k, v)
-            if is_default:
-                self.config.set('DEFAULT', k, v)
+            if v:
+                self.config.set(username, k, v)
+                if is_default:
+                    self.config.set('DEFAULT', k, v)
 
         with open(self._get_config_path(), 'w') as f:
             self.config.write(f)


### PR DESCRIPTION
Currently, if you choose to ignore setting defaults during `configure`, you end up with a config that looks like this:

```
[USERNAME]
    default1 =
    default2 =
    default3 =
```

This breaks e.g. creating an empty Linode, since we try to pass e.g. the Image to the API, but it's a blank string (instead of not passing it at all). Removing these blank defaults fixes the issue, but simply not defining blank defaults in the config, when a user declines an optional default, fixes the application bug.