### PR TITLE
Lke fixes

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -100,10 +100,16 @@ def main():
         cli.config.set_user(parsed.as_user)
 
     if parsed.version:
-        # print version info and exit
-        print("linode-cli {}".format(VERSION))
-        print("Built off spec version {}".format(cli.spec_version))
-        exit(0)
+        if not parsed.command:
+            # print version info and exit - but only if no command was given
+            print("linode-cli {}".format(VERSION))
+            print("Built off spec version {}".format(cli.spec_version))
+            exit(0)
+        else:
+            # something else might want to parse version
+            # find where it was originally, as it was removed from args
+            index = argv.index('--version') - 3 # executable command action
+            args = args[:index] + ['--version'] + args[index:]
 
     # handle a bake - this is used to parse a spec and bake it as a pickle
     if parsed.command == "bake":

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -113,8 +113,21 @@ class CLI:
                     # as is expected here
                     items = self._resolve_allOf(items['allOf'])
                     items = {"type":"object","items":items}
+                if '$ref' in items:
+                    # if it's just a ref, parse that out too
+                    items = self._resolve_ref(items['$ref'])
 
                 args[path]['item_type'] = items['type']
+
+                if (items['type'] == 'object' and 'properties' in items and
+                        not items.get('readOnly')):
+                    # this is a special case - each item has its own properties
+                    # that we need to capture separately
+                    item_args = self._parse_args(items['properties'], prefix=prefix+[arg])
+                    for _, v in item_args.items():
+                        v['list_item'] = path
+                    args.update(item_args)
+                    del args[path] # remove the base element, which is junk
 
         return args
 
@@ -220,7 +233,7 @@ class CLI:
 
                     for arg, info in args.items():
                         new_arg = CLIArg(info['name'], info['type'], info['desc'].split('.')[0]+'.',
-                                         arg, info['format'])
+                                         arg, info['format'], list_item=info.get('list_item'))
 
                         if arg in required_fields:
                             new_arg.required = True

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -164,8 +164,7 @@ class CLIOperation:
                 elif arg.list_item is not None:
                     parser.add_argument('--'+arg.path, metavar=arg.name,
                                         action='append', type=TYPES[arg.arg_type])
-                    if arg.list_item:
-                        list_items.append((arg.path, arg.list_item))
+                    list_items.append((arg.path, arg.list_item))
                 else:
                     if arg.arg_type == 'string' and arg.arg_format == 'password':
                         # special case - password input
@@ -185,12 +184,13 @@ class CLIOperation:
         for arg_name, list_name in list_items:
             item_name = arg_name.split('.')[-1]
             if hasattr(parsed, arg_name):
+                val = getattr(parsed, arg_name) or []
                 if  list_name not in lists:
-                    new_list = [{item_name: c} for c in getattr(parsed, arg_name)]
+                    new_list = [{item_name: c} for c in val]
                     lists[list_name] = new_list
                 else:
                     update_list = lists[list_name]
-                    for obj, item in zip(update_list, getattr(parsed, arg_name)):
+                    for obj, item in zip(update_list, val):
                         obj[item_name] = item
 
         if lists:


### PR DESCRIPTION
This needs https://github.com/linode/linode-api-docs/pull/160

Only respect `--version` if no command is given.  

This broke some LKE commands that use `--version` to supply the version
of kubernetes that should be deployed.  Previously, including
`--version` in invocation would print the version and exit; now it only
does anything if no command is given.  For example:

```bash
linode-cli --version # prints version
linode-cli linodes --version # prints help for linodes command
```

Handle lists of objects 

LKE uses node_pools, a list of objects, to specify what pools must be
supplied when creating an LKE Cluster.  This is the first time we've had
such input, and the CLI didn't handle it well.

This is a slightly scary change as it changes how the spec is parsed -
please test carefully with other endpoints!