### PR TITLE
Update path to openapi spec

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -1,6 +1,6 @@
 FROM python:2
 
-ARG SPEC=https://developers.linode.com/api/v4/openapi.yaml
+ARG SPEC=https://developers.linode.com/api/docs/v4/openapi.yaml
 ARG API_OVERRIDE=api.linode.com
 ARG TOKEN
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PYTHON ?= 3
-SPEC ?= https://developers.linode.com/api/v4/openapi.yaml
+SPEC ?= https://developers.linode.com/api/docs/v4/openapi.yaml
 
 ifeq ($(PYTHON), 3)
 	PYCMD=python3


### PR DESCRIPTION
* The openapi spec is now hosted at https://developers.linode.com/api/docs/v4/openapi.yaml this PR updates some references in the source to reflect this.

* Updated Makefile spec path, Dockerfile to new spec path.