### PR TITLE
Update: Converts bucket size output to human readable bytes

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -440,6 +440,7 @@ def show_usage(client, args):
             if total > 1024:
                 total = total / 1024 
             if total < 1024:
+                total = round(total, 2)
                 total = str(total) + " " + x
                 break
            

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -432,6 +432,17 @@ def show_usage(client, args):
             total += obj.size
 
         grand_total += total
+
+        # Coverts bucket size to human readable bytes. 
+        total = float(total)
+        denomination = ["KB", "MB","GB","TB"]
+        for x in denomination:
+            if total > 1024:
+                total = total / 1024 
+            if total < 1024:
+                total = str(total) + " " + x
+                break
+           
         tab = _borderless_table([[_pad_to(total, length=7), '{} objects'.format(num), b.name]])
         print(tab.table)
 


### PR DESCRIPTION
Had trouble deploying locally to test this, however I did run this code through multiple tests in an online IDE using various bite sizes and it continually worked successfully. 

This code converts the bytes output of a bucket size `linode-cli obj du` to human readable sizes. (KB, MB, GB, TB etc..) instead of just bytes, for easier to read sizes for our customers. 

