### PR TITLE
Run --help without a config in CLI and obj plugin

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -26,7 +26,7 @@ except:
 BASE_URL = 'https://api.linode.com/v4'
 
 
-cli = CLI(VERSION, BASE_URL, skip_config='--skip-config' in argv)
+cli = CLI(VERSION, BASE_URL, skip_config=('--skip-config' in argv or '--help' in argv))
 
 def main():
     ## Command Handling

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -271,10 +271,10 @@ class CLIConfig:
 initial setup.""")
 
         if ENV_TOKEN_NAME in os.environ:
-            print("""Using token from LINODE_TOKEN.
+            print("""Using token from {env_token_name}.
 Note that no token will be saved in your configuration file.
-    * If you lose or remove LINODE_TOKEN, Linode CLI will stop working.
-    * All profiles will use LINODE_TOKEN.""")
+    * If you lose or remove {env_token_name}.
+    * All profiles will use {env_token_name}.""".format(env_token_name=ENV_TOKEN_NAME))
             username = 'DEFAULT'
 
         else:

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -785,6 +785,21 @@ def _get_s3_creds(client, force=False):
     if force or access_key is None:
         # this means there are no stored s3 creds for this user - set them up
 
+        # but first - is there actually a config?  If we got this far, creds aren't
+        # being provided by the environment, but if the CLI is running without a
+        # config, we shouldn't generate new keys (or we'd end up doing so with each
+        # request) - instead ask for them to be set up.
+        if client.config.get_value("token") is None:
+            print(
+                "You are running the Linode CLI without a configuration file, but "
+                "object storage keys were not configured.  Please set the following "
+                "variables in your environment: '{}' and '{}'.  If you'd rather ".format(
+                    ENV_ACCESS_KEY_NAME, ENV_SECRET_KEY_NAME
+                )+"configure the CLI, run `linode-cli configure` or unset the "
+                "'LINODE_CLI_TOKEN' environment variable."
+            )
+            exit(1)
+
         # before we do anything, can they do object storage?
         status, resp = client.call_operation('account', 'view')
 

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -683,13 +683,14 @@ def call(args, context):
         os.environ.get(ENV_SECRET_KEY_NAME, None),
     )
 
-    if access_key and not secret_key or secret_key and not access_key:
-        print("You must set both {} and {}, or neither".format(ENV_ACCESS_KEY_NAME, ENV_SECRET_KEY_NAME))
-        exit(1)
+    if not "--help" in args:
+        if access_key and not secret_key or secret_key and not access_key:
+            print("You must set both {} and {}, or neither".format(ENV_ACCESS_KEY_NAME, ENV_SECRET_KEY_NAME))
+            exit(1)
 
-    # not given on command line, so look them up
-    if not access_key:
-        access_key, secret_key = _get_s3_creds(context.client)
+        # not given on command line, so look them up
+        if not access_key:
+            access_key, secret_key = _get_s3_creds(context.client)
 
     cluster = parsed.cluster
     if context.client.defaults:
@@ -707,7 +708,8 @@ def call(args, context):
             exit(1)
 
         if current_cluster is None:
-            print("Error: No default cluster is configured.")
+            print("Error: No default cluster is configured.  Either configure the CLI "
+                  "or invoke with --cluster to specify a cluster.")
             _configure_plugin(context.client)
             current_cluster = context.client.config.plugin_get_value('cluster')
 


### PR DESCRIPTION
Closes #214

Previously, the CLI Configuration was initialized expecting to load a
config even if `--help` was passed in, which is unintuitive behavior
because the config will prompt for configuration immediately if a file
isn't found.  This was further complicated by the `obj` plugin, which
manages its own configuration and would fail if the CLI wasn't
configured when it was invoked, even with only a `--help` command.

This change is intended to make unconfigured user of the CLI easier by:

 - Allowing `--help` commands to run without configuration
 - Allowing the `obj` plugin to run `--help` commands without
   configuration
 - Providing better errors in the `obj` plugin, namely around cluster,
   to allow users without a config to easily identify and remedy common
   issues.

This should be tested thoroughly, as it touches some fundamental parts
of the CLI's behavior; namely, you should verify that:

 - Configured use works as it does today
 - Calling with `--skip-config` and `--no-defaults` behaves as expected
 - Using environment variables for tokens and obj keys works as expected
 - Incorrectly setup environments for the above produce useful errors