### PR TITLE
Improved JSON output

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -78,13 +78,13 @@ def main():
         cli.output_handler.mode = OutputMode.delimited
     elif parsed.json:
         cli.output_handler.mode = OutputMode.json
-        cli.output_handler.pretty_json = True
         cli.output_handler.columns = '*'
     elif parsed.markdown:
         cli.output_handler.mode = OutputMode.markdown
     if parsed.delimiter:
         cli.output_handler.delimiter = parsed.delimiter
     if parsed.pretty:
+        cli.output_handler.mode = OutputMode.json
         cli.output_handler.pretty_json = True
     if parsed.no_headers:
         cli.output_handler.headers = False

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -86,6 +86,7 @@ def main():
     if parsed.pretty:
         cli.output_handler.mode = OutputMode.json
         cli.output_handler.pretty_json = True
+        cli.output_handler.columns = '*'
     if parsed.no_headers:
         cli.output_handler.headers = False
     if parsed.all:

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -78,6 +78,8 @@ def main():
         cli.output_handler.mode = OutputMode.delimited
     elif parsed.json:
         cli.output_handler.mode = OutputMode.json
+        cli.output_handler.pretty_json = True
+        cli.output_handler.columns = '*'
     elif parsed.markdown:
         cli.output_handler.mode = OutputMode.markdown
     if parsed.delimiter:


### PR DESCRIPTION
This closes #153

Presently, `--json` simply outputs the normal fields as a JSON object,
with no special formatting or considerations, and it's up to the caller
to request `--pretty` and/or `--all` depending on their use-case.  This
change now enables `--all` for all JSON output, and enabled `--json` by
default when calling with `--pretty`.

`--all` can still be overridden via `--format`, which, if provided, will
trim down the resulting JSON object to only the named fields.

`--pretty` not forces json output in a pretty format.  This flag did nothing
otherwise, so this should be safe to do.