### PR TITLE
Change LKE tests to deploy g6-standard-1 nodes

### DIFF
--- a/test/lke/clusters.bats
+++ b/test/lke/clusters.bats
@@ -24,7 +24,7 @@ teardown() {
     run linode-cli lke cluster-create \
         --region us-east \
         --label cli-test-1 \
-        --node_pools.type g6-nanode-1 \
+        --node_pools.type g6-standard-1 \
         --node_pools.count 1 \
         --node_pools.disks '[{"type":"ext4","size":1024}]' \
         --k8s_version 1.16 \


### PR DESCRIPTION
Running the tests this morning, we got this failure:

> node_pools[0].type,The Linode type g6-nanode-1 is currently not supported by LKE

That must be new, as these have passed before.  Anyway, g6-standard-1
should work, so we're using that now.