### PR TITLE
Updated OpenAPI spec URL for new docs site launch

### DIFF
--- a/Dockerfile-bats
+++ b/Dockerfile-bats
@@ -34,7 +34,7 @@ RUN sed -i="" "s/data=body/data=body,verify=False/" /src/linode-cli/linodecli/cl
 # Override the base url in the openapi spec to the build argument
 ARG API_OVERRIDE=api.linode.com
 # Override the Spec url
-ARG SPEC=https://developers.linode.com/api/docs/v4/openapi.yaml
+ARG SPEC=https://www.linode.com/docs/api/openapi.yaml
 
 # Fetch the openapi spec, build and install the Linode CLI
 RUN curl --cacert ./cacert.pem -o ./openapi.yaml "${SPEC}" \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 PYTHON ?= 3
-SPEC ?= https://developers.linode.com/api/docs/v4/openapi.yaml
+SPEC ?= https://www.linode.com/docs/api/openapi.yaml
 
 ifeq ($(PYTHON), 3)
 	PYCMD=python3

--- a/README.rst
+++ b/README.rst
@@ -338,7 +338,7 @@ Running the tests is simple. The only requirements are that you have a .linode-c
 
 The openapi spec must first be saved to the base of the linode-cli project:
 
-   curl -o ./openapi.yaml https://developers.linode.com/api/docs/v4/openapi.yaml
+   curl -o ./openapi.yaml https://www.linode.com/docs/api/openapi.yaml
 
 Run the following command to build the tests container:
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -308,7 +308,7 @@ def main():
 
         print()
         print("To reconfigure, call `linode-cli configure`")
-        print("For comprehensive documentation, visit https://developers.linode.com")
+        print("For comprehensive documentation, visit https://www.linode.com/docs/api/openapi.yaml")
         exit(0)
 
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -308,7 +308,7 @@ def main():
 
         print()
         print("To reconfigure, call `linode-cli configure`")
-        print("For comprehensive documentation, visit https://www.linode.com/docs/api/openapi.yaml")
+        print("For comprehensive documentation, visit https://www.linode.com/docs/api/")
         exit(0)
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=long_description,
     author="Linode",
     author_email='developers@linode.com',
-    url="https://www.linode.com/docs/api/openapi.yaml",
+    url="https://www.linode.com/docs/api/",
     packages=[
         'linodecli',
         'linodecli.plugins',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=long_description,
     author="Linode",
     author_email='developers@linode.com',
-    url="https://developers.linode.com/api/v4",
+    url="https://www.linode.com/docs/api/openapi.yaml",
     packages=[
         'linodecli',
         'linodecli.plugins',


### PR DESCRIPTION
@Dorthu I did a find/replace for any instances of what will be the old URL for the OpenAPI spec and updated them to the new location. 