### PR TITLE
Added linode-cli completion command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,17 @@ in addition to its normal output.  If these warnings can interfere with your
 scripts or you otherwise want them disabled, simply add the ``--suppress-warnings``
 flag to prevent them from being emitted.
 
+Shell Completion
+""""""""""""""""
+
+To generate a completion file for a given shell type, use the ``completion`` command;
+for example to generate completions for bash run::
+
+   linode-cli completion bash
+
+The output of this command is suitable to be included in the relevant completion
+files to enable command completion on your shell.
+
 Environment Variables
 """""""""""""""""""""
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -253,6 +253,23 @@ def main():
         print("Plugin {} removed".format(plugin_name))
         exit(0)
 
+    if parsed.command == "completion":
+        if parsed.help or not parsed.action:
+            print("linode-cli completion [SHELL]")
+            print()
+            print("Prints shell completions for the requested shell to stdout. "
+                  "Currently, only completions for bash are available.")
+            exit(0)
+        if parsed.action == "bash":
+            # generate and print completions, then exit
+            completions = cli.get_completions()
+            print(completions)
+            exit(0)
+        else:
+            print("Completions are only available for bash at this time.  To retrieve "
+                  "these, please invoke as `linode-cli completion bash`.")
+            exit(1)
+
     # handle a help for the CLI
     if parsed.command is None or (parsed.command is None and  parsed.help):
         parser.print_help()
@@ -271,6 +288,14 @@ def main():
         pm_commands = [['register-plugin', 'remove-plugin']]
         table = SingleTable(pm_commands)
         table.inner_heading_row_border = False
+        print(table.table)
+
+        # other CLI commands
+        print()
+        print('Other CLI commands:')
+        other_commands = [['completion']]
+        table = SingleTable(other_commands)
+        table.inner_heading_row_border=False
         print(table.table)
 
         # commands generated from the spec (call the API directly)

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -297,9 +297,9 @@ class CLI:
         with open(data_file, 'wb') as f:
             pickle.dump(self.ops, f)
 
-    def bake_completions(self):
+    def get_completions(self):
         """
-        Given a baked CLI, generates and saves a bash completion file
+        Generates and returns shell completions based on the baked spec
         """
         completion_template=Template("""# This is a generated file!  Do not modify!
 _linode_cli()
@@ -330,7 +330,13 @@ complete -F _linode_cli linode-cli""")
         command_blocks = [command_template.safe_substitute(command=op, actions=" ".join([act for act in actions.keys()])) for op, actions in self.ops.items()]
         rendered = completion_template.safe_substitute(actions=" ".join(self.ops.keys()),
                                                        command_items="\n        ".join(command_blocks))
+        return rendered
 
+    def bake_completions(self):
+        """
+        Given a baked CLI, generates and saves a bash completion file
+        """
+        rendered = self.get_completions()
         # save it off
         with open('linode-cli.sh', 'w') as f:
             print("Writing file...")


### PR DESCRIPTION
Closes #194

This command prints shell completions for the requested shell to stdout
and exits.  Presently, only bash is supported, but adding support for
other shells should be simple.