### PR TITLE
Edit Makefile to fix issue #78 and allow py2/py3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ SPEC ?= https://developers.linode.com/api/docs/v4/openapi.yaml
 ifeq ($(PYTHON), 3)
 	PYCMD=python3
 	PIPCMD=pip3
+	PY2CMD=python2
 else
 	PYCMD=python
 	PIPCMD=pip
+	PY2CMD=python
 endif
 
 install: check-prerequisites requirements build
@@ -18,7 +20,7 @@ install: check-prerequisites requirements build
 
 .PHONY: build
 build: clean
-	python -m linodecli bake ${SPEC} --skip-config
+	${PY2CMD} -m linodecli bake ${SPEC} --skip-config
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-2 linodecli/
 	cp data-3 linodecli/


### PR DESCRIPTION
As described in Issue #78, the existing makefile expects "python" to
point to python2. However, on many modern distros "python" actually
points to python3 (and python2 is available by "python2"). This changes
the python2 command to "python2" if the python version detected is
python3. (This *could* create a different issue if python2 isn't
    available with "python2" ... but I *believe* that it should be in
    99-100% of cases?)