### PR TITLE
Handle Prefixes in Obj Plugin

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -77,7 +77,9 @@ def list_objects_or_buckets(get_client, args):
 
     parser.add_argument('bucket', metavar='NAME', type=str, nargs='?',
                         help="Optional.  If not given, lists all buckets.  If given, "
-                             "lists the contents of the given bucket.")
+                             "lists the contents of the given bucket.  May contain a "
+                             "/ followed by a directory path to show the contents of "
+                             "a directory within the named bucket.")
 
     parsed = parser.parse_args(args)
     client = get_client()


### PR DESCRIPTION
CC @phillc 

Previously, the obj plugin skipped objects with `/` in their names,
which is a somewhat perplexing choice I'd made when originally
implementing it.  This change brings the behavior more inline with s3cmd -
objects are listed with `/` as a delimiter, and prefixes can be
specified after the bucket name.  For instance:

```
$ linode-cli obj ls prefix-test
                  DIR  prefix/
2020-08-11 17:50  8    testfile3
$ linode-cli obj ls prefix-test/prefix/
2020-08-11 17:50  4  prefix/testfile
2020-08-11 17:50  5  prefix/testfile2
```