### PR TITLE
Allow invoking obj plugin without config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,12 @@ will allow you to set defaults without having to set a token.  Be aware that if
 the environment variable should be unset, the Linode CLI will stop working until
 it is set again or the CLI is reconfigured with a token.
 
+You may also use environment variables to store your Object Storage Keys for
+the ``obj`` plugin that ships with the CLI.  To do so, simply set
+``LINODE_CLI_OBJ_ACCESS_KEY`` and ``LINODE_CLI_OBJ_SECRET_KEY`` to the
+appropriate values.  This allows using Linode Object Storage through the CLI
+without having a configuration file, which is desirable in some situations.
+
 Multiple Users
 ^^^^^^^^^^^^^^
 

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -16,6 +16,9 @@ from math import ceil
 from linodecli.configuration import input_helper
 
 
+ENV_ACCESS_KEY_NAME = "LINODE_CLI_OBJ_ACCESS_KEY"
+ENV_SECRET_KEY_NAME = "LINODE_CLI_OBJ_SECRET_KEY"
+
 try:
     import boto
     from boto.exception import S3CreateError, S3ResponseError, BotoClientError
@@ -622,14 +625,6 @@ def call(args, context):
                         help='The command to execute in object storage')
     parser.add_argument('--cluster', metavar='CLUSTER', type=str,
                         help='The cluster to use.  Defaults to us-east-1 (presently)')
-    parser.add_argument('--access-key', metavar='ACCESS_KEY', type=str,
-                        help='The Object Storage Access Key to use.  Optional.  '
-                             'If not provided, will use the configured access key '
-                             'for the active user, or generate a new one and save it')
-    parser.add_argument('--secret-key', metavar='SECRET_KEY', type=str,
-                        help='The Object Storage Secret Key to use.  Optional.  '
-                             'If not provided, will use the configured secret key '
-                             'for the active user, or generate a new one and save it')
 
     parsed, args = parser.parse_known_args(args)
 
@@ -658,10 +653,14 @@ def call(args, context):
 
     # make a client, but only if we weren't printing help
 
-    access_key, secret_key = parsed.access_key, parsed.secret_key
+    access_key, secret_key = (
+        os.environ.get(ENV_ACCESS_KEY_NAME, None),
+        os.environ.get(ENV_SECRET_KEY_NAME, None),
+    )
+
 
     if access_key and not secret_key or secret_key and not access_key:
-        print("You must give both of --access-key and --secret-key, or neither")
+        print("You must set both {} and {}, or neither".format(ENV_ACCESS_KEY_NAME, ENV_SECRET_KEY_NAME))
         exit(1)
 
     # not given on command line, so look them up


### PR DESCRIPTION
This is for @phillc

Previously, the `obj` plugin would require a config file to use to
get/store its object storage keys.  This isn't great for scripting.
This change allows those keys to be provided via flags to the plugin.

To invoke the plugin without a config, do something like this:

```bash
TOKEN=$API_V4_TOKEN linode-cli obj ls --access-key $ACCESS_KEY --secret-key $SECRET_KEY
```

Should this be pulled from the environment instead of the command line?