### PR TITLE
[DNM, breaks interface] Use whitespace separated arguments for arrays

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -148,7 +148,7 @@ class CLIOperation:
                 if arg.arg_type == 'array':
                     # special handling for input arrays
                     parser.add_argument('--'+arg.path, metavar=arg.name,
-                                        action='append', type=TYPES[arg.arg_item_type])
+                                        nargs='*', type=TYPES[arg.arg_item_type])
                 else:
                     if arg.arg_type == 'string' and arg.arg_format == 'password':
                         # special case - password input


### PR DESCRIPTION
Rather than needing to pass the `--flags` argument multiple times like this to pass multiple flags:

`linode-cli linodes create --root_pass someth0343## --tags tag1 --tags tag2 --tags tag2`

This changes the interface to whitespace separated arguments for an array

`linode-cli linodes create --root-pass someth0343## --tags tag1 tag2 tag3`