### PR TITLE
Added epiphany browser to known working web browesrs for auth

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -35,7 +35,7 @@ OAUTH_CLIENT_ID = '5823b4627e45411d18e9'
 # this is a list of browser that _should_ work for web-based auth.  This is mostly
 # intended to exclude lynx and other terminal browsers which could be opened, but
 # won't work.
-KNONW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser', 'epiphany'))
+KNOW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser', 'epiphany'))
 
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page
@@ -447,7 +447,7 @@ Note that no token will be saved in your configuration file.
                 # there are no browsers installed
                  can_use_browser = False
 
-            if can_use_browser and not KNONW_GOOD_BROWSERS.intersection(webbrowser._tryorder):
+            if can_use_browser and not KNOW_GOOD_BROWSERS.intersection(webbrowser._tryorder):
                 print()
                 print("This tool defaults to web-based authentication, however "
                       "no known-working browsers were found.")

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -35,7 +35,7 @@ OAUTH_CLIENT_ID = '5823b4627e45411d18e9'
 # this is a list of browser that _should_ work for web-based auth.  This is mostly
 # intended to exclude lynx and other terminal browsers which could be opened, but
 # won't work.
-KNOW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser', 'epiphany'))
+KNOWN_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser', 'epiphany'))
 
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page
@@ -447,7 +447,7 @@ Note that no token will be saved in your configuration file.
                 # there are no browsers installed
                  can_use_browser = False
 
-            if can_use_browser and not KNOW_GOOD_BROWSERS.intersection(webbrowser._tryorder):
+            if can_use_browser and not KNOWN_GOOD_BROWSERS.intersection(webbrowser._tryorder):
                 print()
                 print("This tool defaults to web-based authentication, however "
                       "no known-working browsers were found.")

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -35,7 +35,7 @@ OAUTH_CLIENT_ID = '5823b4627e45411d18e9'
 # this is a list of browser that _should_ work for web-based auth.  This is mostly
 # intended to exclude lynx and other terminal browsers which could be opened, but
 # won't work.
-KNONW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser'))
+KNONW_GOOD_BROWSERS = set(('chrome', 'firefox', 'mozilla', 'netscape', 'opera', 'safari', 'chromium', 'chromium-browser', 'epiphany'))
 
 # in the event that we can't load the styled landing page from file, this will
 # do as a landing page


### PR DESCRIPTION
This was verified as working, so we should allow it.  This is the
default browser on ElementaryOS
