### PR TITLE
fix: Allow merging of settings when token is not present in config

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -63,7 +63,7 @@ class CLIConfig:
         if not username:
             username = "DEFAULT"
 
-        if not self.config.has_option(username, 'token') and not os.environ.get(ENV_TOKEN_NAME, None:
+        if not self.config.has_option(username, 'token') and not os.environ.get(ENV_TOKEN_NAME, None):
             print("User {} is not configured.".format(username))
             sys.exit(1)
 

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -63,7 +63,7 @@ class CLIConfig:
         if not username:
             username = "DEFAULT"
 
-        if not self.config.has_option(username, 'token'):
+        if not self.config.has_option(username, 'token') and not os.environ.get(ENV_TOKEN_NAME, None:
             print("User {} is not configured.".format(username))
             sys.exit(1)
 


### PR DESCRIPTION
It turns out that using the environment variable to store the token can fail because the check for merging the configured settings and the command line supplied settings relies on `token` being present in the configuration. I hadn't noticed because I had already done a `configure` beforehand which stored a valid token in the `DEFAULT` user.

This PR fixes that issue by letting the configuration merge happen when the environment variable is defined.

Sorry for not catching this sooner! If you'd like me to open an issue for tracking purposes, let me know.

Cheers,