### PR TITLE
OAuth-Based Configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include linodecli/data-2
 include linodecli/data-3
+include linodecli/oauth-landing-page.html
 include linode-cli.sh

--- a/README.rst
+++ b/README.rst
@@ -54,10 +54,10 @@ to invoke a specific action, use `--help` for that action::
 
    linode-cli linodes create --help
 
-The first time you invoke the CLI, you will be asked to configure it with a
-token, and optionally select some default values for "region," "image," and "type."
-If you configure these defaults, you may omit them as parameters to actions
-and the default value will be used.
+The first time you invoke the CLI, you will be asked to configure (see
+"Configuration" below for details), and optionally select some default values
+for "region," "image," and "type." If you configure these defaults, you may
+omit them as parameters to actions and the default value will be used.
 
 Common Operations
 ^^^^^^^^^^^^^^^^^
@@ -102,13 +102,26 @@ View your user::
 
    linode-cli profile view
 
-Reconfiguring
+Configuration
 """""""""""""
 
-If your token expires or you want to otherwise change your configuration, simply
-run the *configure* command::
+The first time the CLI runs, it will prompt you to configure it.  The CLI defaults
+to using web-based configuration, which is fast and convenient for users who
+have access to a browser.
 
-   linode-cli configure
+To manually configure the CLI or reconfigure it if your token expires, you can
+run the ``configure`` command::
+
+  linode-cli configure
+
+If you prefer to provide a token directly through the terminal, possibly because
+you don't have access to a browser where you're configuring the CLI, pass the
+``--token`` flag to the configure command as shown::
+
+   linode-cli configure --token
+
+When configuring multiple users using web-based configuration, you may need to
+log out of cloud.linode.com before configuring a second user.
 
 Suppressing Defaults
 """"""""""""""""""""

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -30,8 +30,7 @@ CONFIG_NAME = 'linode-cli'
 TOKEN_GENERATION_URL='https://cloud.linode.com/profile/tokens'
 
 # This is used for web-based configuration
-# TODO - use an official app
-OAUTH_CLIENT_ID = 'e36db7f4ec4dcffe558f'
+OAUTH_CLIENT_ID = '5823b4627e45411d18e9'
 
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -32,6 +32,11 @@ TOKEN_GENERATION_URL='https://cloud.linode.com/profile/tokens'
 # This is used for web-based configuration
 OAUTH_CLIENT_ID = '5823b4627e45411d18e9'
 
+# this is a list of browser that _should_ work for web-based auth.  This is mostly
+# intended to exclude lynx and other terminal browsers which could be opened, but
+# won't work.
+KNONW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser'))
+
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page
 DEFAULT_LANDING_PAGE = """
@@ -434,7 +439,26 @@ Note that no token will be saved in your configuration file.
             username = 'DEFAULT'
 
         else:
-            if self.configure_with_pat:
+            # let's see if we _can_ use web
+            can_use_browser = True
+            try:
+                webbrowser.get()
+            except webbrowser.Error:
+                # there are no browsers installed
+                 can_use_browser = False
+
+            if can_use_browser and not KNONW_GOOD_BROWSERS.intersection(webbrowser._tryorder):
+                print()
+                print("This tool defaults to web-based authentication, however "
+                      "no known-working browsers were found.")
+
+                while True:
+                    r = input_helper("Try it anyway? [y/N]: ")
+                    if r.lower() in 'yn ':
+                        can_use_browser = r.lower() == 'y'
+                        break
+
+            if self.configure_with_pat or not can_use_browser:
                 username, config['token'] = self._get_token_terminal()
             else:
                 print()

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -374,7 +374,7 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
                 self.end_headers()
 
                 # TODO: Clean up this page and make it look nice
-                self.wfile.write(bytes(landing_page.format(port=self.server.server_address[1]), "utf-8"))
+                self.wfile.write(bytes(landing_page.format(port=self.server.server_address[1]).encode("utf-8")))
 
             def log_message(self, form, *args):
                 """Don't actually log the request"""

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -31,7 +31,7 @@ TOKEN_GENERATION_URL='https://cloud.linode.com/profile/tokens'
 
 # This is used for web-based configuration
 # TODO - use an official app
-OAUTH_CLIENT_ID = 'e3dc6ddb291b4709ae54'
+OAUTH_CLIENT_ID = 'e36db7f4ec4dcffe558f'
 
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -330,17 +330,6 @@ on your account to work correctly.""".format(TOKEN_GENERATION_URL))
         Sends the user to a URL to perform an OAuth login for the CLI, then redirets
         them to a locally-hosted page that captures teh token
         """
-        url = "https://login.linode.com/oauth/authorize?client_id={}&response_type=token&scopes=*".format(
-            OAUTH_CLIENT_ID
-        )
-        print("""Your browser will be directed to this URL to authenticate:
-
-{}
-
-If you are not automatically directed there, please copy/paste the link into your browser
-to continue..
-""".format(url))
-
         class Handler(server.BaseHTTPRequestHandler):
             """
             The issue here is that Login sends the token in the URL hash, meaning
@@ -366,18 +355,31 @@ to continue..
 <h2>Success</h2><br/><p>You may return to your terminal to continue..</p>
 <script>
 // this is gross, sorry
-let r = new XMLHttpRequest('http://localhost:8123');
+let r = new XMLHttpRequest('http://localhost:{port}');
 r.open('GET', '/token/'+window.location.hash.substr(1));
 r.send();
 </script>
-""", "utf-8"))
+""".format(port=self.server.server_address[1]), "utf-8"))
 
             def log_message(self, form, *args):
                 """Don't actually log the request"""
 
         # start a server to catch the response
-        serv = server.HTTPServer(("localhost",8123), Handler)
+        serv = server.HTTPServer(("localhost",0), Handler)
         serv.token = None
+
+        # figure out the URL to direct the user to and print out the prompt
+        url = "https://login.linode.com/oauth/authorize?client_id={}&response_type=token&scopes=*&redirect_uri=http://localhost:{}".format(
+            OAUTH_CLIENT_ID, serv.server_address[1]
+        )
+        print("""Your browser will be directed to this URL to authenticate:
+
+{}
+
+If you are not automatically directed there, please copy/paste the link into your browser
+to continue..
+""".format(url))
+
 
         webbrowser.open(url)
 

--- a/linodecli/oauth-landing-page.html
+++ b/linodecli/oauth-landing-page.html
@@ -1,0 +1,46 @@
+<div style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 95vh;">
+<pre style="font-size: 8px;">                                                         
+ $M                         MVM                             
+ $VV$M                 $V**:..V                             
+  VVVVV$M         $V**:.......V                             
+  $VVVVVVV$$ $I*:.............F                             
+   VVVVVVVVV$*................F                             
+   VVVVVVVVVVI................*                             
+   $VVVVVVVVV$................*                             
+    VVVVVVVVV$:...............:                             
+    $VVVVVVVV$F...............:                             
+     $VVVVVVVV$..............:*                             
+       M$VVVVVM:.........:*IM                               
+         M$VVV$*......*F$                                   
+            M$VV..:F$                                       
+      M$       M$            V*$         M$$             MI 
+       VV$M              $I*...V         MVVVV$M      MV*.: 
+       $VVVVM        MV*:......F          $VVVVVV$M $*:...F 
+        VVVVVV$   MI*..........*            M$VVVVVV......$ 
+        VVVVVVVVM:.............*              M$VVVF.....:  
+        $VVVVVVV$*.............*           MI*:$VV$*...:FM  
+         VVVVVVVVV.............*MM      MV*...*$VV$:.*V     
+          MVVVVVVM..........:*V$VVV$  $*:.....* M$MIM       
+            M$VVV$*......:*V M$VVVVVVV........F             
+              M$VVI...:*V       $VVVVV.......:$             
+          M$    M$M:*V       MI*$VVVVV.....*$               
+           VV$             V*...$$VVVV..:FM                 
+           $VVV$        $*:.....V  $$V*V                    
+            VVVVV$   $F:........I                           
+            $VVVVVVM*...........F                           
+             $VVVVV$*.........:FM                           
+               $VVVVV.......*V                              
+                M$VVM....:FM                                
+                  M$$:.*$                                   
+                     $M                                     
+</pre>
+<h2 style="margin-bottom: 0;">Success!</h2>
+<p style="margin-top: 8px;">You may return to your terminal to continue.</p>
+</div>
+<script>
+/// we need to send the hash, which includes the generate access token, to the
+/// server (the CLI itself) since that won't be part of the URL sent by the browser.
+let r = new XMLHttpRequest('http://localhost:{port}');
+r.open('GET', '/token/'+window.location.hash.substr(1));
+r.send();
+</script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorclass
 requests
 PyYAML
 enum34; python_version < '3.4'
+future; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,13 @@ setup(
         'linodecli.plugins',
     ],
     license="BSD 3-Clause License",
-    install_requires=["terminaltables","colorclass","requests","PyYAML"],
+    install_requires=[
+        "terminaltables",
+        "colorclass",
+        "requests",
+        "PyYAML",
+        "future; python_version <= '3.0.0'"
+    ],
     extras_require={
         ":python_version<'3.4'": ['enum34'],
     },


### PR DESCRIPTION
When I started using the GitHub CLI, I was very impressed with its OAuth-based configuration in the terminal, so I ported the feature over to the Linode CLI.  This is how a configuration works with it:

```
$ linode-cli configure
Welcome to the Linode CLI.  This will walk you through some
initial setup.

How would you like to configure the CLI?  [W]eb or [t]oken?
'w' for web or 't' for token: w
Your browser will be directed to this URL to authenticate:

https://login.linode.com/oauth/authorize?client_id=e3dc6ddb291b4709ae54&response_type=token&scopes=*

If you are not automatically directed there, please copy/paste the link into your browser
to continue..


Configuring dorthu
```

Not visible above is a browser being opened, directed to the authorization URL, which then redirects back to localhost for the CLI to capture the OAuth response at a server hosted on `localhost:8123` (and serve a simple landing page telling you to return to your terminal).  The entire workflow feels very nice.

I have a few more thoughts:

 * Should this be the default method (i.e. enter for web, "t" for token?)
 * Should `linode-cli configure` accept a `--token` or `--web` to remove that prompt?

The following follow-up is needed:

- [x] Determining an ideal port for the landing page.
- [x] Style the landing page.
- [x] Change Client ID to be that of an official Linode App.
- [x] Test in all supported python versions.
- [x] Test on other OSes (Windows if possible).