### PR TITLE
Added --debug flag for printing HTTP request details

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -70,6 +70,8 @@ def main():
                              "This is useful for scripting the CLI's behavior.")
     parser.add_argument('--version', '-v', action="store_true",
                         help="Prints version information and exits.")
+    parser.add_argument('--debug', action='store_true',
+                        help="Enable verbose HTTP debug output")
 
     parsed, args = parser.parse_known_args()
 
@@ -94,6 +96,7 @@ def main():
     cli.defaults = not parsed.no_defaults
     cli.suppress_warnings = parsed.suppress_warnings
     cli.page = parsed.page
+    cli.debug_request = parsed.debug
 
     if parsed.as_user:
         # if they are acting as a non-default user, set it up early


### PR DESCRIPTION
This closes #169

This is something I frequently jam into the CLI (much less gracefully)
during development of new features, to better see what's actually going
on.  Since it was requested as a feature, I figure it doesn't hurt to
include in the official build and save myself time going forward.

I based the actual output on curl's `-v` option, which I use for the
same purposes fairly regularly.  I'm open to other ideas, though.

Example output: 

```
$ linode-cli --debug linodes list --label Demo2
> GET https://api.linode.com/v4//linode/instances?page=1
> Authorization: Bearer [REDACTED]
> Content-Type: application/json
> User-Agent: linode-cli:2.13.1
> X-Filter: {"label": "Demo2"}
> Body:
>
>
< HTTP/1.1 200 OK
< Server: nginx
< Date: Fri, 13 Mar 2020 18:55:23 GMT
< Content-Type: application/json
< Content-Length: 737
< Connection: keep-alive
< Cache-Control: private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
< X-OAuth-Scopes: *
< X-Accepted-OAuth-Scopes: linodes:read_only
< X-Frame-Options: DENY, DENY
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: HEAD, GET, OPTIONS, POST, PUT, DELETE
< Access-Control-Allow-Headers: Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
< X-Spec-Version: 4.59.2
< Vary: Authorization, X-Filter, Authorization, X-Filter
< X-RateLimit-Limit: 1600
< X-RateLimit-Remaining: 1597
< X-RateLimit-Reset: 1584125764
< Retry-After: 40
< Access-Control-Allow-Credentials: true
< Access-Control-Expose-Headers: X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
< Content-Security-Policy: default-src 'none'
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Strict-Transport-Security: max-age=31536000
<
┌─────────┬───────┬────────────┬───────────────┬────────────────┬─────────┬─────────────┐
│ id      │ label │ region     │ type          │ image          │ status  │ ipv4        │
├─────────┼───────┼────────────┼───────────────┼────────────────┼─────────┼─────────────┤
│ 8294222 │ Demo2 │ us-central │ g6-standard-1 │ linode/debian9 │ offline │ 45.79.5.231 │
└─────────┴───────┴────────────┴───────────────┴────────────────┴─────────┴─────────────┘
```

Note: In the above example., I redacted my own token; it's actually printed in the normal output.  I chose to keep it in as it could help users construct their own requests without the CLI, but I'm open to removing it there if it's a concern.