### PR TITLE
Personal Access Token coaching text matches interface

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -101,7 +101,7 @@ Note that no token will be saved in your configuration file.
             print("""
 First, we need a Personal Access Token.  To get one, please visit
 {} and click
-"Create a Personal Access Token".  The CLI needs access to everything
+"Add a Personal Access Token".  The CLI needs access to everything
 on your account to work correctly.""".format(TOKEN_GENERATION_URL))
 
             while True:


### PR DESCRIPTION
Proposing this language change so that the coaching text matches the interface seen by the user. 

<img width="1438" alt="screenshot_2018-12-07_16_20_18" src="https://user-images.githubusercontent.com/1627192/49673755-8a988300-fa3d-11e8-8ad8-553ac401004f.png">
