### PR TITLE
Make total size human-readable in `linode-cli obj du` output

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -453,26 +453,32 @@ def show_usage(client, args):
 
         grand_total += total
 
-        # Coverts bucket size to human readable bytes.
-        total = float(total)
-        denomination = ["KB", "MB","GB","TB"]
-        for x in denomination:
-            if total > 1024:
-                total = total / 1024
-            if total < 1024:
-                total = round(total, 2)
-                total = str(total) + " " + x
-                break
+        total = _denominate(total)
 
         tab = _borderless_table([[_pad_to(total, length=7), '{} objects'.format(num), b.name]])
         print(tab.table)
 
     if len(buckets) > 1:
         print('--------')
-        print('{} Total'.format(grand_total))
+        print('{} Total'.format(_denominate(grand_total)))
 
     exit(0)
 
+
+def _denominate(total):
+    """
+    Coverts bucket size to human readable bytes.
+    """
+    total = float(total)
+    denomination = ["KB", "MB","GB","TB"]
+    for x in denomination:
+        if total > 1024:
+            total = total / 1024
+        if total < 1024:
+            total = round(total, 2)
+            total = str(total) + " " + x
+            break
+    return total
 
 def list_all_objects(client, args):
     """


### PR DESCRIPTION
Closes #181

When the object storage plugin lists bucket usage via the `du` command,
the size of each bucket is converted in KB, MB, or GB to present a more
human-friendly interface.  Due to an oversight, the total size of all
buckets was not converted to a human-friendly value in the same way, and
is being displayed simply as total bytes.

This change refactors the code that did the conversion out into its own
function, and calls it for both bucket totals and the grand total of
usage in a cluster.