### PR TITLE
Remove dependency on colorclass

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -389,8 +389,8 @@ added to Linode's OpenAPI spec:
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-action          | method      | The action name for operations under this path. If not present, operationId is used.      |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-color           | property    | If present, defines key-value pairs of property value: color.  Colors must be understood  |
-|                             |             | by colorclass.Color.  Must include a default.                                             |
+|x-linode-cli-color           | property    | If present, defines key-value pairs of property value: color.  Colors must be one of      |
+|                             |             | "red", "green", "yellow", "white", and "black".  Must include a default.                  |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-command         | path        | The command name for operations under this path. If not present, "default" is used.       |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -4,7 +4,23 @@ on the OpenAPI spec.
 """
 from __future__ import print_function
 
-from colorclass import Color
+
+CLEAR_COLOR = "\x1b[0m"
+COLOR_CODE_MAP = {
+    "red": "\x1b[31m",
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "black": "\x1b[30m",
+    "white": "\x1b[40m",
+}
+
+
+def colorize_string(string, color):
+    col = COLOR_CODE_MAP.get(color, CLEAR_COLOR)
+
+    return "{}{}{}".format(
+        col, string, CLEAR_COLOR,
+    )
 
 
 class ModelAttr:
@@ -51,7 +67,7 @@ class ModelAttr:
             # apply colors
             value = str(value) # just in case
             color = self.color_map.get(value) or self.color_map['default_']
-            value = str(Color('{'+color+'}'+value+'{/'+color+'}'))
+            value = colorize_string(value, color)
 
         if value is None:
             # don't print the word "None"

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -4,6 +4,33 @@ on the OpenAPI spec.
 """
 from __future__ import print_function
 
+import os
+import platform
+
+DO_COLORS = True
+# !! Windows compatibility for ANSI color codes !!
+#
+# If we're running on windows, we need to run the "color" command to enable
+# ANSI color code support.
+if platform.system() == "Windows":
+    ver = platform.version()
+
+    if '.' in ver:
+        ver = ver.split('.', 1)[0]
+
+    try:
+        verNum = int(ver)
+    except ValueError:
+        DO_COLORS = False
+
+    # windows 10+ supports ANSI color codes after running the 'color' command to
+    # properly set up the command prompt.  Older versions of windows do not, and
+    # we should not attempt to use them there.
+    if verNum >= 10:
+        os.system("color")
+    else:
+        DO_COLORS = False
+
 
 CLEAR_COLOR = "\x1b[0m"
 COLOR_CODE_MAP = {
@@ -16,6 +43,14 @@ COLOR_CODE_MAP = {
 
 
 def colorize_string(string, color):
+    """
+    Returns the requested string, wrapped in ANSI color codes to colorize it as
+    requested.  On platforms where colors are not supported, this just returns
+    the string passed into it.
+    """
+    if not DO_COLORS:
+        return string
+
     col = COLOR_CODE_MAP.get(color, CLEAR_COLOR)
 
     return "{}{}{}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 terminaltables
-colorclass
 requests
 PyYAML
 enum34; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     license="BSD 3-Clause License",
     install_requires=[
         "terminaltables",
-        "colorclass",
         "requests",
         "PyYAML",
         "future; python_version <= '3.0.0'"


### PR DESCRIPTION
Closes https://github.com/linode/linode-cli/issues/231

The colorclass module is not compatible with Python 3.10, and is
currently [archived on github](https://github.com/Robpol86/colorclass)
with issues open about future compatibility issues and no real
suggestion of movement.

This change replaces `colorclass` with the few color codes that were
actually used so far, which removes the dependency entirely and should
allow the CLI to work on python 3.10.

This appears to work where I've tested it, and from what I read it aught
to work the same on Windows too, but I'd like someone to give it a spin
first to be sure.
