### PR TITLE
Fix: SSH bats tests

### DIFF
--- a/test/linodes/backups.bats
+++ b/test/linodes/backups.bats
@@ -47,7 +47,7 @@ teardown() {
 }
 
 @test "it should enable backups" {
-    if [ "$TEST_ENVIRONMENT" = "dev" ] || [ $"TEST_ENVIRONMENT" = "test" ]; then
+    if [ "$TEST_ENVIRONMENT" = "dev" ] || [ "$TEST_ENVIRONMENT" = "test" ]; then
         skip "Skipping backups tests"
     fi
 

--- a/test/ssh/distro-and-connection-check.bats
+++ b/test/ssh/distro-and-connection-check.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "it should create a linode and wait for it to be running" {
-    alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine')
+    alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine' | xargs | awk '{ print $1 }')
     plan=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
     ssh_key="$(cat ~/.ssh/id_rsa.pub)"
     createLinodeAndWait "$alpine_image" "$plan" "$ssh_key"

--- a/test/ssh/ssh.bats
+++ b/test/ssh/ssh.bats
@@ -40,7 +40,7 @@ teardown() {
 }
 
 @test "it should create a linode and wait for it to be running" {
-    alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine')
+    alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine' | xargs | awk '{ print $1 }')
 	plan=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
 	ssh_key="$(cat ~/.ssh/id_rsa.pub)"
 	createLinodeAndWait "$alpine_image" "$plan" "$ssh_key"


### PR DESCRIPTION
* When written, there was only one alpine distro option, now there's multiple. Updated the tests to use the first alpine image in the list.

