### PR TITLE
Correct version bounds for enum34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,13 @@ setup(
         'linodecli.plugins',
     ],
     license="BSD 3-Clause License",
-    install_requires=["terminaltables","colorclass","requests","PyYAML","enum34"],
+    install_requires=[
+        "terminaltables",
+        "colorclass",
+        "requests",
+        "PyYAML",
+        "enum34;python_version<'3.4'",
+    ],
     entry_points={
         "console_scripts": [
             "linode-cli = linodecli:main",


### PR DESCRIPTION
Enum34 is a backport to python<=3.3, in python>=3.4 the library is available in the stdlib.