### PR TITLE
bug: Fix filtering by tags (and other arrays)

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -129,12 +129,18 @@ class CLI:
                 attrs += self._parse_properties(info['properties'],
                                                 prefix+[name])
             else:
+                item_type = None
+                item_container = info.get('items')
+                if item_container:
+                    item_type = item_container.get('type')
                 attrs.append(ModelAttr(
                     '.'.join(prefix+[name]),
                     info.get('x-linode-filterable') or False,
                     info.get('x-linode-cli-display') or False,
                     info.get('type') or 'string',
-                    color_map=info.get('x-linode-cli-color')))
+                    color_map=info.get('x-linode-cli-color'),
+                    item_type=item_type))
+
         return attrs
 
     def bake(self, spec):

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -27,7 +27,6 @@ def parse_dict(value):
     intended to be passed to the `type=` kwarg for ArgumentParaser.add_argument.
     """
     if not isinstance(value, str):
-        print("not a string :(")
         raise argparse.ArgumentTypeError('Expected a JSON string')
     try:
         return json.loads(value)
@@ -149,7 +148,12 @@ class CLIOperation:
             # build args for filtering
             for attr in self.response_model.attrs:
                 if attr.filterable:
-                    parser.add_argument('--'+attr.name, type=TYPES[attr.datatype], metavar=attr.name)
+                    expected_type = TYPES[attr.datatype]
+                    if expected_type == list:
+                        parser.add_argument('--'+attr.name, type=TYPES[attr.item_type],
+                                            metavar=attr.name, nargs='?')
+                    else:
+                        parser.add_argument('--'+attr.name, type=expected_type, metavar=attr.name)
 
         elif self.method in ("post", "put"):
             # build args for body JSON

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -8,7 +8,7 @@ from colorclass import Color
 
 
 class ModelAttr:
-    def __init__(self, name, filterable, display, datatype, color_map=None):
+    def __init__(self, name, filterable, display, datatype, color_map=None, item_type=None):
         self.name = name
         self.value = None
         self.filterable = filterable
@@ -16,6 +16,7 @@ class ModelAttr:
         self.column_name = self.name.split('.')[-1]
         self.datatype = datatype
         self.color_map = color_map
+        self.item_type = item_type
 
     def _get_value(self, model):
         """


### PR DESCRIPTION
Closes #151

This was introduced in #141 - by parsing filter arguments as their
declared types in the spec, we were unintentionally turning "tags" into
an array of characters (it's defined as an array in the spec), so
`--tags test` would result in an header of `X-Filter: '{"tags":["t","e","s","t"]}'`,
which the API would balk at (correctly).

This change now captures the declared _item type_, and expects that for
any filterable attribute that is declared as an array.

@patthiel, we should add a test for filtering requests with tags to
prevent future regressions in the same vein.