### PR TITLE
Accept passwords from environment

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import argparse
 from getpass import getpass
 import json
-from os import path
+from os import path, environ
 
 
 def parse_boolean(value):
@@ -43,11 +43,17 @@ class PasswordPromptAction(argparse.Action):
         super(PasswordPromptAction, self).__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
+        # if not provided on the command line, pull from the environment if it
+        # exists at this key
+        environ_key = "LINODE_CLI_{}".format(self.dest.upper())
+
         if values:
             if isinstance(values, str):
                 password = values
             else:
                 raise argparse.ArgumentTypeError('Expected a string (or leave blank for prompt)')
+        elif environ_key in environ:
+            password = environ.get(environ_key)
         else:
             prompt = 'Value for {}: '.format(self.dest)
             password = getpass(prompt)


### PR DESCRIPTION
Closes #200

As it is now, the CLI either accepts passwords on the command line, or
interactively.  The interactive option was added to allow more secure
password entry, but it doesn't cover the automated case as mentioned in
the above issue.

This change implements the suggestion included in #200 to accept
passwords via environment variables to allow secure entry in a
non-interactive setting.  The CLI now gets the values for password
fields like so:

* If a password was given on the command line, use it
* If not, is an environment variable is set for the field, use its value
* If not, prompt for a password

This preserves backwards-compatible behavior while allowing the
environment to be considered.

The CLI will expect environment variables to match the CLI's argument
name, all uppercase, prefixed with `LINODE_CLI_` - for example, the
`--root_pass` argument to `linodes create` will look for
`LINODE_CLI_ROOT_PASS` in the environment.