### PR TITLE
Allow recursively deleting not-empty buckets

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -154,9 +154,24 @@ def delete_bucket(get_client, args):
 
     parser.add_argument('name', metavar='NAME', type=str,
                         help="The name of the bucket to remove.")
+    parser.add_argument('--recursive', action="store_true",
+                        help="If given, force removal of non-empty buckets by deleting "
+                             "all objects in the bucket before deleting the bucket.  For "
+                             "large buckets, this may take a while.")
 
     parsed = parser.parse_args(args)
     client = get_client()
+
+    if parsed.recursive:
+        try:
+            bucket = client.get_bucket(parsed.name)
+        except S3ResponseError:
+            print('No bucket named '+parsed.name)
+            sys.exit(2)
+
+        for c in bucket.list():
+            print("delete: {} {}".format(parsed.name, c.key))
+            bucket.delete_key(c)
 
     client.delete_bucket(parsed.name)
 


### PR DESCRIPTION
Closes #236 and #225

A much-requested feature of the obj plugin was to add the ability to
delete buckets that aren't empty, or otherwise remove many objects in
one operation.  Unfortunately this has to happen client-side, so it can
take a while for large buckets.

This change adds a `--recursive` flag to `linode-cli obj rb` that will,
if given, remove all objects from the bucket before removing the bucket.
As implemented here this will not abort in-progress multi-part uploads
or clear stale object versions; that may be added later if it's
necessary (but if such things exist, they will prevent the bucket
deletion from completing successfully).
