### PR TITLE
Don't require configuration when running `--version`

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -26,7 +26,10 @@ except:
 BASE_URL = 'https://api.linode.com/v4'
 
 
-cli = CLI(VERSION, BASE_URL, skip_config=('--skip-config' in argv or '--help' in argv))
+# if any of these arguments are given, we don't need to prompt for configuration
+skip_config = any([c in argv for c in ('--skip-config', '--help', '--version')])
+
+cli = CLI(VERSION, BASE_URL, skip_config=skip_config)
 
 def main():
     ## Command Handling


### PR DESCRIPTION
Closes #235

While `--skip-config` does allow you to find the version without a token
provided, there's no reason to prompt for it at all, and I can see how
this would be disruptive.

This change treats `--version` as `--skip-config` when deciding if the
user should be prompted for configuration if none is present.
