### PR TITLE
Don't send empty lists in requests

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -83,11 +83,14 @@ class CLI:
 
         return tmp
 
-    def _parse_args(self, node, prefix=[], args={}):
+    def _parse_args(self, node, prefix=[], args=None):
         """
         Given a node in a requestBody, parses out the properties and returns the
         CLIArg info
         """
+        if args is None:
+            args = {}
+
         for arg, info in node.items():
             if 'allOf' in info:
                 info = self._resolve_allOf(info['allOf'])

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -203,6 +203,15 @@ class CLIOperation:
                     for obj, item in zip(update_list, val):
                         obj[item_name] = item
 
+        # don't send along empty lists
+        to_delete = []
+        for k, v in lists.items():
+            if len(v) == 0:
+                to_delete.append(k)
+
+        for c in to_delete:
+            del lists[c]
+
         if lists:
             parsed = vars(parsed)
             parsed.update(lists)


### PR DESCRIPTION
This was pointed out by @adammohammed

This impacts the `object-storage keys-create` operation, and by
extension the `obj` plugin for new users.

This behavior didn't matter before now, which is probably why it went
unnoticed.  The new `bucket_access` argument to `POST /object-storage/keys`
does behave differently when given an empty list, however, and sending
it along caused the generated keys to have no access to anything.