### PR TITLE
Allow API POST/PUT Body Elements to Conflict with CLI Flags

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -104,6 +104,7 @@ class CLI:
                 "desc": info.get('description') or '',
                 "name": arg,
                 "format": info.get('format', None),
+                "name_override": info.get('x-linode-cli-name', None),
             }
             # handle input lists
             if args[path]['type'] == 'array' and 'items' in info:
@@ -250,8 +251,11 @@ class CLI:
                     cli_args = []
 
                     for arg, info in args.items():
-                        new_arg = CLIArg(info['name'], info['type'], info['desc'].split('.')[0]+'.',
-                                         arg, info['format'], list_item=info.get('list_item'))
+                        cli_name = info['name_override'] or info['name']
+                        cli_path = info['name_override'] or arg
+                        new_arg = CLIArg(cli_name, info['type'], info['desc'].split('.')[0]+'.',
+                                         cli_path, info['format'], list_item=info.get('list_item'),
+                                         api_name=arg)
 
                         if arg in required_fields:
                             new_arg.required = True


### PR DESCRIPTION
Closes #154

For the first time ever, one of the API's request arguments conflicts
with a built-in CLI flag, that being `POST lke/clusters`'s argument
"version".  When translated to the CLI's interface, it becomes
`--version`, which the CLI will pick up as a request to print its own
version number an exit.

This change adds a new spec extension to Linode's OpenAPI spec,
`x-linode-cli-name`, which is allowed in schemas and defines the name
the CLI should use for that element _instead of_ the name of that schema
in the spec.  This should be used only in exceptional cases (like that
noted above) to keep the CLI's behavior predictable.