### PR TITLE
Fix unbound local error in padding OBJ disk usage

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -735,6 +735,8 @@ def _pad_to(val, length=10, right_align=False):
     Pads val to be at minimum length characters long
     """
     ret = str(val)
+    padding = ""
+
     if len(ret) < 10:
         padding = " "*(10-len(ret))
 


### PR DESCRIPTION
Closes #159

It turns out that if you have more than 10 characters worth of disk
usage, the padding code broke.  This initialized `padding` to `""`
before setting it for smaller strings to avoid the break.