### PR TITLE
fix: Document image-upload file requirements

### DIFF
--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -74,7 +74,9 @@ def call(args, context):
     parser.add_argument("--description", metavar="DESC", nargs="?",
                         help="A description for this Image.  Blank if omitted.")
     parser.add_argument("file", metavar="FILE",
-                        help="The image file to upload.")
+                        help="The image file to upload.  Should be a raw disk image "
+                             "compressed with gzip, in .img.gz format.  We recommend "
+                             "using unpartitioned images with an ext3 or ext4 filesystem.")
 
     parsed = parser.parse_args(args)
 


### PR DESCRIPTION
Closes #243

The CLI is most useful if it contains all the information you need to
use it; image requirements for successful uploads and deployments are
definitely included in that.

The help now appears as:

```
$ linode-cli image-upload --help
usage: linode-cli image-upload [-h] [--region [REGION]] [--label [LABEL]] [--description [DESC]] FILE

positional arguments:
  FILE                  The image file to upload. Should be a raw disk image compressed with gzip, in .img.gz format. We recommend using unpartitioned images with an ext3 or ext4
                        filesystem.

  ...
```