### PR TITLE
Decode base64-encoded fields during output

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -164,7 +164,8 @@ class CLI:
                     info.get('x-linode-cli-display') or False,
                     info.get('type') or 'string',
                     color_map=info.get('x-linode-cli-color'),
-                    item_type=item_type))
+                    item_type=item_type,
+                    content_encoding=info.get("contentEncoding")))
 
         return attrs
 

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -4,6 +4,7 @@ on the OpenAPI spec.
 """
 from __future__ import print_function
 
+import base64
 import os
 import platform
 
@@ -59,7 +60,7 @@ def colorize_string(string, color):
 
 
 class ModelAttr:
-    def __init__(self, name, filterable, display, datatype, color_map=None, item_type=None):
+    def __init__(self, name, filterable, display, datatype, color_map=None, item_type=None, content_encoding=None):
         self.name = name
         self.value = None
         self.filterable = filterable
@@ -68,6 +69,7 @@ class ModelAttr:
         self.datatype = datatype
         self.color_map = color_map
         self.item_type = item_type
+        self.content_encoding = content_encoding
 
     def _get_value(self, model):
         """
@@ -79,6 +81,10 @@ class ModelAttr:
             if value is None:
                 return None
             value = value[part]
+
+        if self.content_encoding:
+            if self.content_encoding == "base64":
+                value = base64.b64decode(value.encode()).decode()
 
         return value
 


### PR DESCRIPTION
Closes https://github.com/linode/linode-cli/issues/247

Related to https://github.com/linode/linode-api-docs/pull/468

The API returned kubeconfigs as a base64-encoded YAML string.  The
linked docs PR uses the appropriate JSON Schema fields to note the
encoding and actual media type, and this CLI PR adds support for that
information and handling it.

However, the output for `linode-cli lke kubeconfig-view $CLUSTER_ID` is
_pretty terrible_ with this change.  The `token` and `certificate-authority-data`
fields are _very long_, and cause wrapping in the terminal, which messes
up the entire output table.  This can be corrected by using `--text` as
the output format, which, paired with `--no-headers`, produces a
nicely-formatted YAML file as output; the default behavior being ugly
isn't great in my opinion though.

This change isn't strictly necessary, as a user can run
`linode-cli lke kubeconfig-view $CLUSTER_ID --text --no-headers | base64 -d`
to see the same output today; however, having the default output be
useful would be a nice touch.

I see the following options here:

 * Accept that the current output is fine and do not merge this PR
 * Accept that this PR's output is ugly by default and merge it anyway
 * Come up with a way to signal to the CLI that an operation should
   default to `--text --no-headers`-style output as part of this PR.

This change probably also represents a breaking change for the CLI, as
an existing script that does the decoding as noted above would stop
working with this change merged in.

Opinions appreciated; I will close/open/update this PR as relevant based
on discussion here.
