### PR TITLE
bug: Fixed populating defaults when no configuration is present

### DIFF
--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -133,7 +133,9 @@ class CLIConfig:
             print("User {} is not configured.".format(username))
             sys.exit(1)
 
-        return self.update_namespace(namespace, dict(self.config.items(username)))
+        if self.config.has_section(username):
+            return self.update_namespace(namespace, dict(self.config.items(username)))
+        return namespace
 
     def get_token(self):
         """


### PR DESCRIPTION
Closes #239

If using the CLI with an environment-defined token (`LINODE_CLI_TOKEN`),
populating defaults in a request would fail with a
`configparser.NoSectionError` as it attempted to load defaults for an
unconfigured user.

This change checks to see if the user is configured before attempting to
apply defaults, and if so returns the namespace given instead of
attempting to update it.
