### PR TITLE
Revert "Fix spec fetching on alternative environments"

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -3,7 +3,6 @@ FROM python:2
 ARG SPEC=https://developers.linode.com/api/v4/openapi.yaml
 ARG API_OVERRIDE=api.linode.com
 ARG TOKEN
-ARG SPEC_NAME
 
 RUN apt-get update && apt-get install -y python3 python3-pip bats \
     && pip install requests terminaltables colorclass PyYAML enum34 \
@@ -25,7 +24,8 @@ RUN sed -i="" "s/data=body/data=body,verify=False/" /src/linode-cli/linodecli/cl
     && echo "from requests.packages.urllib3.exceptions import InsecureRequestWarning\nrequests.packages.urllib3.disable_warnings(InsecureRequestWarning)" >> /src/linode-cli/linodecli/cli.py
 
 # Build and Install the Linode CLI
-RUN sed -n "s|${DEFAULT_API}|${API_ENV}|g;w cli-tests.yaml" /src/linode-cli/${SPEC_NAME} \
+RUN curl -o /src/linode-cli/openapi.yaml ${SPEC} \
+    && sed -n "s|${DEFAULT_API}|${API_ENV}|g;w cli-tests.yaml" /src/linode-cli/openapi.yaml \
     && git submodule init \
     && git submodule update \
     && make build SPEC=cli-tests.yaml \

--- a/test/nodebalancers/nodebalancers.bats
+++ b/test/nodebalancers/nodebalancers.bats
@@ -86,19 +86,13 @@ export nodebalancerCreated="[0-9]+,balancer[0-9]+,us-east,nb-[0-9]+-[0-9]+-[0-9]
 }
 
 @test "it should add a node to the configuration profile" {
-	images=$(linode cli images list --text --no-headers --format "id")
-
-	set -- $images
-
-	nodeImage=$1
-
 	nodeIp=$(linode-cli linodes create \
 	     --root_pass aComplex@Password \
 	     --booted true \
 	     --region us-east \
 	     --type g6-standard-2 \
 	     --private_ip true \
-	     --image $nodeImage \
+	     --image linode/arch \
 	     --text \
 	     --no-headers \
 	     --format "ip_address" | egrep -o "192.168.[0-9]{1,3}.[0-9]{1,3}")


### PR DESCRIPTION
Reverts linode/linode-cli#95

This change appears to have broken the builder, rolling back for now.