### PR TITLE
test user creation, deletion, retrieval, and listing

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -14,6 +14,11 @@ fi
 if [ -z "$uniqueTag" ]; then
     export uniqueTag="$(date +%s)-tag"
 fi
+#
+# A Unique user to use in user related tests
+if [ -z "$uniqueUser" ]; then
+    export uniqueUser="test-user-$(date +%s)"
+fi
 
 createLinode() {
     local region=${1:-us-east}

--- a/test/users/users.bats
+++ b/test/users/users.bats
@@ -25,7 +25,7 @@ teardown() {
     echo "export user=$uniqueUser" > .tmp-user
     run linode-cli users create \
         --username $uniqueUser \
-        --email $uniqueUser@localhost \
+        --email $uniqueUser@linode.com \
         --restricted true \
         --text \
         --no-headers

--- a/test/users/users.bats
+++ b/test/users/users.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-assert/load'
+load '../test_helper/bats-support/load'
+load '../common'
+
+setup() {
+    suiteName="users"
+    setToken "$suiteName"
+}
+
+teardown() {
+    if [ "$LAST_TEST" = "TRUE" ]; then
+        clearToken "$suiteName"
+        rm .tmp-user
+    fi
+}
+
+@test "it should display users" {
+    run linode-cli users list
+    assert_success
+}
+
+@test "it should create a user" {
+    echo "export user=$uniqueUser" > .tmp-user
+    run linode-cli users create \
+        --username $uniqueUser \
+        --email $uniqueUser@localhost \
+        --restricted true \
+        --text \
+        --no-headers
+    assert_success
+}
+
+@test "it should view a user" {
+    source .tmp-user
+
+    run linode-cli users view $user
+    assert_success
+}
+
+@test "it should remove a user" {
+    LAST_TEST="TRUE"
+    source .tmp-user
+
+    run linode-cli users delete $user
+    assert_success
+}


### PR DESCRIPTION
I came to report an issue retrieving users, but found @patthiel had already opened an issue for it (https://github.com/linode/linode-cli/issues/42).

I didn't look into the details of why it is failing. It seems like @Dorthu had a good idea of what was going on. Thought I could help and write some tests for it. Taken almost 1:1 from tags.bats, but they do exemplify what I was going to report.

p.s. no clue of this `localhost` email is accepted by the API. The warning when trying to test it locally about deleting all my things scared me, so I'm letting CI here do it for me.