### PR TITLE
bug: Fix handling lists of objects

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -200,6 +200,8 @@ class CLIOperation:
         if lists:
             parsed = vars(parsed)
             parsed.update(lists)
+            for name, _ in list_items:
+                del parsed[name]
             parsed = argparse.Namespace(**parsed)
 
         return parsed


### PR DESCRIPTION
Closes #166

It looks like in many cases, the original lists remained after the
objects were reconstructed, causing the eventual parsing to JSON to
fail.  This removes the input lists after reconstructing the expected
objects to allow parsing to JSON to succeed.