### PR TITLE
Move to openapi3 for Linode CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,23 +360,27 @@ Specification Extensions
 In order to be more useful, the following `Specification Extensions`_ have been
 added to Linode's OpenAPI spec:
 
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|Attribute            | Location | Purpose                                                                                   |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-action  | method   | The action name for operations under this path. If not present, operationId is used.      |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-color   | property | If present, defines key-value pairs of property value: color.  Colors must be understood  |
-|                     |          | by colorclass.Color.  Must include a default.                                             |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-command | path     | The command name for operations under this path. If not present, "default" is used.       |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
-|                     |          | (left to right).                                                                          |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid values are `file`  |
-|                     |          | and `json`.                                                                               |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|Attribute               | Location   | Purpose                                                                                   |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-action     | method     | The action name for operations under this path. If not present, operationId is used.      |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-color      | property   | If present, defines key-value pairs of property value: color.  Colors must be understood  |
+|                        |            | by colorclass.Color.  Must include a default.                                             |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-command    | path       | The command name for operations under this path. If not present, "default" is used.       |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-display    | property   | If truthy, displays this as a column in output.  If a number, determines the ordering     |
+|                        |            | (left to right).                                                                          |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-format     | property   | Overrides the "format" given in this property for the CLI only.  Valid values are `file`  |
+|                        |            | and `json`.                                                                               |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-skip       | path       | If present and truthy, this method will not be available in the CLI.                      |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-use-schema | media type | TODO                                                                                      |
++------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-rows       | ???        | TODO                                                                                      |
++------------------------+------------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/README.rst
+++ b/README.rst
@@ -382,5 +382,7 @@ added to Linode's OpenAPI spec:
 +------------------------+------------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-rows       | ???        | TODO                                                                                      |
 +------------------------+------------+-------------------------------------------------------------------------------------------+
+|x-linode-filterable     | schema     | If this field may be filtered on in paginated requests.                                   |
++------------------------+------------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/linodecli/baked/__init__.py
+++ b/linodecli/baked/__init__.py
@@ -1,0 +1,1 @@
+from .operation import OpenAPIOperation

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -86,7 +86,7 @@ class OpenAPIOperation:
                 )
         elif method in ('get',):
             # for get requests, self.request is all filterable fields of the response model
-            if self.response_model:
+            if self.response_model and self.response_model.is_paginated:
                 self.request = OpenAPIFilteringRequest(self.response_model)
 
     @property

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -1,0 +1,164 @@
+def _is_paginated(response):
+    """
+    Returns True if this operation has a paginated response
+
+    :param response: The response we're checking
+    :type response: openapi3.Response
+    """
+    return (
+        response.schema.properties is not None and
+        len(response.schema.properties) == 4 and
+        all([c in response.schema.properties for c in ('pages', 'page', 'results', 'data')])
+    )
+
+
+class OpenAPIOperation:
+    """
+    A wrapper class for information parsed from the OpenAPI spec for a single operation.
+    This is the class that should be pickled when building the CLI.
+    """
+    def __init__(self, operation, method):
+        """
+        Wraps an openapi3.Operation object and handles pulling out values relevant
+        to the Linode CLI.
+
+        .. note::
+           This function runs _before pickling!  As such, this is the only place
+           where the OpenAPI3 objects can be accessed safely (as they are not
+           usable when unpickled!)
+        """
+        #: The method to use when invoking this operation
+        self.method = method
+
+        server = operation.servers[0].url if operation.servers else operation._root.servers[0].url
+        #: The URL to call to invoke this operation
+        self.url = server + operation.path[-2]
+
+        #: This operation's summary for the help screen
+        self.summary = operation.summary
+        #: This operation's long description for the help screen
+        self.description = operation.description.split(".")[0]
+
+        #: The responses this operation understands
+        self.responses = {}
+
+        #TODO - add these
+        #self.args = args
+        #self.params = params
+
+        #for code, data in operation.responses.items():
+        #    if "application/json" in data.content:
+        #        self.responses[code] = OpenAPIResponse(data.content['application/json'])
+        #    else:
+        #        print(
+        #            "WARNING: Operation {} {} has invalid response for code {} (only accepts application/json)".format(
+        #                self.method,
+        #                self.url,
+        #                code,
+        #        ))
+
+
+        #self.response_model = self.responses['200'] if '200' in self.responses else None
+
+        self.response_model = None
+
+        if '200' in operation.responses and 'application/json' in operation.responses['200'].content:
+            self.response_model = OpenAPIResponse(operation.responses['200'].content['application/json'])
+
+
+class OpenAPIResponseAttr:
+    """
+    Represents a single attribute of an API response as defined by the OpenAPI spec.
+    This class is given the schema node from the spec and parses out its own information
+    from it.
+    """
+    def __init__(self, name, schema, prefix=None):
+        """
+        :param name: The key that held this schema in the properties list, representing
+                     its name in a response.
+        :type name: str
+        :param schema: The schema this attribute will represent
+        :type schema: openapi3.Schema
+        :param prefix: The json path style prefix (dot notation) to this schema
+                       in the response object
+        :type prefix: str
+        """
+        #: The name of this attribute, which is the full json path to it within the schema
+        self.name = name if prefix is None else prefix + "." + name
+
+        #: TODO: Not sure what this is for
+        self.value = None
+
+        #: If this attribute is filterable in GET requests
+        self.filterable = schema.extensions.get("x-linode-filterable")
+
+        #: If this attribute should be displayed by default, and where in the output table
+        #: it should be displayed
+        self.display = schema.extensions.get("x-linode-cli-display")
+
+        #: The name of the column header for this attribute.  This is the schema's name
+        #: without the full path to it
+        self.column_name = name
+
+        #: The type of data this attribute contains
+        self.datatype = schema.type
+
+        #: How we should associate values of this attribute to output colors
+        self.color_map = schema.extensions.get("x-linode-cli-color")
+
+        #: The type for items in this attribute, if this attribute is a list
+        self.item_type = None
+        if schema.type == "array":
+            print("My name is {} and my path is {}".format(name, schema.path))
+            self.item_type = schema.items.type
+
+
+def _parse_response_model(schema, prefix=None):
+    """
+    Recursively parses all properties of this schema to create a flattened set of
+    OpenAPIResponseAttr objects that allow the CLI to display this response in a
+    terminal.
+
+    :param schema: The schema to parse.  Every item in this schemas properties will
+                   become a new OpenAPIResponseAttr instance, and this process is
+                   recursive to include the properties of properties and so on.
+    :type schema: openapi3.Schema
+
+    :returns: The list of parsed OpenAPIResponseAttr objects representing this schema
+    :rtype: List[OpenAPIResponseAttr]
+    """
+    attrs = []
+
+    if schema.properties is not None:
+        print("Lookiung at {}".format(schema))
+        print("It is of type {}".format(type(schema)))
+        print("It has path {}".format(schema.path))
+        for k, v in schema.properties.items():
+            if v.type == "object":
+                prefix = prefix + "." + k if prefix else k
+                attrs += _parse_response_model(v, prefix=prefix)
+            else:
+                print("making model for {} {}".format(k, v))
+                attrs.append(
+                    OpenAPIResponseAttr(k, v, prefix=prefix)
+                )
+
+    return attrs
+
+
+class OpenAPIResponse:
+    def __init__(self, response):
+        """
+        :param response: The response's MediaType object in the OpenAPI spec,
+                          corresponding to the application/json response type
+        :type response: openapi3.MediaType
+        """
+        self.is_paginated = _is_paginated(response)
+
+        schema_override = response.extensions.get("x-linode-cli-use-schema")
+        if schema_override:
+            self.attrs = _parse_response_model(schema_override)
+        else:
+            self.attrs = _parse_response_model(response.schema)
+        self.rows = response.schema.extensions.get("x-linode-cli-rows")
+        self.nested_list = response.extensions.get("x-linode-cli-nested-list")

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -1,15 +1,18 @@
-def _is_paginated(response):
-    """
-    Returns True if this operation has a paginated response
+from linodecli.baked.response import OpenAPIResponse
+from linodecli.baked.request import OpenAPIRequest
 
-    :param response: The response we're checking
-    :type response: openapi3.Response
+
+class OpenAPIOperationParameter:
     """
-    return (
-        response.schema.properties is not None and
-        len(response.schema.properties) == 4 and
-        all([c in response.schema.properties for c in ('pages', 'page', 'results', 'data')])
-    )
+    A parameter is a variable element of the URL path, generally an ID or slug
+    """
+    def __init__(self, parameter):
+        """
+        :param parameter: The Parameter object this is parsing values from
+        :type parameter: openapi3.Parameter
+        """
+        self.name = parameter.name
+        self.type = parameter.schema.type
 
 
 class OpenAPIOperation:
@@ -17,7 +20,7 @@ class OpenAPIOperation:
     A wrapper class for information parsed from the OpenAPI spec for a single operation.
     This is the class that should be pickled when building the CLI.
     """
-    def __init__(self, operation, method):
+    def __init__(self, operation, method, params):
         """
         Wraps an openapi3.Operation object and handles pulling out values relevant
         to the Linode CLI.
@@ -42,9 +45,22 @@ class OpenAPIOperation:
         #: The responses this operation understands
         self.responses = {}
 
-        #TODO - add these
-        #self.args = args
-        #self.params = params
+        self.request = None
+
+        if method in ('post', 'put') and operation.requestBody:
+            if 'application/json' in operation.requestBody.content:
+                self.request = OpenAPIRequest(operation.requestBody.content['application/json'])
+            else:
+                print(
+                    "WARNING: {} {} has no valid requestBody (must be application/json)!".format(
+                         self.method,
+                         self.url,
+                    )
+                )
+
+        self.params = [
+            OpenAPIOperationParameter(c) for c in params
+        ]
 
         #for code, data in operation.responses.items():
         #    if "application/json" in data.content:
@@ -65,100 +81,6 @@ class OpenAPIOperation:
         if '200' in operation.responses and 'application/json' in operation.responses['200'].content:
             self.response_model = OpenAPIResponse(operation.responses['200'].content['application/json'])
 
-
-class OpenAPIResponseAttr:
-    """
-    Represents a single attribute of an API response as defined by the OpenAPI spec.
-    This class is given the schema node from the spec and parses out its own information
-    from it.
-    """
-    def __init__(self, name, schema, prefix=None):
-        """
-        :param name: The key that held this schema in the properties list, representing
-                     its name in a response.
-        :type name: str
-        :param schema: The schema this attribute will represent
-        :type schema: openapi3.Schema
-        :param prefix: The json path style prefix (dot notation) to this schema
-                       in the response object
-        :type prefix: str
-        """
-        #: The name of this attribute, which is the full json path to it within the schema
-        self.name = name if prefix is None else prefix + "." + name
-
-        #: TODO: Not sure what this is for
-        self.value = None
-
-        #: If this attribute is filterable in GET requests
-        self.filterable = schema.extensions.get("x-linode-filterable")
-
-        #: If this attribute should be displayed by default, and where in the output table
-        #: it should be displayed
-        self.display = schema.extensions.get("x-linode-cli-display")
-
-        #: The name of the column header for this attribute.  This is the schema's name
-        #: without the full path to it
-        self.column_name = name
-
-        #: The type of data this attribute contains
-        self.datatype = schema.type
-
-        #: How we should associate values of this attribute to output colors
-        self.color_map = schema.extensions.get("x-linode-cli-color")
-
-        #: The type for items in this attribute, if this attribute is a list
-        self.item_type = None
-        if schema.type == "array":
-            print("My name is {} and my path is {}".format(name, schema.path))
-            self.item_type = schema.items.type
-
-
-def _parse_response_model(schema, prefix=None):
-    """
-    Recursively parses all properties of this schema to create a flattened set of
-    OpenAPIResponseAttr objects that allow the CLI to display this response in a
-    terminal.
-
-    :param schema: The schema to parse.  Every item in this schemas properties will
-                   become a new OpenAPIResponseAttr instance, and this process is
-                   recursive to include the properties of properties and so on.
-    :type schema: openapi3.Schema
-
-    :returns: The list of parsed OpenAPIResponseAttr objects representing this schema
-    :rtype: List[OpenAPIResponseAttr]
-    """
-    attrs = []
-
-    if schema.properties is not None:
-        print("Lookiung at {}".format(schema))
-        print("It is of type {}".format(type(schema)))
-        print("It has path {}".format(schema.path))
-        for k, v in schema.properties.items():
-            if v.type == "object":
-                prefix = prefix + "." + k if prefix else k
-                attrs += _parse_response_model(v, prefix=prefix)
-            else:
-                print("making model for {} {}".format(k, v))
-                attrs.append(
-                    OpenAPIResponseAttr(k, v, prefix=prefix)
-                )
-
-    return attrs
-
-
-class OpenAPIResponse:
-    def __init__(self, response):
-        """
-        :param response: The response's MediaType object in the OpenAPI spec,
-                          corresponding to the application/json response type
-        :type response: openapi3.MediaType
-        """
-        self.is_paginated = _is_paginated(response)
-
-        schema_override = response.extensions.get("x-linode-cli-use-schema")
-        if schema_override:
-            self.attrs = _parse_response_model(schema_override)
-        else:
-            self.attrs = _parse_response_model(response.schema)
-        self.rows = response.schema.extensions.get("x-linode-cli-rows")
-        self.nested_list = response.extensions.get("x-linode-cli-nested-list")
+    @property
+    def args(self):
+        return self.request.args if self.request else []

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -1,0 +1,93 @@
+class OpenAPIRequestArg:
+    """
+    A single argument to a request as defined by a Schema in the OpenAPI spec
+    """
+    def __init__(self, name, schema, prefix=None):
+        """
+        Parses a single Schema node into a argument the CLI can use when making
+        requests.
+
+        :param name: The name of this argument
+        :type name: str
+        :param schema: The schema we're parsing data from
+        :type schema: openapi3.Schema
+        :param prefix: The prefix for this arg's path, used in the actual argument
+                       to the CLI to ensure unique arg names
+        :type prefix: str
+        """
+        #: The name of this argument, mostly used for display and docs
+        self.name = name
+
+        #: The path for this argument, which is full json path for its place in
+        #: the larger response model
+        self.path = prefix + "." + name if prefix else name
+
+        #: The description of this argument, for help display
+        self.desc = schema.description
+
+        #: The format of data this argument accepts; typically ignored, but can be
+        #: either "json" to signal that we should not parse further spec here and just
+        #: accept arbitrary json, or "file" to signal to the CLI to attempt to resolve
+        #: the string passed in by the end user as a file path and send the entire file
+        self.format = schema.extensions.get("x-linode-cli-format") or schema.format or None
+
+        #: The type accepted for this argument. This will ultimately determine what
+        #: we accept in the ArgumentParser
+        self.type = "object" if self.format == "json" else schema.type
+
+        #: The type of item accepted in this list; if None, this is not a list
+        self.item_type = None
+
+        # handle the type for list values if this is an array
+        if self.type == "array" and schema.items:
+            self.item_type = schema.items.type
+
+        # make sure we're not doing something wrong
+        if self.item_type == "object":
+            raise ValueError(
+                "Invalid OpenAPIRequestArg creation; created arg for base object "
+                "instead of object's properties!  This is a programming error."
+            )
+
+
+def _parse_request_model(schema, prefix=None, list_of_objects=False):
+    """
+    Parses a schema into a list of OpenAPIRequest objects
+    """
+    args = []
+
+    if schema.properties is not None:
+        for k, v in schema.properties.items():
+            print("Looking at {} {}".format(k, v))
+            if v.type == "object":
+                # nested objects receive a prefix and are otherwise parsed normally
+                pref = prefix + "." + k if prefix else k
+                args += _parse_request_model(v, prefix=pref)
+            elif v.type == "array" and v.items and v.items.type == "object":
+                # handle lists of objects as a special case, where each property
+                # of the object in the list is its own argument
+                pref = prefix + "." + k if prefix else k
+                args += _parse_request_model(v.items, prefix=pref, list_of_objects=True)
+            else:
+                args.append(OpenAPIRequestArg(k, v, prefix=prefix))
+
+    return args
+
+
+class OpenAPIRequest:
+    """
+    This class represent the request object we send in to an API endpoint based
+    on the MediaType object of a requestBody portion of an OpenAPI Operation
+    """
+    def __init__(self, request):
+        """
+        :param request: The request's MediaType object in the OpenAPI spec,
+                        corresponding to the application/json data the endpoint
+                        accepts.
+        :type request: openapi3.MediaType
+        """
+        schema_override = request.extensions.get("x-linode-cli-use-schema")
+        if schema_override:
+            self.attrs = _parse_request_model(schema_override)
+        else:
+            self.attrs = _parse_request_model(request.schema)

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -38,13 +38,13 @@ class OpenAPIRequestArg:
 
         #: The type accepted for this argument. This will ultimately determine what
         #: we accept in the ArgumentParser
-        self.type = "object" if self.format == "json" else schema.type
+        self.datatype = "object" if self.format == "json" else schema.type or "string"
 
         #: The type of item accepted in this list; if None, this is not a list
         self.item_type = None
 
         # handle the type for list values if this is an array
-        if self.type == "array" and schema.items:
+        if self.datatype == "array" and schema.items:
             self.item_type = schema.items.type
 
         # make sure we're not doing something wrong

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -2,7 +2,7 @@ class OpenAPIRequestArg:
     """
     A single argument to a request as defined by a Schema in the OpenAPI spec
     """
-    def __init__(self, name, schema, prefix=None):
+    def __init__(self, name, schema, required, prefix=None):
         """
         Parses a single Schema node into a argument the CLI can use when making
         requests.
@@ -11,6 +11,8 @@ class OpenAPIRequestArg:
         :type name: str
         :param schema: The schema we're parsing data from
         :type schema: openapi3.Schema
+        :param required: If this argument is required by the schema
+        :type required: bool
         :param prefix: The prefix for this arg's path, used in the actual argument
                        to the CLI to ensure unique arg names
         :type prefix: str
@@ -23,7 +25,10 @@ class OpenAPIRequestArg:
         self.path = prefix + "." + name if prefix else name
 
         #: The description of this argument, for help display
-        self.desc = schema.description
+        self.description = schema.description.split(".")[0] if schema.description else ""
+
+        #: If this argument is required for requests
+        self.required = required
 
         #: The format of data this argument accepts; typically ignored, but can be
         #: either "json" to signal that we should not parse further spec here and just
@@ -53,6 +58,19 @@ class OpenAPIRequestArg:
 def _parse_request_model(schema, prefix=None, list_of_objects=False):
     """
     Parses a schema into a list of OpenAPIRequest objects
+
+    :param schema: The schema to parse as a request model
+    :type schema: openapi3.Schema
+    :param prefix: The prefix to add to all keys in this schema, as a json path
+    :type prefix: str
+    :param list_of_object: If true, this schema is the schema for items of a list.
+                           This is a complex case for the CLI, where lists of objects
+                           must be associated in a way that allows proper matching
+                           of inputs on the command line.
+    :type list_of_objects: bool
+
+    :returns: The flattened request model, as a list
+    :rtype: list[OpenAPIRequestArg]
     """
     args = []
 
@@ -69,7 +87,13 @@ def _parse_request_model(schema, prefix=None, list_of_objects=False):
                 pref = prefix + "." + k if prefix else k
                 args += _parse_request_model(v.items, prefix=pref, list_of_objects=True)
             else:
-                args.append(OpenAPIRequestArg(k, v, prefix=prefix))
+                # required fields are defined in the schema above the property, so
+                # we have to check here if required fields are defined/if this key
+                # is among them and pass it into the OpenAPIRequestArg class.
+                required = False
+                if schema.required:
+                    required = k in schema.required
+                args.append(OpenAPIRequestArg(k, v, required, prefix=prefix))
 
     return args
 
@@ -91,3 +115,52 @@ class OpenAPIRequest:
             self.attrs = _parse_request_model(schema_override)
         else:
             self.attrs = _parse_request_model(request.schema)
+
+
+def _parse_filterable_schema(schema):
+    """
+    Given a schema that may contain filterable elements, returns the filterable
+    elements as OpenAPIRequestArgs.
+
+    :param schema: The schema whose properties may be filterable
+    :type schema: openapi3.Schema
+
+    :returns: A list of filterable arguments found in the schema
+    :rtype: list[OpenAPIRequestArg]
+    """
+    # TODO - finish this!  It should recurse through the model to find all filterable
+    # TODO - elements and returns them as _parse_request_model does
+
+
+class OpenAPIFilteringRequest:
+    """
+    This class represents the X-Filter header we send for GET requests based on
+    the x-linode-filterable spec extension defined in the schema of the model
+    for 200 Response from an endpoint.  This only applies to paginated collection
+    endpoints where filters are accepted.
+    """
+    def __init__(self, schema):
+        """
+        :param schema: The schema of the 200 response for this operation.
+
+                       It is an error to send this any schema that does not
+                       represent a pagination envelope (i.e. has the properties
+                       "pages", "page", "results", and "data", where "data" is
+                       an array whose items attribute defines the schema we can
+                       filter by).
+        :type schema: openapi3.MediaType
+        """
+        # enforce the above requirements for parameters to this constructor
+        if (
+            len(schema.properties) != 4
+            or any([c not in schema.properties for c in ("pages","page","results","data")])
+            or schema.data.type != "array"
+        ):
+            raise ValueError(
+                "Non-paginated schema {} send to OpenAPIFilteringRequest constructor!".format(
+                    schema
+                )
+            )
+
+        # actually parse out what we can filter by
+        self.attrs = _parse_filterable_schema(schema.properties['data'].items)

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -1,0 +1,110 @@
+def _is_paginated(response):
+    """
+    Returns True if this operation has a paginated response
+
+    :param response: The response we're checking
+    :type response: openapi3.Response
+    """
+    return (
+        response.schema.properties is not None and
+        len(response.schema.properties) == 4 and
+        all([c in response.schema.properties for c in ('pages', 'page', 'results', 'data')])
+    )
+
+
+class OpenAPIResponseAttr:
+    """
+    Represents a single attribute of an API response as defined by the OpenAPI spec.
+    This class is given the schema node from the spec and parses out its own information
+    from it.
+    """
+    def __init__(self, name, schema, prefix=None):
+        """
+        :param name: The key that held this schema in the properties list, representing
+                     its name in a response.
+        :type name: str
+        :param schema: The schema this attribute will represent
+        :type schema: openapi3.Schema
+        :param prefix: The json path style prefix (dot notation) to this schema
+                       in the response object
+        :type prefix: str
+        """
+        #: The name of this attribute, which is the full json path to it within the schema
+        self.name = name if prefix is None else prefix + "." + name
+
+        #: TODO: Not sure what this is for
+        self.value = None
+
+        #: If this attribute is filterable in GET requests
+        self.filterable = schema.extensions.get("x-linode-filterable")
+
+        #: If this attribute should be displayed by default, and where in the output table
+        #: it should be displayed
+        self.display = schema.extensions.get("x-linode-cli-display")
+
+        #: The name of the column header for this attribute.  This is the schema's name
+        #: without the full path to it
+        self.column_name = name
+
+        #: The type of data this attribute contains
+        self.datatype = schema.type
+
+        #: How we should associate values of this attribute to output colors
+        self.color_map = schema.extensions.get("x-linode-cli-color")
+
+        #: The type for items in this attribute, if this attribute is a list
+        self.item_type = None
+        if schema.type == "array":
+            print("My name is {} and my path is {}".format(name, schema.path))
+            self.item_type = schema.items.type
+
+
+def _parse_response_model(schema, prefix=None):
+    """
+    Recursively parses all properties of this schema to create a flattened set of
+    OpenAPIResponseAttr objects that allow the CLI to display this response in a
+    terminal.
+
+    :param schema: The schema to parse.  Every item in this schemas properties will
+                   become a new OpenAPIResponseAttr instance, and this process is
+                   recursive to include the properties of properties and so on.
+    :type schema: openapi3.Schema
+
+    :returns: The list of parsed OpenAPIResponseAttr objects representing this schema
+    :rtype: List[OpenAPIResponseAttr]
+    """
+    attrs = []
+
+    if schema.properties is not None:
+        for k, v in schema.properties.items():
+            if v.type == "object":
+                prefix = prefix + "." + k if prefix else k
+                attrs += _parse_response_model(v, prefix=prefix)
+            else:
+                attrs.append(
+                    OpenAPIResponseAttr(k, v, prefix=prefix)
+                )
+
+    return attrs
+
+
+class OpenAPIResponse:
+    """
+    This object represents a single Response as defined by a MediaType in the
+    responses section of an OpenAPI Operation
+    """
+    def __init__(self, response):
+        """
+        :param response: The response's MediaType object in the OpenAPI spec,
+                          corresponding to the application/json response type
+        :type response: openapi3.MediaType
+        """
+        self.is_paginated = _is_paginated(response)
+
+        schema_override = response.extensions.get("x-linode-cli-use-schema")
+        if schema_override:
+            self.attrs = _parse_response_model(schema_override)
+        else:
+            self.attrs = _parse_response_model(response.schema)
+        self.rows = response.schema.extensions.get("x-linode-cli-rows")
+        self.nested_list = response.extensions.get("x-linode-cli-nested-list")

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -46,14 +46,14 @@ class OpenAPIResponseAttr:
 
         #: If this attribute should be displayed by default, and where in the output table
         #: it should be displayed
-        self.display = schema.extensions.get("linode-cli-display")
+        self.display = schema.extensions.get("linode-cli-display") or 0
 
         #: The name of the column header for this attribute.  This is the schema's name
         #: without the full path to it
         self.column_name = name
 
         #: The type of data this attribute contains
-        self.datatype = schema.type
+        self.datatype = schema.type or "string"
 
         #: How we should associate values of this attribute to output colors
         self.color_map = schema.extensions.get("linode-cli-color")

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -123,13 +123,7 @@ class CLI:
                     print("warning: no action or operationId for {} {}".format(m.upper(), path))
                     continue
 
-                #TODO: we're excluding some operations because the openapi3 library doesn't
-                #TODO: correctly resolve references nested in properties within an allOf
-                if path in (
-                    '/account/entity-transfers',
-                ):
-                    continue
-
+                # TODO: Remove debugging
                 print("Doing {} {}".format(m, path))
                 print("Operation is: {}".format(operation))
                 self.ops[command][action] = OpenAPIOperation(operation, m.upper())

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -123,10 +123,15 @@ class CLI:
                     print("warning: no action or operationId for {} {}".format(m.upper(), path))
                     continue
 
+                #TODO: There's a bug in the openapi3 library that causes some $refs
+                #TODO: nested in schema properties to not be resolved.
+                if path in ('/lke/clusters/{clusterId}/pools/{poolId}', ):
+                    continue
+
                 # TODO: Remove debugging
                 print("Doing {} {}".format(m, path))
                 print("Operation is: {}".format(operation))
-                self.ops[command][action] = OpenAPIOperation(operation, m.upper())
+                self.ops[command][action] = OpenAPIOperation(operation, m, pobj.parameters)
 
         # save these off - maybe not necessary?
         self.ops['_base_url'] = self.spec.servers[0].url

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -125,14 +125,8 @@ class CLI:
 
                 #TODO: we're excluding some operations because the openapi3 library doesn't
                 #TODO: correctly resolve references nested in properties within an allOf
-                #TODO:
-                #TODO: There's another bug impacting NodeBalancerConfig objects where allOfs
-                #TODO: modify the global referenced Schema, causing unexpected properties in
-                #TODO: other places that reference that Schema
                 if path in (
                     '/account/entity-transfers',
-                    '/nodebalancers/{nodeBalancerId}/configs/{configId}',
-                    '/nodebalancers/{nodeBalancerId}/configs',
                 ):
                     continue
 

--- a/linodecli/cmd/json.py
+++ b/linodecli/cmd/json.py
@@ -1,0 +1,14 @@
+def flatten_response(operation, response):
+    """
+    Given an operation and a response (JSON as a python dict) from that operation,
+    flattens the response into a table as per the parsed spec data.
+
+    :param operation: The Operation this request was made to
+    :type operation: linodecli.baked.OpenAPIOperation
+    :param response: The response from the API for the given operation
+    :type response: dict
+
+    :returns: The flattened response
+    :rtype: list[any]
+    """
+    return [] # TODO

--- a/linodecli/cmd/parser.py
+++ b/linodecli/cmd/parser.py
@@ -1,0 +1,170 @@
+import argparse
+
+
+def parse_boolean(value):
+    """
+    A helper to allow accepting booleans in from argparse.  This is intended to
+    be passed to the `type=` kwarg for ArgumentParser.add_argument.
+    """
+    if value.lower() in ('yes', 'true', 'y', '1'):
+        return True
+    if value.lower() in ('no', 'false', 'n', '0'):
+        return False
+    raise argparse.ArgumentTypeError('Expected a boolean value')
+
+
+def parse_dict(value):
+    """
+    A helper function to decode incoming JSON data as python dicts.  This is
+    intended to be passed to the `type=` kwarg for ArgumentParaser.add_argument.
+    """
+    if not isinstance(value, str):
+        raise argparse.ArgumentTypeError('Expected a JSON string')
+    try:
+        return json.loads(value)
+    except:
+        raise argparse.ArgumentTypeError('Expected a JSON string')
+
+
+class PasswordPromptAction(argparse.Action):
+    """
+    A special argparse Action to handle prompting for password.  Also accepts
+    passwords on the terminal to allow for backwards-compatible behavior.
+    """
+    def __init__(self, *args, **kwargs):
+        super(PasswordPromptAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # if not provided on the command line, pull from the environment if it
+        # exists at this key
+        environ_key = "LINODE_CLI_{}".format(self.dest.upper())
+
+        if values:
+            if isinstance(values, str):
+                password = values
+            else:
+                raise argparse.ArgumentTypeError('Expected a string (or leave blank for prompt)')
+        elif environ_key in environ:
+            password = environ.get(environ_key)
+        else:
+            prompt = 'Value for {}: '.format(self.dest)
+            password = getpass(prompt)
+        setattr(namespace, self.dest, password)
+
+
+class OptionalFromFileAction(argparse.Action):
+    """
+    A special action for handling loading a value from a file.  This will
+    attempt to load the value from a file if the value looks like a path and
+    the file exists, otherwise it will fall back to using the provided value.
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        if isinstance(values, str):
+            input_path = path.expanduser(values)
+            if path.exists(input_path) and path.isfile(input_path):
+                with open(input_path) as f:
+                    data = f.read()
+                setattr(namespace, self.dest, data)
+            else:
+                setattr(namespace, self.dest, values)
+        else:
+            raise argparse.ArgumentTypeError('Expected a string')
+
+
+#: TYPES is a mapping of OpenAPI type strings into python types
+TYPES = {
+    "string": str,
+    "integer": int,
+    "boolean": parse_boolean,
+    "array": list,
+    "object": parse_dict,
+    "number": float,
+}
+
+
+def parse_args(operation, args):
+    """
+    Given an operation and the sys.argv after the operation name, parse args
+    based on the params and args of the operation.
+    
+    :param operation: The operation we're parsing args for
+    :type operation: linodecli.baked.OpenAPIOperation
+    :param args: The args we're parsing; this is sys.argv after the command and action
+                 have been removed (which is necessary to find the operation).
+    :type args: list[str]
+    """
+    list_items = []
+
+    #  build an argparse
+    parser = argparse.ArgumentParser(description=operation.summary)
+    for param in operation.params:
+        parser.add_argument(param.name, metavar=param.name,
+                            type=TYPES[param.param_type])
+
+    if operation.method == "get":
+        # build args for filtering
+        for attr in operation.response_model.attrs:
+            if attr.filterable:
+                expected_type = TYPES[attr.datatype]
+                if expected_type == list:
+                    parser.add_argument('--'+attr.name, type=TYPES[attr.item_type],
+                                        metavar=attr.name, nargs='?')
+                else:
+                    parser.add_argument('--'+attr.name, type=expected_type, metavar=attr.name)
+
+    elif operation.method in ("post", "put"):
+        # build args for body JSON
+        for arg in operation.args:
+            if arg.arg_type == 'array':
+                # special handling for input arrays
+                parser.add_argument('--'+arg.path, metavar=arg.name,
+                                    action='append', type=TYPES[arg.arg_item_type])
+            elif arg.list_item is not None:
+                parser.add_argument('--'+arg.path, metavar=arg.name,
+                                    action='append', type=TYPES[arg.arg_type])
+                list_items.append((arg.path, arg.list_item))
+            else:
+                if arg.arg_type == 'string' and arg.arg_format == 'password':
+                    # special case - password input
+                    parser.add_argument('--'+arg.path, nargs='?', action=PasswordPromptAction)
+                elif arg.arg_type == 'string' and arg.arg_format in ('file','ssl-cert','ssl-key'):
+                    parser.add_argument('--'+arg.path, metavar=arg.name,
+                                        action=OptionalFromFileAction,
+                                        type=TYPES[arg.arg_type])
+                else:
+                    parser.add_argument('--'+arg.path, metavar=arg.name,
+                                        type=TYPES[arg.arg_type])
+
+    parsed = parser.parse_args(args)
+
+    lists = {}
+    # group list items as expected
+    for arg_name, list_name in list_items:
+        item_name = arg_name.split('.')[-1]
+        if hasattr(parsed, arg_name):
+            val = getattr(parsed, arg_name) or []
+            if  list_name not in lists:
+                new_list = [{item_name: c} for c in val]
+                lists[list_name] = new_list
+            else:
+                update_list = lists[list_name]
+                for obj, item in zip(update_list, val):
+                    obj[item_name] = item
+
+    # don't send along empty lists
+    to_delete = []
+    for k, v in lists.items():
+        if len(v) == 0:
+            to_delete.append(k)
+
+    for c in to_delete:
+        del lists[c]
+
+    if lists:
+        parsed = vars(parsed)
+        parsed.update(lists)
+        for name, _ in list_items:
+            del parsed[name]
+        parsed = argparse.Namespace(**parsed)
+
+    return parsed

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -128,17 +128,47 @@ class ResponseModel:
             return [json]
 
 
+
+
 class OpenAPIOperation:
+    """
+    A wrapper class for information parsed from the OpenAPI spec for a single operation.
+    This is the class that should be pickled when building the CLI.
+    """
     def __init__(self, operation, method):
         """
         Wraps an openapi3.Operation object and handles pulling out values relevant
-        to the Linode CLI
+        to the Linode CLI.
+
+        .. note::
+           This function runs _before pickling!  As such, this is the only place
+           where the OpenAPI3 objects can be accessed safely (as they are not
+           usable when unpickled!)
         """
-        self.operation = operation
-        print(self.operation)
-        print(self.operation._root)
+        #: The method to use when invoking this operation
         self.method = method
 
+        server = operation.servers[0].url if operation.servers else operation._root.servers[0].url
+        #: The URL to call to invoke this operation
+        self.url = server + operation.path[-2]
+
+        #: This operation's summary for the help screen
+        self.summary = operation.summary
+        #: This operation's long description for the help screen
+        self.description = operation.description.split(".")[0]
+
+        #: The responses this operation understands
+        self.responses = {}
+
+        for code, data in operation.responses.items():
+            if "application/json" in data.content:
+                self.responses[code] = OpenAPIResponse(data.content['application/json'])
+            else:
+                print("WARNING: Operation {} {} has invalid response for code {}".format(
+                    self.method,
+                    self.url,
+                    code,
+                ))
 
     def print_output(self, output_handler, response, response_status):
         """
@@ -153,21 +183,10 @@ class OpenAPIOperation:
 
         print("Response schema is {}".format(response_schema))
 
-    def _is_paginated(self, response):
+class OpenAPIResponse:
+    def __init__(self, response):
         """
-        Returns True if this operation has a paginate response
+        :param response: The Response object in the OpenAPI spec
+        :type response: openapi3.Response
         """
-        return (
-            len(self.response.properties) == 4 and
-            all([c in self.response.properties for c in ('pages', 'page', 'results', 'data')])
-        )
-
-    @property
-    def url(self):
-        """
-        Returns the URL for requests to this Operation
-        """
-        print(self.operation)
-        print(self.operation._root)
-        server = self.operation.servers[0].url if self.operation.servers else self.operation._root.servers[0].url
-        return  + self.path[-2]
+        self.is_paginated = _is_paginated(response)

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -126,3 +126,48 @@ class ResponseModel:
             return json['data']
         else:
             return [json]
+
+
+class OpenAPIOperation:
+    def __init__(self, operation, method):
+        """
+        Wraps an openapi3.Operation object and handles pulling out values relevant
+        to the Linode CLI
+        """
+        self.operation = operation
+        print(self.operation)
+        print(self.operation._root)
+        self.method = method
+
+
+    def print_output(self, output_handler, response, response_status):
+        """
+        Given a response for this operation, pulls out the data for it and prints
+        it using the given output handler
+        """
+        response = self.opertaion.responses[response_status].content['application/json']
+        response_schema = response.schema
+
+        if self._is_paginated(response):
+            response_schema = response.schema.properties['data'].items
+
+        print("Response schema is {}".format(response_schema))
+
+    def _is_paginated(self, response):
+        """
+        Returns True if this operation has a paginate response
+        """
+        return (
+            len(self.response.properties) == 4 and
+            all([c in self.response.properties for c in ('pages', 'page', 'results', 'data')])
+        )
+
+    @property
+    def url(self):
+        """
+        Returns the URL for requests to this Operation
+        """
+        print(self.operation)
+        print(self.operation._root)
+        server = self.operation.servers[0].url if self.operation.servers else self.operation._root.servers[0].url
+        return  + self.path[-2]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
     url="https://www.linode.com/docs/api/",
     packages=[
         'linodecli',
+        'linodecli.baked',
+        'linodecli.cmd',
         'linodecli.plugins',
     ],
     license="BSD 3-Clause License",


### PR DESCRIPTION
This is for us.

This requires:

- [x] Dorthu/openapi3#21
- [x] Dorthu/openapi3#24
- [x] Dorthu/openapi3#25
- [ ] https://github.com/Dorthu/openapi3/pull/52
- [ ] https://github.com/Dorthu/openapi3/pull/53

Currently, the Linode CLI uses an OpenAPI parser that was written to our
OpenAPI spec (at the time the CLI was written) and evolved slowly as
issues were found.  What's resulted is a very organic, free-range parser
that exists specifically for the Linode CLI and is rather difficult to
unwind and maintain.

This change removes the CLI's spec parser in favor of the [openapi3
python package](https://github.com/Dorthu/openapi3), which I wrote after
completing the CLI as a proper spec parser, in part to replace the one
in this project.  The openapi3 package [is already used to validate
Linode's OpenAPI specification during automated builds](https://github.com/linode/linode-api-docs/blob/9da259cbf7f50c3d26fec1f9a227337c6dc87068/.travis.yml#L6),
meaning that transitioning to this parser will ensure the doc's builds
never fall out of sync with the CLI's capabilities.

⚠️ This is a major change, and will require manual testing.

Additional considerations:

- [ ] Ensure all CLI-specific spec extensions are still supported
- [ ] Ensure all first-party plugins function as needed
- [ ] Adjust requirements for installation as necessary
- [ ] How large of a version bump should this be? (in theory it's only a
      refactor, but it also has a lot of potential to break things
      unintentionally).


Notes to self:

 - [ ] The error message behavior in https://github.com/linode/linode-cli/pull/274 should be ported to this branch