### PR TITLE
Fix - Resize and backups Tests

### DIFF
--- a/test/domains/domain-records.bats
+++ b/test/domains/domain-records.bats
@@ -21,7 +21,7 @@ teardown() {
 
     run linode-cli domains create \
         --type master \
-        --domain "$timestamp-example.com" \
+        --domain "A$timestamp-example.com" \
         --soa_email="pthiel@linode.com" \
         --text \
         --no-header

--- a/test/domains/master-domains.bats
+++ b/test/domains/master-domains.bats
@@ -20,7 +20,7 @@ teardown() {
 
 @test "it should fail to create a domain without specifying a type" {
 	run linode-cli domains create \
-		--domain "$timestamp-example.com" \
+		--domain "BC$timestamp-example.com" \
 		--soa_email="pthiel+$timestamp@linode.com" \
 		--text \
 		--no-header
@@ -33,7 +33,7 @@ teardown() {
 @test "it should fail to create a master domain without a SOA email" {
 	run linode-cli domains create \
 		--type master \
-		--domain "$timestamp-example.com" \
+		--domain "BC$timestamp-example.com" \
 		--text \
 		--no-header
 
@@ -46,14 +46,14 @@ teardown() {
 	run linode-cli domains create \
 		--type master \
 		--soa_email="pthiel+$timestamp@linode.com" \
-		--domain "$timestamp-example.com" \
+		--domain "BC$timestamp-example.com" \
 		--text \
 		--no-header \
 		--delimiter "," \
 		--format="id,domain,type,status,soa_email"
 
 	assert_success
-	assert_output --regexp "[0-9]+,$timestamp-example.com,master,active,pthiel\+$timestamp@linode.com"
+	assert_output --regexp "[0-9]+,BC$timestamp-example.com,master,active,pthiel\+$timestamp@linode.com"
 }
 
 @test "it should update the master domain soa_email" {
@@ -80,7 +80,7 @@ teardown() {
 		--delimiter=","
 
 	assert_success
-	assert_output --regexp "[0-9]+,[0-9]+-example.com,master,active"
+	assert_output --regexp "[0-9]+,BC[0-9]+-example.com,master,active"
 }
 
 @test "it should show domain detail" {
@@ -91,7 +91,7 @@ teardown() {
 		--format="id,domain,type,status,soa_email"
 
 	assert_success
-	assert_output --regexp "[0-9]+,[0-9]+-example.com,master,active"
+	assert_output --regexp "[0-9]+,BC[0-9]+-example.com,master,active"
 }
 
 @test "it should delete all master domains" {

--- a/test/linodes/backups.bats
+++ b/test/linodes/backups.bats
@@ -13,7 +13,7 @@ setup() {
     suiteName="backups"
     setToken "$suiteName"
     export timestamp=$(date +%s)
-    clean_linodes="false"
+    clean_linodes="FALSE"
     linode_id=$(linode-cli linodes list --format id --text --no-header | head -n 1)
     snapshot_label="test_snapshot1"
 }
@@ -21,7 +21,7 @@ setup() {
 teardown() {
     unset timestamp
 
-    if [ "$clean_linodes" = "true" ] || [ "$last_test" = "true" ]; then
+    if [ "$clean_linodes" = "TRUE" ] || [ "$LAST_TEST" = "TRUE" ]; then
         run removeLinodes
     fi
 
@@ -65,7 +65,7 @@ teardown() {
     assert_output --partial "$linode_id,True"
 
     # Cleanup linodes
-    clean_linodes="true"
+    clean_linodes="TRUE"
 }
 
 @test "it should create a backup with backups enabled" {
@@ -131,12 +131,12 @@ teardown() {
 
         # assert_output --regexp "[0-9]+,pending,snapshot,[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+,${snapshot_label}"
         # BUG outputs the backup as json, assertion below asserts that outputs the expected.
-        assert_output --regexp "\'status\': \'pending."
-        assert_output --regexp "\'finished\': None"
-        assert_output --regexp "\'type\': \'snapshot\'"
-        assert_output --regexp "\'label\': \'$snapshot_label\'"
-        assert_output --regexp "\'region\': \'us-east\'"
-        assert_output --regexp "\'id\': [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+        assert_output --regexp "'status\': 'pending."
+        assert_output --regexp "'finished': None"
+        assert_output --regexp "'type\': 'snapshot\'"
+        assert_output --regexp "'label\': '$snapshot_label'"
+        assert_output --regexp "'region\': 'us-east'"
+        assert_output --regexp "'id': [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
     else
         skip "Skipping long-running Test, to run set RUN_LONG_TESTS=TRUE"
     fi
@@ -159,5 +159,5 @@ teardown() {
         --no-headers
     assert_success
 
-    clean_linodes="true"
+    clean_linodes="TRUE"
 }

--- a/test/linodes/backups.bats
+++ b/test/linodes/backups.bats
@@ -131,12 +131,12 @@ teardown() {
 
         # assert_output --regexp "[0-9]+,pending,snapshot,[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+,${snapshot_label}"
         # BUG outputs the backup as json, assertion below asserts that outputs the expected.
-        assert_output --regexp "'status\': 'pending."
-        assert_output --regexp "'finished': None"
-        assert_output --regexp "'type\': 'snapshot\'"
-        assert_output --regexp "'label\': '$snapshot_label'"
-        assert_output --regexp "'region\': 'us-east'"
-        assert_output --regexp "'id': [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+        assert_output --regexp "'status':.*'pending"
+        assert_output --regexp "'finished':.*None"
+        assert_output --regexp "'type':.*'snapshot'"
+        assert_output --regexp "'label':.*'$snapshot_label'"
+        assert_output --regexp "'region':.*'us-east'"
+        assert_output --regexp "'id':.*[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
     else
         skip "Skipping long-running Test, to run set RUN_LONG_TESTS=TRUE"
     fi


### PR DESCRIPTION
* Fixed assertions for backups tests
* Fixed the setup for the resize tests, as this test would create a linode prior to each test and remove it after each (took a lot more time)

## Running the Tests

```bash
cd test
RUN_LONG_TESTS=TRUE bats linodes/backups.bats linodes/resize.bats
```