### PR TITLE
Accept nested lists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,8 @@ added to Linode's OpenAPI spec:
 |x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
 |                     |          | (left to right).                                                                          |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid value is `file`.   |
+|x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid values are `file`  |
+|                     |          | and `json`.                                                                               |
 +---------------------+----------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
 +---------------------+----------+-------------------------------------------------------------------------------------------+

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -106,6 +106,11 @@ class CLI:
                 "format": info.get('x-linode-cli-format', info.get('format', None)),
             }
 
+            # if this is coming in as json, stop here
+            if args[path]["format"] == "json":
+                args[path]["type"] = "object"
+                continue
+
             # handle input lists
             if args[path]['type'] == 'array' and 'items' in info:
                 items = info['items']

--- a/test/clean-accounts.sh
+++ b/test/clean-accounts.sh
@@ -7,7 +7,7 @@ export LINODE_CLI_TOKEN=$1
 CLEAN_TARGETS=( linodes volumes domains nodebalancers stackscripts images lke)
 
 for i in "${CLEAN_TARGETS[@]}"; do
-    local deleteCmd="delete"
+    deleteCmd="delete"
 
     if [ "${i}" = "stackscripts" ] || [ "${i}" = "images" ]; then
         ENTITIES=( $(linode-cli "${i}" list --is_public false --text --no-headers --format "id" --delimiter " ") )

--- a/test/clean-accounts.sh
+++ b/test/clean-accounts.sh
@@ -4,20 +4,25 @@ set -e
 
 export LINODE_CLI_TOKEN=$1
 
-CLEAN_TARGETS=( linodes volumes domains nodebalancers stackscripts images)
+CLEAN_TARGETS=( linodes volumes domains nodebalancers stackscripts images lke)
 
 for i in "${CLEAN_TARGETS[@]}"; do
-    ENTITIES=( $(linode-cli "${i}" list --text --no-headers --format "id" --delimiter " ") )
+    local deleteCmd="delete"
 
     if [ "${i}" = "stackscripts" ] || [ "${i}" = "images" ]; then
         ENTITIES=( $(linode-cli "${i}" list --is_public false --text --no-headers --format "id" --delimiter " ") )
+    elif [ "${i}" == "lke" ]; then
+        ENTITIES=( $(linode-cli "${i}" clusters-list --text --no-headers --format "id" --delimiter " ") )
+        deleteCmd="cluster-delete"
+    else
+        ENTITIES=( $(linode-cli "${i}" list --text --no-headers --format "id" --delimiter " ") )
     fi
 
     declare ENTITIES
 
     if [ ${#ENTITIES[@]}  != "0" ]; then
         for id in "${ENTITIES[@]}"; do
-            linode-cli "${i}" delete "${id}"
+            linode-cli "${i}" "${deleteCmd}" "${id}"
         done
     fi
 done

--- a/test/common.bash
+++ b/test/common.bash
@@ -83,6 +83,15 @@ removeVolumes() {
     done
 }
 
+removeLkeClusters() {
+    local cluster_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers lke clusters-list | awk '{ print $1 }' | xargs) )"
+    local id
+
+    for id in $cluster_ids ; do
+        run bash -c "LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli lke cluster-delete $id"
+    done
+}
+
 removeAll() {
     if [ "$1" = "stackscripts" ]; then
         entity_ids="( $(linode-cli $1 list --is_public=false --text --no-headers --format="id" | xargs) )"

--- a/test/lke/clusters.bats
+++ b/test/lke/clusters.bats
@@ -37,7 +37,6 @@ teardown() {
     assert_output --regexp "cli-test-1,us-east,1.16"
 }
 
-
 @test "it should remove all lke clusters" {
     LAST_TEST="TRUE"
 

--- a/test/lke/clusters.bats
+++ b/test/lke/clusters.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+##################################################################
+#  WARNING: THIS TEST WILL DELETE ALL OF YOUR LKE CLUSTERS       #
+#  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+##################################################################
+
+setup() {
+    suiteName="lke-clusters"
+    setToken "$suiteName"
+}
+
+teardown() {
+    if [ "$LAST_TEST" = "TRUE" ]; then
+        clearToken "$suiteName"
+    fi
+}
+
+@test "it should deploy an lke cluster" {
+    run linode-cli lke cluster-create \
+        --region us-east \
+        --label cli-test-1 \
+        --node_pools.type g6-nanode-1 \
+        --node_pools.count 1 \
+        --node_pools.disks '[{"type":"ext4","size":1024}]' \
+        --k8s_version 1.16 \
+        --text \
+        --delimiter "," \
+        --no-headers \
+        --format 'label,region,k8s_version' \
+        --no-defaults
+
+    assert_output --regexp "cli-test-1,us-east,1.16"
+}
+
+
+@test "it should remove all lke clusters" {
+    LAST_TEST="TRUE"
+
+    run removeLkeClusters
+}


### PR DESCRIPTION
The `lke cluster-create` command is unique in the CLI in that it accepts
a list of dicts whose contents may themselves contain a list.  The CLI
didn't have a good way of disambiguating which element of the outer list
you intended inner list elements to belong to.  This made using the
endpoint impossible.

This change allows the spec to specify that an attribute is accepted as
JSON using the `x-linode-cli-format` extension; if the format is set to
"json" this way, the CLI will stop parsing sub-objects or list items and
accept the entire blob as JSON.  This fixes the above issue with the
below-linked docs PR merged.