### PR TITLE
fix: Check Image upload size before attempting upload

### DIFF
--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -12,6 +12,7 @@ import os
 from sys import exit
 
 PLUGIN_BASE = 'linode-cli image-upload'
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024 * 1024 # 5GB
 
 
 def _progress(cur, total):
@@ -92,6 +93,11 @@ def call(args, context):
 
     if not os.path.isfile(filepath):
         print("No file at {}; must be a path to a valid file.".format(filepath))
+        exit(2)
+
+    # make sure it's not larger than the max upload size
+    if os.path.getsize(filepath) > MAX_UPLOAD_SIZE:
+        print("File {} is too large; compressed size must be less than 5GB".format(filepath))
         exit(2)
 
     label = parsed.label or os.path.basename(filepath)

--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -84,10 +84,6 @@ def call(args, context):
     # get default region populated
     context.client.config.update(parsed)
 
-    if not parsed.region:
-        print("No region provided.  Please set a default region or use --region")
-        exit(1)
-
     # make sure the file exists and is ready to upload
     filepath = os.path.expanduser(parsed.file)
 
@@ -99,6 +95,10 @@ def call(args, context):
     if os.path.getsize(filepath) > MAX_UPLOAD_SIZE:
         print("File {} is too large; compressed size must be less than 5GB".format(filepath))
         exit(2)
+
+    if not parsed.region:
+        print("No region provided.  Please set a default region or use --region")
+        exit(1)
 
     label = parsed.label or os.path.basename(filepath)
 


### PR DESCRIPTION
Closes #250

Right now, the `image-upload` plugin just attempts to upload whatever
it's given, but that can waste a lot of time.

This change checks that the compressed size is no larger than the
maximum allowed (5GB) before initiating the upload.

This change does not attempt to catch cases where the _uncompressed_
size of the image is larger than allowed; the maximum uncompressed size
is not constant, and the CLI has no way to know if an Image uploaded
will end up being too large when it gets there.
