### PR TITLE
Fix spec fetching on alternative environments

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -3,6 +3,7 @@ FROM python:2
 ARG SPEC=https://developers.linode.com/api/v4/openapi.yaml
 ARG API_OVERRIDE=api.linode.com
 ARG TOKEN
+ARG SPEC_NAME
 
 RUN apt-get update && apt-get install -y python3 python3-pip bats \
     && pip install requests terminaltables colorclass PyYAML enum34 \
@@ -24,8 +25,7 @@ RUN sed -i="" "s/data=body/data=body,verify=False/" /src/linode-cli/linodecli/cl
     && echo "from requests.packages.urllib3.exceptions import InsecureRequestWarning\nrequests.packages.urllib3.disable_warnings(InsecureRequestWarning)" >> /src/linode-cli/linodecli/cli.py
 
 # Build and Install the Linode CLI
-RUN curl -o /src/linode-cli/openapi.yaml ${SPEC} \
-    && sed -n "s|${DEFAULT_API}|${API_ENV}|g;w cli-tests.yaml" /src/linode-cli/openapi.yaml \
+RUN sed -n "s|${DEFAULT_API}|${API_ENV}|g;w cli-tests.yaml" /src/linode-cli/${SPEC_NAME} \
     && git submodule init \
     && git submodule update \
     && make build SPEC=cli-tests.yaml \

--- a/test/nodebalancers/nodebalancers.bats
+++ b/test/nodebalancers/nodebalancers.bats
@@ -86,13 +86,19 @@ export nodebalancerCreated="[0-9]+,balancer[0-9]+,us-east,nb-[0-9]+-[0-9]+-[0-9]
 }
 
 @test "it should add a node to the configuration profile" {
+	images=$(linode cli images list --text --no-headers --format "id")
+
+	set -- $images
+
+	nodeImage=$1
+
 	nodeIp=$(linode-cli linodes create \
 	     --root_pass aComplex@Password \
 	     --booted true \
 	     --region us-east \
 	     --type g6-standard-2 \
 	     --private_ip true \
-	     --image linode/arch \
+	     --image $nodeImage \
 	     --text \
 	     --no-headers \
 	     --format "ip_address" | egrep -o "192.168.[0-9]{1,3}.[0-9]{1,3}")


### PR DESCRIPTION
* Removes fetching the open api spec from inside the container.
* Instead, save the openapi spec outside the container context and pass in the filename as a build argument.
* Feel free to ping me for further instructions on testing this if needed