### PR TITLE
Fix: Remove any existing linodes before running the test

### DIFF
--- a/test/ssh/distro-and-connection-check.bats
+++ b/test/ssh/distro-and-connection-check.bats
@@ -12,20 +12,17 @@ load '../common'
 setup() {
     suiteName="distro-and-connection-check"
     setToken "$suiteName"
-    # linode_label="sshTestLinode"
 }
 
 teardown() {
-    if [[ "$LAST_TEST" = "TRUE" ]]; then
-        run removeLinodes
-    fi
-
     if [ "$LAST_TEST" = "TRUE" ]; then
+        run removeLinodes
         clearToken "$suiteName"
     fi
 }
 
 @test "it should create a linode and wait for it to be running" {
+    run removeLinodes
     alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine' | xargs | awk '{ print $1 }')
     plan=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
     ssh_key="$(cat ~/.ssh/id_rsa.pub)"

--- a/test/ssh/ssh.bats
+++ b/test/ssh/ssh.bats
@@ -12,20 +12,17 @@ load '../common'
 setup() {
     suiteName="ssh"
     setToken "$suiteName"
-    # linode_label="sshTestLinode"
 }
 
 teardown() {
-    if [[ "$LAST_TEST" = "TRUE" ]]; then
-        run removeLinodes
-    fi
-
     if [ "$LAST_TEST" = "TRUE" ]; then
+        run removeLinodes
         clearToken "$suiteName"
     fi
 }
 
 @test "it should display the ssh plugin usage information" {
+    run removeLinodes
     run linode-cli ssh -h
 
     assert_success


### PR DESCRIPTION
*Fixed for these flaky CLI tests.. 

* Occasionally, test data isn't cleaned up and these tests run and fail because they were getting the first linode ID and attempting to ssh into it. this PR forces removal of any existing linodes as the first step of each first test in the .bats file. 

* We can't add this to the setup hook, since that is run before each @test within the file.
 

