### PR TITLE
bug: Handle paginated responses without $refs

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -237,7 +237,10 @@ class CLI:
                         if 'properties' in resp_con and 'pages' in resp_con['properties']:
                             resp_con = resp_con['properties']
                         if 'pages' in resp_con and 'data' in resp_con:
-                            resp_con = self._resolve_ref(resp_con['data']['items']['$ref'])
+                            if '$ref' in resp_con['data']['items']:
+                                resp_con = self._resolve_ref(resp_con['data']['items']['$ref'])
+                            else:
+                                resp_con = resp_con['data']['items']
 
                         attrs = []
                         if 'properties' in resp_con:


### PR DESCRIPTION
The CLI's spec parser currently makes a lot of assumptions, and one is
that paginated responses will have a `$ref` for their data, instead of
listing the schema directly.  This isn't required by OpenAPI, and for
the first time it isn't the case in our spec.

This change handles non-`$ref` paginated response data.