### PR TITLE
Added support for plugin configuration

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -137,6 +137,30 @@ class CLIConfig:
 
     # plugin methods - these are intended for plugins to utilize to store their
     # own persistent config information
+    def get_value(self, key):
+        """
+        Retrieves and returns an existing config value for the current user.  This
+        is intended for plugins to use instead of having to deal with figuring out
+        who the current user is when accessing their config.
+
+        .. warning::
+           Plugins _MUST NOT_ set values for the user's config except through
+           ``plugin_set_value`` below.
+
+        :param key: The key to look up.
+        :type key: str
+
+        :returns: The value for that key, or None if the key doesn't exist for the
+                  current user.
+        :rtype: any
+        """
+        username = self.username or self.default_username()
+
+        if not self.config.has_option(username, key):
+            return None
+
+        return self.config.get(username, key)
+
     def plugin_set_value(self, plugin_name, key, value):
         """
         Sets a new config value for a plugin for the current user.  Plugin config

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -68,6 +68,10 @@ class CLIConfig:
         """
         ns_dict = vars(namespace)
         for k in new_dict:
+            if k.startswith('plugin-'):
+                # plugins set config options that start with 'plugin-' - these don't
+                # get included in the updated namespace
+                continue
             if k in ns_dict and ns_dict[k] is None:
                 ns_dict[k] = new_dict[k]
 
@@ -105,7 +109,7 @@ class CLIConfig:
 
         if self.config.has_section(username):
             self.config.remove_section(username)
-            self._write_config()
+            self.write_config()
 
     def print_users(self):
         """
@@ -129,7 +133,70 @@ class CLIConfig:
             sys.exit(1)
 
         self.config.set('DEFAULT', 'default-user', username)
-        self._write_config()
+        self.write_config()
+
+    # plugin methods - these are intended for plugins to utilize to store their
+    # own persistent config information
+    def plugin_set_value(self, plugin_name, key, value):
+        """
+        Sets a new config value for a plugin for the current user.  Plugin config
+        keys are set in the following format::
+
+           plugin-{plugin_name}-{key}
+
+        Values set with this method are intended to be retrieved with ``plugin_get_value``
+        below.  Plugins are responsible for passing in the correct name in both instances.
+
+        :param plugin_name: The name of the plugin setting this value
+        :type plugin_name: str
+        :param key: The config key to set - this is needed to retrieve the value
+        :type key: str
+        :param value: The value to set for this key
+        :type value: any
+        """
+        username = self.username or self.default_username()
+        self.config.set(username, 'plugin-{}-{}'.format(plugin_name, key), value)
+
+    def plugin_get_value(self, plugin_name, key):
+        """
+        Retrieves and returns a config value previously set for a plugin.  Your
+        plugin should have set this value in the past using the same plugin name.
+        If this value does not exist in the config, ``None`` is returned.  This
+        is the only time ``None`` is returned, so receiving this value should be
+        treated as "plugin is not configured."
+
+        :param plugin_name: The name of the plugin that set this value
+        :type plugin_name: str
+        :param key: The key of the value to return
+        :type key: str
+
+        :returns: The value for this plugin for this key, or None if not set
+        :rtype: any
+        """
+        username = self.username or self.default_username()
+        full_key = 'plugin-{}-{}'.format(plugin_name, key)
+
+        if not self.config.has_option(username, full_key):
+            return None
+
+        return self.config.get(username, full_key)
+
+    def write_config(self, silent=False):
+        """
+        Saves the config file as it is right now.  This can be used by plugins
+        to save values they've set, and is used internally to update the config
+        on disk when a new user if configured.
+
+        :param silent: If True, does not print a message noting the config file
+                       has been updated.  This is primarily intended for silently
+                       updated the config file from one version to another.
+        :type silent: bool
+        """
+        with open(self._get_config_path(), 'w') as f:
+            self.config.write(f)
+
+        if not silent:
+            print("\nConfig written to {}".format(self._get_config_path()))
 
     def configure(self):
         """
@@ -226,19 +293,9 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
             if v:
                 self.config.set(username, k, v)
 
-        self._write_config()
+        self.write_config()
         os.chmod(self._get_config_path(), 0o600)
         self._configured = True
-
-    def _write_config(self, silent=False):
-        """
-        Saves the config file as it is right now
-        """
-        with open(self._get_config_path(), 'w') as f:
-            self.config.write(f)
-
-        if not silent:
-            print("\nConfig written to {}".format(self._get_config_path()))
 
     def _get_config_path(self):
         """
@@ -312,7 +369,7 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
         if len(users) == 1:
             # only one user configured - they're the default
             self.config.set('DEFAULT', 'default-user', users[0])
-            self._write_config(silent=True)
+            self.write_config(silent=True)
             return
 
         if len(users) == 0:
@@ -338,7 +395,7 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
                 self.config.set(username, 'type', self.config.get('DEFAULT', 'type'))
                 self.config.set(username, 'image', self.config.get('DEFAULT', 'image'))
 
-                self._write_config(silent=True)
+                self.write_config(silent=True)
             else:
                 # got nothin', reconfigure
                 self.configure()
@@ -357,6 +414,6 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
 
             if username in users:
                 self.config.set('DEFAULT', 'default-user', username)
-                self._write_config()
+                self.write_config()
                 return
             print('No user {}'.format(username))

--- a/linodecli/plugins/README.md
+++ b/linodecli/plugins/README.md
@@ -48,6 +48,57 @@ invoked with a command and an action, and executes the given CLI command as if
 it were entered into the command line, returning the resulting status code and
 JSON data.
 
+## Configuration
+
+Plugins can access the CLI's configuration through the CLI Client mentioned above.
+Plugins are allowed to:
+
+ * Read values from the current user's config
+ * Read and write their own values to the current user's config
+
+Any other operation is not supported and may break without notice.
+
+### Methods
+
+The `Configuration` class provides the following methods for plugins to use:
+
+**get_value(key)** Returns the value the current user has set for this key, or `None`
+if the key does not exist.  Currently supported keys are `region`, `type`, and `image`.
+
+**plugin_set_value(key, value)** Sets a value in the user's config for this plugin.
+Plugins can safely set values for any key, and they are namespaced away from other
+config keys.
+
+**plugin_get_value(key)** Returns the value this plugin previously set for the given
+key, or `None` if not set.  Plugins should assume they are not configured if they
+receive `None` when getting a value with this method.
+
+**write_config()** Writes config changes to disk.  This is required to save changes
+after calling `plugin_set_value` above.
+
+### Sample Code
+
+The following code manipulates and reads from the config in a plugin:
+
+```python
+
+def call(args, context):
+    # get a value from the user's config
+    default_region = context.client.config.get_value('region')
+
+    # check if we set a value perviously
+    our_value = context.client.config.plugin_get_value('configured')
+
+    if our_value is None:
+        # plugin not configured - do configuration here
+        context.client.config.plugin_set_value('configured', 'yes')
+
+        # save the config so changes take effect
+        context.client.config.write_config()
+
+    # normal plugin code
+```
+
 ## Development
 
 To develop a plugin, simply create a python source file in this directory that

--- a/linodecli/plugins/__init__.py
+++ b/linodecli/plugins/__init__.py
@@ -13,6 +13,10 @@ def invoke(name, args, context):
         raise ValueError('No plugin named {}'.format(name))
 
     plugin = import_module('linodecli.plugins.'+name)
+
+    # setup config to know what plugin is running
+    context.client.config.running_plugin = name
+
     plugin.call(args, context)
 
 

--- a/linodecli/plugins/k8s-alpha.py
+++ b/linodecli/plugins/k8s-alpha.py
@@ -56,7 +56,7 @@ def create_varmap(context):
         },
         'region': {
             'name': 'region',
-            'default': context.client.config.config.get('DEFAULT', 'region'),
+            'default': context.client.config.get_value('region'),
         },
         'ssh_public_key': {
             'name': 'ssh_public_key',
@@ -446,7 +446,7 @@ def get_default_master_type(context):
 def requested_type_with_fallback(context):
     default_node_type = 'g6-standard-2'
     try:
-        default_node_type = context.client.config.config.get('DEFAULT', 'type')
+        default_node_type = context.client.config.get_value('type')
     except:
         pass
     return default_node_type

--- a/linodecli/plugins/k8s-alpha.py
+++ b/linodecli/plugins/k8s-alpha.py
@@ -446,7 +446,10 @@ def get_default_master_type(context):
 def requested_type_with_fallback(context):
     default_node_type = 'g6-standard-2'
     try:
-        default_node_type = context.client.config.get_value('type')
+        requested_node_type = context.client.config.get_value('type')
+        if not requested_node_type:
+            raise ValueError('user did not provide a Linode type by argument or config')
+        return requested_node_type
     except:
         pass
     return default_node_type


### PR DESCRIPTION
Plugins may want to store persistent configuration data on a per-user
bases.  Instead of having them manage that themselves, this allows
plugins to use the Linode CLI's config in a uniform manner to store
persistent data.

All plugin config items' keys begin with `plugin-` followed by the
plugin's name.  Keys are stored per-user in the config, so multiple
users may have different settings configured.

This is not presently in use, but it might come in handy for some
upcoming plugins that may or may not be in the works ;)