### PR TITLE
Tests - Fix while conditional timeouts

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -91,8 +91,8 @@ createLinodeAndWait() {
     until [ $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
         echo 'still provisioning'
         sleep 5 # Wait 5 seconds before checking status again, to rate-limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
+            echo "Failed to provision.. Failed after $SECONDS seconds" >&3
             assert_failure # Fail test, linode did not boot in time
             break
         fi

--- a/test/linodes/backups.bats
+++ b/test/linodes/backups.bats
@@ -1,3 +1,5 @@
+#!/usr/bin/env bats
+
 load '../test_helper/bats-support/load'
 load '../test_helper/bats-assert/load'
 load '../common'
@@ -87,7 +89,7 @@ teardown() {
             echo 'still provisioning'
             # Wait 5 seconds before checking status again, to rate-limit ourselves
             sleep 5
-            if [[ "$SECONDS" -eq 180 ]];
+            if (( $SECONDS > 180 ));
             then
                 assert_failure # Linode failed to boot
                 break

--- a/test/linodes/linodes.bats
+++ b/test/linodes/linodes.bats
@@ -90,8 +90,7 @@ teardown() {
 
     SECONDS=0
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "offline" ]; do
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not initialize in time"
             assert_failure  # This will fail the test
             break

--- a/test/linodes/power-status.bats
+++ b/test/linodes/power-status.bats
@@ -40,8 +40,7 @@ teardown() {
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
         echo 'still provisioning'
         sleep 5 # Rate limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not boot in time"
             assert_failure  # This will fail the test
             break
@@ -54,8 +53,7 @@ teardown() {
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
         echo "still provisioning"
         sleep 5 # Rate limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not boot in time"
             assert_failure  # This will fail the test
             break
@@ -71,8 +69,7 @@ teardown() {
     SECONDS=0
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) != "running" ]; do
         sleep 5 # Rate limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not reboot in time"
             assert_failure # This will fail the test
             break
@@ -86,8 +83,7 @@ teardown() {
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
         echo 'still provisioning'
         sleep 5 # Rate limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not start running in time"
             assert_failure # This will fail the test
             break
@@ -102,12 +98,10 @@ teardown() {
     until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "offline" ]; do
         echo 'still shutting down'
         sleep 5 # Rate limit ourselves
-        if [[ "$SECONDS" -eq 180 ]];
-        then
+        if (( $SECONDS > 180 )); then
             echo "Timeout elapsed! Linode did not shutdown in time"
             assert_failure # This will fail the test
             break
         fi
     done
 }
-

--- a/test/linodes/rebuild.bats
+++ b/test/linodes/rebuild.bats
@@ -76,8 +76,7 @@ teardown() {
         until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "rebuilding" ]; do
             echo 'still running'
             sleep 5 # Wait 5 seconds between requests
-            if [[ "$SECONDS" -eq 180 ]];
-            then
+            if (( $SECONDS > 180 )); then
                 assert_failure # Fail if status is not rebuilding
                 break
             fi
@@ -89,7 +88,7 @@ teardown() {
     	until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]; do
             echo 'still rebuilding'
             sleep 5 # Wait 5 seconds between requests
-            if [[ "$SECONDS" -eq 180 ]];
+            if (( $SECONDS > 180 ));
             then
                 assert_failure # Linode failed to start
                 break

--- a/test/linodes/resize.bats
+++ b/test/linodes/resize.bats
@@ -92,8 +92,7 @@ teardown() {
     	until [ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "resizing" ]; do
             echo 'waiting for resize to start'
             sleep 5
-            if [[ "$SECONDS" -eq 180 ]]
-            then
+            if (( $SECONDS > 180 )); then
                 assert_failure # Linode failed to start resizing
                 break
             fi
@@ -107,8 +106,7 @@ teardown() {
 
     		# Check for resizing completion every 15 seconds
             sleep 15
-            if [[ "$SECONDS" -eq 600 ]];
-            then
+            if (( $SECONDS > 600 )); then
                 assert_failure # Linode failed to completge resizing within 10 minutes
                 break
             fi


### PR DESCRIPTION
* It occurred to me that the timeout logic preventing infinite loops was not sound. These while loops are used to wait for linodes/entities to be provisioned/booted/etc.
* Rewrote every while loop to definitely meet the condition to timeout after 180 seconds.
* My bad