### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python setup.py install ; linode-cli "

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 linode-cli
 ==========
-
+.. image:: https://repl.it/badge/github/linode/linode-cli
+    :target: https://repl.it/github/linode/linode-cli
 The Linode Command Line Interface
 
 .. image:: https://raw.githubusercontent.com/linode/linode-cli/master/demo.gif


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.It adds a `.replit` configuration file and a Repl.it badge to the `README`. This will allow viewers of the repository to click the run on Repl.it button and be able to use ddgr inside the Repl.it environment.
You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/linode-cli).