### PR TITLE
Changed requirements so that enum34 is only installed on python3.3 an…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ terminaltables
 colorclass
 requests
 PyYAML
-enum34
+enum34; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ setup(
         'linodecli.plugins',
     ],
     license="BSD 3-Clause License",
-    install_requires=["terminaltables","colorclass","requests","PyYAML","enum34"],
+    install_requires=["terminaltables","colorclass","requests","PyYAML"],
+    extras_require={
+        ":python_version<'3.4'": ['enum34'],
+    },
     entry_points={
         "console_scripts": [
             "linode-cli = linodecli:main",


### PR DESCRIPTION
…d earlier

- as recommended by cmorgenstern in https://github.com/linode/linode-cli/issues/29#issuecomment-476027354

Current dependency on enum34 breaks virtualenvs and (according to thee comments on the above issue) linux packaging for recent python versions.