### PR TITLE
Accept StackScript scripts from file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,17 +365,17 @@ added to Linode's OpenAPI spec:
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-action  | method   | The action name for operations under this path. If not present, operationId is used.      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-command | path     | The command name for operations under this path. If not present, "default" is used.       |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-color   | property | If present, defines key-value pairs of property value: color.  Colors must be understood  |
 |                     |          | by colorclass.Color.  Must include a default.                                             |
++---------------------+----------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-command | path     | The command name for operations under this path. If not present, "default" is used.       |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
 |                     |          | (left to right).                                                                          |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid value is `file`.   |
++---------------------+----------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/README.rst
+++ b/README.rst
@@ -375,5 +375,7 @@ added to Linode's OpenAPI spec:
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid value is `file`.   |
++---------------------+----------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/README.rst
+++ b/README.rst
@@ -363,17 +363,17 @@ added to Linode's OpenAPI spec:
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |Attribute            | Location | Purpose                                                                                   |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
-|                     |          | (left to right).                                                                          |
+|x-linode-cli-action  | method   | The action name for operations under this path. If not present, operationId is used.      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-command | path     | The command name for operations under this path. If not present, "default" is used.       |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-action  | method   | The action name for operations under this path. If not present, operationId is used.      |
+|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-color   | property | If present, defines key-value pairs of property value: color.  Colors must be understood  |
 |                     |          | by colorclass.Color.  Must include a default.                                             |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
+|x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
+|                     |          | (left to right).                                                                          |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid value is `file`.   |
 +---------------------+----------+-------------------------------------------------------------------------------------------+

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -103,8 +103,9 @@ class CLI:
                 "type": info.get('type') or 'string',
                 "desc": info.get('description') or '',
                 "name": arg,
-                "format": info.get('format', None),
+                "format": info.get('x-linode-cli-format', info.get('format', None)),
             }
+
             # handle input lists
             if args[path]['type'] == 'array' and 'items' in info:
                 items = info['items']

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -179,7 +179,7 @@ class CLIOperation:
                     if arg.arg_type == 'string' and arg.arg_format == 'password':
                         # special case - password input
                         parser.add_argument('--'+arg.path, nargs='?', action=PasswordPromptAction)
-                    elif arg.arg_type == 'string' and arg.arg_format in ('ssl-cert','ssl-key'):
+                    elif arg.arg_type == 'string' and arg.arg_format in ('file','ssl-cert','ssl-key'):
                         parser.add_argument('--'+arg.path, metavar=arg.name,
                                             action=OptionalFromFileAction,
                                             type=TYPES[arg.arg_type])


### PR DESCRIPTION
Closes #201

Previously, only "ssl-cert" and "ssl-key" formatted fields were
accepted as file paths (and then only if the input looked like a path
and a file existed at it); this change brings that behavior over to
other fields.  The linked docs PR below ties this into the StackScript
"script" field, but it can be used with any field now using a new spec
extension: `x-linode-cli-format`.  As per the included documentation in
this PR, the only valid value is "file" at present; the intention is
that this overrides the "format" given in the OpenAPI spec, but only in
the CLI, and only if present.  Any field with this format will inherit
the above-described path-checking behavior.

I also sorted the spec extension in the README, because they were all out of sorts.