### PR TITLE
Add entity.id to argparse for int Conversion

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -70,6 +70,8 @@ def main():
                              "This is useful for scripting the CLI's behavior.")
     parser.add_argument('--version', '-v', action="store_true",
                         help="Prints version information and exits.")
+    # type cast string args to other types
+    parser.add_argument('--entity.id', type=int, help=argparse.SUPPRESS)
 
     parsed, args = parser.parse_known_args()
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -70,8 +70,6 @@ def main():
                              "This is useful for scripting the CLI's behavior.")
     parser.add_argument('--version', '-v', action="store_true",
                         help="Prints version information and exits.")
-    # type cast string args to other types
-    parser.add_argument('--entity.id', type=int, help=argparse.SUPPRESS)
 
     parsed, args = parser.parse_known_args()
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -133,6 +133,7 @@ class CLI:
                     '.'.join(prefix+[name]),
                     info.get('x-linode-filterable') or False,
                     info.get('x-linode-cli-display') or False,
+                    info.get('type') or 'string',
                     color_map=info.get('x-linode-cli-color')))
         return attrs
 

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -147,7 +147,7 @@ class CLIOperation:
 
         #  type cast certain args from string to int
         for arg in INT_FILTER_ARGS:
-            parser.add_argument('--'+arg, type=int, dest=arg, help=argparse.SUPPRESS)
+            parser.add_argument('--'+arg, type=int)
 
         for param in self.params:
             parser.add_argument(param.name, metavar=param.name,

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -83,6 +83,9 @@ TYPES = {
     "number": float,
 }
 
+INT_FILTER_ARGS = [
+    'entity.id'
+]
 
 class CLIArg:
     """
@@ -141,6 +144,11 @@ class CLIOperation:
         """
         #  build an argparse
         parser = argparse.ArgumentParser(description=self.summary)
+
+        #  type cast certain args from string to int
+        for arg in INT_FILTER_ARGS:
+            parser.add_argument('--'+arg, type=int, dest=arg, help=argparse.SUPPRESS)
+
         for param in self.params:
             parser.add_argument(param.name, metavar=param.name,
                                 type=TYPES[param.param_type])
@@ -148,7 +156,7 @@ class CLIOperation:
         if self.method == "get":
             # build args for filtering
             for attr in self.response_model.attrs:
-                if attr.filterable:
+                if attr.filterable and attr.name not in INT_FILTER_ARGS:
                     parser.add_argument('--'+attr.name, metavar=attr.name)
 
         elif self.method in ("post", "put"):

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -83,9 +83,6 @@ TYPES = {
     "number": float,
 }
 
-INT_FILTER_ARGS = [
-    'entity.id'
-]
 
 class CLIArg:
     """
@@ -144,11 +141,6 @@ class CLIOperation:
         """
         #  build an argparse
         parser = argparse.ArgumentParser(description=self.summary)
-
-        #  type cast certain args from string to int
-        for arg in INT_FILTER_ARGS:
-            parser.add_argument('--'+arg, type=int)
-
         for param in self.params:
             parser.add_argument(param.name, metavar=param.name,
                                 type=TYPES[param.param_type])
@@ -156,8 +148,8 @@ class CLIOperation:
         if self.method == "get":
             # build args for filtering
             for attr in self.response_model.attrs:
-                if attr.filterable and attr.name not in INT_FILTER_ARGS:
-                    parser.add_argument('--'+attr.name, metavar=attr.name)
+                if attr.filterable:
+                    parser.add_argument('--'+attr.name, type=TYPES[attr.datatype], metavar=attr.name)
 
         elif self.method in ("post", "put"):
             # build args for body JSON

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -8,12 +8,13 @@ from colorclass import Color
 
 
 class ModelAttr:
-    def __init__(self, name, filterable, display, color_map=None):
+    def __init__(self, name, filterable, display, datatype, color_map=None):
         self.name = name
         self.value = None
         self.filterable = filterable
         self.display = display
         self.column_name = self.name.split('.')[-1]
+        self.datatype = datatype
         self.color_map = color_map
 
     def _get_value(self, model):


### PR DESCRIPTION
This is a fix for #106

Args that are not picked up by the argparse are being treated as
strings. A way around this is to add the specific argument,
'--entity.id', to argparse and treat it as an 'int'. We also suppress
the argument when displaying the "help" message.