### PR TITLE
Allow regenerating Object Storage keys

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -620,7 +620,7 @@ def call(args, context):
         print("Regenerating Object Storage keys..")
         _get_s3_creds(context.client, force=True)
         print("Done.")
-        print("Warning: Your old Object Storage keys _were not_ expired!  If you want "
+        print("Warning: Your old Object Storage keys _were not_ automatically expired!  If you want "
               "to expire them, see `linode-cli object-storage keys-list` and "
               "`linode-cli object-storage keys-delete [KEYID]`.")
     else:


### PR DESCRIPTION
Closes #178

Previously, there was no way to regenerate your object storage keys
without manually editing the CLI's config, which is a pretty lousy user
experience.  If you were to delete the keys in cloud, for example, the
CLI would be stuck attempting to use them for requests to Object
Storage.

This change adds the "regenerate-keys" command to the `obj` plugin,
allowing object storage keys to be regenerated in case they become
expired or otherwise don't work.