### PR TITLE
Fix configuration behavior

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -281,7 +281,7 @@ Note that no token will be saved in your configuration file.
             print("""
 First, we need a Personal Access Token.  To get one, please visit
 {} and click
-"Add a Personal Access Token".  The CLI needs access to everything
+"Create a Personal Access Token".  The CLI needs access to everything
 on your account to work correctly.""".format(TOKEN_GENERATION_URL))
 
             while True:
@@ -326,14 +326,15 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
             self.config.add_section(username)
 
         if not is_default:
-            while True:
-                value = input_helper('Make active user? [y/N]: ')
+            if username != self.default_username():
+                while True:
+                    value = input_helper('Make active user? [y/N]: ')
 
-                if value.lower() in 'yn':
-                    is_default = value.lower() == 'y'
-                    break
-                elif not value.strip():
-                    break
+                    if value.lower() in 'yn':
+                        is_default = value.lower() == 'y'
+                        break
+                    elif not value.strip():
+                        break
 
             if not is_default: # they didn't change the default user
                 print('Active user will remain {}'.format(self.config.get('DEFAULT', 'default-user')))


### PR DESCRIPTION
This was pointed out by @caker

When configuring multiple users, the CLI will prompt you to set the user
you're configuring as the active user, used by default when making
requests.  It also skips this question the first time you're configuring
the CLI.  However, confusingly, it still asks even if the user you're
configuring is already the active user, which happens if you only have
one user configured (and are updating their token).

This change removes the prompt to set the newly-configured user as
active if they are already the active user, and also matches the new
language in Cloud Manager for creating a token.
