### PR TITLE
Added third-party plugin support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,29 @@ your JSON output.  If you want your JSON pretty-printed, we can do that too::
 
    linode-cli linodes list --json --pretty --all
 
+Plugins
+-------
+
+The Linode CLI allows its features to be expanded with plugins.  Some official
+plugins come bundled with the CLI and are documented above.  Additionally, anyone
+can write and distribute plugins for the CLI - these are called Third Party Plugins.
+
+To register a Third Party Plugin, use the following command::
+
+   linode-cli register-plugin PLUGIN_MODULE_NAME
+
+Plugins should give the exact command required to register them.
+
+Once registered, the command to invoke the Third Party Plugin will be printed, and
+it will appear in the plugin list when invoking ``linode-cli --help``.
+
+Developing Plugins
+==================
+
+For information on how To write your own Third Party Plugin, see the `Plugins documentation`_.
+
+.. _Plugins documentation: https://github.com/linode/linode-cli/blob/master/linodecli/plugins/README.md
+
 Building from Source
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,14 @@ Plugins should give the exact command required to register them.
 Once registered, the command to invoke the Third Party Plugin will be printed, and
 it will appear in the plugin list when invoking ``linode-cli --help``.
 
+To remove a previously registered plugin, use the following command::
+
+   linode-cli remove-plugin PLUGIN_NAME
+
+This command accepts the name used to invoke the plugin in the CLI as it appears
+in ``linode-cli --help``, which may not be the same as the module name used to
+register it.
+
 Developing Plugins
 ^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -311,7 +311,7 @@ your JSON output.  If you want your JSON pretty-printed, we can do that too::
    linode-cli linodes list --json --pretty --all
 
 Plugins
-=======
+-------
 
 The Linode CLI allows its features to be expanded with plugins.  Some official
 plugins come bundled with the CLI and are documented above.  Additionally, anyone
@@ -327,7 +327,7 @@ Once registered, the command to invoke the Third Party Plugin will be printed, a
 it will appear in the plugin list when invoking ``linode-cli --help``.
 
 Developing Plugins
-------------------
+^^^^^^^^^^^^^^^^^^
 
 For information on how To write your own Third Party Plugin, see the `Plugins documentation`_.
 

--- a/README.rst
+++ b/README.rst
@@ -311,7 +311,7 @@ your JSON output.  If you want your JSON pretty-printed, we can do that too::
    linode-cli linodes list --json --pretty --all
 
 Plugins
--------
+=======
 
 The Linode CLI allows its features to be expanded with plugins.  Some official
 plugins come bundled with the CLI and are documented above.  Additionally, anyone
@@ -327,7 +327,7 @@ Once registered, the command to invoke the Third Party Plugin will be printed, a
 it will appear in the plugin list when invoking ``linode-cli --help``.
 
 Developing Plugins
-==================
+------------------
 
 For information on how To write your own Third Party Plugin, see the `Plugins documentation`_.
 

--- a/examples/third-party-plugin/README.md
+++ b/examples/third-party-plugin/README.md
@@ -1,0 +1,63 @@
+# Example Third Party Plugin
+
+This is included as an example of how to develop a third party plugin for the
+Linode CLI.  There are only two files:
+
+#### example_third_party_plugin.py
+
+This file contains the python source code for your plugin.  Notably, it is a valid
+plugin because it exposes two attributes at the module level:
+
+ * `PLUGIN_NAME` - a constant whose value is the string used to invoke the plugin
+   once it's registered
+ * `call(args, context)` - a function called when the plugin is invoked
+
+While this example is a single file, a module that exposes those two attributes
+at the top level is also a valid CLI plugin (define or import them in the module's
+`__init__.py` file to expose them at the module level).
+
+
+#### setup.py
+
+This file is used by setuptools to create a python module.  This example is very
+sparse, but is enough to install the module locally and get you started.  Please
+see the [setuptools docs](https://setuptools.readthedocs.io/en/latest/index.html)
+for all available options.
+
+## Installation
+
+To install this example plugin, run the following in this directory:
+
+```bash
+python setup.py install
+```
+
+### Registration and Invocation
+
+Once installed, you have to register the plugin with the Linode CLI by python
+module name (as defined in `setup.py`):
+
+```bash
+linode-cli register-plugin example_third_party_plugin
+```
+
+The CLI will print out the command to invoke this plugin, which in this example
+is:
+
+
+```bash
+linode-cli example-plugin
+```
+
+Doing so will print `Hello world!` and exit.
+
+## Development
+
+To begin working from this base, simply edit `example_third_party_plugin.py` and
+add whatever features you need.  When it comes time to distribute your plugin,
+copy this entire directory elsewhere and modify the `setup.py` file as described
+within it to create your own module.
+
+To test your changes, simply reinstall the plugin as described above.  This
+_does not_ require reregistering it, as it references the installed module and
+will invoke the updated code next time it's called.

--- a/examples/third-party-plugin/example_third_party_plugin.py
+++ b/examples/third-party-plugin/example_third_party_plugin.py
@@ -1,0 +1,18 @@
+"""
+This file is an example third-party plugin.  See `the plugin docs`_ for more
+information.
+
+.. _the plugin docs: https://github.com/linode/linode-cli/blob/master/linodecli/plugins/README.md
+"""
+
+#: This is the name the plugin will be invoked with once it's registered.  Note
+#: that this name is different than the module name, which is what's used to
+#: register it.  This is required for all third party plugins.
+PLUGIN_NAME = "example-plugin"
+
+def call(args, context):
+    """
+    This is the entrypoint for the plugin when invoked through the CLI.  See the
+    docs linked above for more information.
+    """
+    print('Hello world!')

--- a/examples/third-party-plugin/setup.py
+++ b/examples/third-party-plugin/setup.py
@@ -1,0 +1,23 @@
+"""
+This file allows installation of this plugin as a python module.  See the docs
+for setuptools for more information.
+"""
+from setuptools import setup
+
+setup(
+    # replace this with the module name you want your plugin to install as
+    name="example_third_party_plugin",
+    # replace with your plugin's version - use semantic versioning if possible
+    version=1,
+    # this is used in pip to show details about your plugin
+    description="Example third party plugin for the Linode CLI",
+    # replace these fields with information about yourself or your organization
+    author="linode",
+    author_email='developers@linode.com',
+    # in this case, the plugin is a single file, so that file is listed here
+    # replace with the name of your plugin file, or use ``packages=[]`` to list
+    # whole python modules to include
+    py_modules=[
+        'example_third_party_plugin',
+    ],
+)

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -245,11 +245,19 @@ def main():
     if parsed.command is None or (parsed.command is None and  parsed.help):
         parser.print_help()
 
-        # commands to manager CLI users (don't call out to API)
+        # commands to manage CLI users (don't call out to API)
         print()
         print('CLI user management commands:')
         um_commands = [['configure', 'set-user', 'show-users'],['remove-user']]
         table = SingleTable(um_commands)
+        table.inner_heading_row_border = False
+        print(table.table)
+
+        # commands to manage plugins (don't call out to API)
+        print()
+        print('CLI Plugin management commands:')
+        pm_commands = [['register-plugin', 'remove-plugin']]
+        table = SingleTable(pm_commands)
         table.inner_heading_row_border = False
         print(table.table)
 

--- a/linodecli/plugins/README.md
+++ b/linodecli/plugins/README.md
@@ -6,15 +6,30 @@ CLI as other features are.  All plugins are found in this directory.
 
 ## Creating a Plugin
 
-To create a plugin, simply drop a new python file into this directory.  The
-plugin must meet the following conditions:
+To create a plugin, simply drop a new python file into this directory or write a
+module that presents the interface described below.
 
+Plugins in this directory are called "Internal Plugins," and must meet the
+following conditions:
+
+ * It must be compatible with python 2 and 3
  * Its name must be unique, both with the other plugins and with all commands
    offered through the generated CLI
- * Its name must not contain special characters, and should be easily enter able
+ * Its name must not contain special characters, and should be easily to enter
    on the command line
+ * It must contain a `call(args, context)` function for invocation
  * It must support a `--help` command as all other CLI commands do.
 
+Plugins that are installed separately and registered with the `register-plugin`
+command are called "Third Party Plugins," and must meet the following
+conditions:
+
+ * It should be compatible with python 2 and 3
+ * Its name must be unique, both with the internal plugins and all CLI operations
+ * It must contain a `call(args, context)` function for invocation
+ * It must contain a `PLUGIN_NAME` constant whose value is a string that does not
+   contain special characters, and should be easy to enter on the command line.
+ * It should support a `--help` command as all other CLI commands do.
 
 ## The Plugin Interface
 
@@ -108,8 +123,16 @@ root directory of the project (this installs the code without generating new
 baked data, and will only work if you've installed the CLI via `make install`
 at least once, however it's a lot faster).
 
+To develop a third party plugin, simply create and install your module and register
+it to the CLI.  As long as the `PLUGIN_NAME` doesn't change, updated installations
+should invoke the new code.
+
 ### Examples
 
 This directory contains two example plugins, `echo.py.example` and
 `regionstats.py.example`.  To run these, simply remove the `.example` at the end
 of the file and build the CLI as described above.
+
+[This directory](https://github.com/linode/linode-cli/tree/master/examples/third-party-plugin)
+contains an example Third Party Plugin module.  This module is installable and
+can be registered to the CLI.

--- a/linodecli/plugins/__init__.py
+++ b/linodecli/plugins/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 
 _available_files = listdir(dirname(__file__))
-_available_local = [f[:-3] for f in _available_files if f.endswith('.py') and f != '__init__.py']
+available_local = [f[:-3] for f in _available_files if f.endswith('.py') and f != '__init__.py']
 
 
 def available(config):
@@ -18,7 +18,7 @@ def available(config):
 
         additional = registered_plugins.split(',')
 
-    return _available_local + additional
+    return available_local + additional
 
 
 def invoke(name, args, context):
@@ -28,7 +28,7 @@ def invoke(name, args, context):
     # setup config to know what plugin is running
     context.client.config.running_plugin = name
 
-    if name in _available_local:
+    if name in available_local:
         plugin = import_module('linodecli.plugins.'+name)
         plugin.call(args, context)
     elif name in available(context.client.config):

--- a/linodecli/plugins/__init__.py
+++ b/linodecli/plugins/__init__.py
@@ -1,23 +1,53 @@
 from importlib import import_module
 from os import listdir
 from os.path import dirname
+import sys
+
 
 _available_files = listdir(dirname(__file__))
-available = [f[:-3] for f in _available_files if f.endswith('.py') and f != '__init__.py']
+_available_local = [f[:-3] for f in _available_files if f.endswith('.py') and f != '__init__.py']
+
+
+def available(config):
+    """
+    Returns a list of plugins that are available
+    """
+    additional = []
+    if config.config.has_option('DEFAULT', 'registered-plugins'):
+        registered_plugins = config.config.get('DEFAULT', 'registered-plugins')
+
+        additional = registered_plugins.split(',')
+
+    return _available_local + additional
+
 
 def invoke(name, args, context):
     """
     Given the plugin name, executes a plugin
     """
-    if name not in available:
-        raise ValueError('No plugin named {}'.format(name))
-
-    plugin = import_module('linodecli.plugins.'+name)
-
     # setup config to know what plugin is running
     context.client.config.running_plugin = name
 
-    plugin.call(args, context)
+    if name in _available_local:
+        plugin = import_module('linodecli.plugins.'+name)
+        plugin.call(args, context)
+    elif name in available(context.client.config):
+        # this is a third-party plugin
+        try:
+            plugin_module_name = context.client.config.config.get(
+                    'DEFAULT', 'plugin-name-{}'.format(name))
+        except KeyError:
+            print('Plugin {} is misconfigured - please re-register it'.format(name))
+            sys.exit(9)
+        try:
+            plugin = import_module(plugin_module_name)
+        except ImportError:
+            print("Expected module '{}' not found.  Either {} is misconfigured, "
+                  "or the backing module was uninstalled.".format(plugin_moduel_name, name))
+            sys.exit(10)
+        plugin.call(args, context)
+    else:
+        raise ValueError('No plugin named {}'.format(name))
 
 
 class PluginContext:


### PR DESCRIPTION
This adds a new command, `register-plugin`, which loads the python
module supplied by the user and checks that it is a runnable CLI plugin
before registering it to the CLI's config.  On further invocations of
the config, this plugin will be available.

Third party plugins require two things:

1. A `call` function that matches the expected signature
1. A `PLUGIN_NAME` constant that defines how the plugin should be called

This PR needs the following:

- [x] Documentation
- [x] Handling naming conflicts between plugins
- [x] Re-registering