### PR TITLE
Feature/parse complex responses better

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -224,7 +224,8 @@ class CLI:
                             attrs = self._parse_properties(resp_con['properties'])
                             # maybe we have special columns?
                             rows = data[m]['responses']['200']['content']['application/json'].get('x-linode-cli-rows') or None
-                            response_model = ResponseModel(attrs, rows=rows)
+                            nested_list = data[m]['responses']['200']['content']['application/json'].get('x-linode-cli-nested-list') or None
+                            response_model = ResponseModel(attrs, rows=rows, nested_list=nested_list)
 
                     cli_args = []
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -224,8 +224,6 @@ class CLI:
                             attrs = self._parse_properties(resp_con['properties'])
                             # maybe we have special columns?
                             rows = data[m]['responses']['200']['content']['application/json'].get('x-linode-cli-rows') or None
-                            if rows:
-                                print('got columns {}'.format(rows))
                             response_model = ResponseModel(attrs, rows=rows)
 
                     cli_args = []

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -177,9 +177,6 @@ class CLIOperation:
         if self.response_model is None:
             return
 
-        if 'pages' in json:
-            json = json['data']
-        else:
-            json = [json]
+        json = self.response_model.fix_json(json)
 
         handler.print(self.response_model, json)

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -88,7 +88,9 @@ class ResponseModel:
             # take the columns as specified
             ret = []
             for c in self.rows:
-                cur = json.get(c)
+                cur = json
+                for part in c.split('.'):
+                    cur = cur.get(part)
 
                 if not cur:
                     # probably shouldn't happen, but ok

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -76,9 +76,10 @@ class ModelAttr:
 
 
 class ResponseModel:
-    def __init__(self, attrs, rows=None):
+    def __init__(self, attrs, rows=None, nested_list=None):
         self.attrs = attrs
         self.rows = rows
+        self.nested_list = nested_list
 
     def fix_json(self, json):
         """
@@ -102,6 +103,23 @@ class ResponseModel:
                     ret.append(cur)
 
             # we're good
+            return ret
+        elif self.nested_list:
+            # we need to explode the rows into one row per entry in the nested list,
+            # copying the external values
+            if 'pages' in json:
+                json = json['data']
+
+            ret = []
+            if not isinstance(json, list):
+                json = [json]
+            for cur in json:
+                nlist = cur.get(self.nested_list)
+                for item in nlist:
+                    cobj = {k: v for k, v in cur.items() if k != self.nested_list}
+                    cobj[self.nested_list] = item
+                    ret.append(cobj)
+
             return ret
         elif 'pages' in json:
             return json['data']

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -76,5 +76,32 @@ class ModelAttr:
 
 
 class ResponseModel:
-    def __init__(self, attrs):
+    def __init__(self, attrs, rows=None):
         self.attrs = attrs
+        self.rows = rows
+
+    def fix_json(self, json):
+        """
+        Takes JSON from the API and formats it into a list of rows
+        """
+        if self.rows:
+            # take the columns as specified
+            ret = []
+            for c in self.rows:
+                cur = json.get(c)
+
+                if not cur:
+                    # probably shouldn't happen, but ok
+                    continue
+
+                if isinstance(cur, list):
+                    ret += cur
+                else:
+                    ret.append(cur)
+
+            # we're good
+            return ret
+        elif 'pages' in json:
+            return json['data']
+        else:
+            return [json]


### PR DESCRIPTION
This adds two new custom attributes for use in the OpenAPI spec:

 - `x-linode-cli-rows` - Placed in an `application/json` section of a
   `response_body`, this attribute defines how the CLI should find its
   rows for tabular output.
 - `x-linode-cli-use-schema` - Placed alongside `x-linode-cli-rows`,
   this defines what schema to use for the rows defined by that
   attribute.

This fixes responses like `linode-cli linodes backups-list` that don't
conform to normal paginated response design in the API.

Before:

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────┬─────────────┐
│ automatic                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      │ current │ in_progress │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────┼─────────────┤
│ {u'status': u'successful', u'updated': u'2019-11-21T11:28:45', u'created': u'2019-11-21T11:19:58', u'region': u'us-east', u'disks': [{u'size': 2032, u'filesystem': u'ext4', u'label': u'Ubuntu 14.04 LTS Disk'}, {u'size': 0, u'filesystem': u'swap', u'label': u'256MB Swap Image'}], u'label': None, u'finished': u'2019-11-21T11:22:06', u'configs': [u'My Ubuntu 14.04 LTS Profile'], u'type': u'auto', u'id': 131698849}, {u'status': u'successful', u'updated': u'2019-11-21T11:28:45', u'created': u'2019-11-17T11:19:36', u'region': u'us-east', u'disks': [{u'size': 2018, u'filesystem': u'ext4', u'label': u'Ubuntu 14.04 LTS Disk'}, {u'size': 0, u'filesystem': u'swap', u'label': u'256MB Swap Image'}], u'label': None, u'finished': u'2019-11-17T11:21:07', u'configs': [u'My Ubuntu 14.04 LTS Profile'], u'type': u'auto', u'id': 131397712}, {u'status': u'successful', u'updated': u'2019-11-21T11:28:45', u'created': u'2019-11-10T11:19:08', u'region': u'us-east', u'disks': [{u'size': 1948, u'filesystem': u'ext4', u'label': u'Ubuntu 14.04 LTS Disk'}, {u'size': 0, u'filesystem': u'swap', u'label': u'256MB Swap Image'}], u'label': None, u'finished': u'2019-11-10T11:20:34', u'configs': [u'My Ubuntu 14.04 LTS Profile'], u'type': u'auto', u'id': 130871901} │         │             │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────┴─────────────┘
```

After:

```
┌───────────┬────────────┬──────┬─────────────────────┬───────┐
│ id        │ status     │ type │ created             │ label │
├───────────┼────────────┼──────┼─────────────────────┼───────┤
│ 131698849 │ successful │ auto │ 2019-11-21T11:19:58 │       │
│ 131397712 │ successful │ auto │ 2019-11-17T11:19:36 │       │
│ 130871901 │ successful │ auto │ 2019-11-10T11:19:08 │       │
└───────────┴────────────┴──────┴─────────────────────┴───────┘
```
