### PR TITLE
bug: Resolve nested refs

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -101,6 +101,8 @@ class CLI:
                 continue # we can't edit this level of the tree
             if info.get('readOnly'):
                 continue
+            if '$ref' in info:
+                info = self._resolve_ref(info['$ref'])
             path = '.'.join(prefix+[arg])
             args[path] = {
                 "type": info.get('type') or 'string',


### PR DESCRIPTION
Closes #255

The spec for LKE Node Pools included deeper `$ref` nesting than the
CLI's parser supported.  This change resolves one more level of `$ref`,
allowing node pools counts to be updated easily.

This isn't an awesome fix; the real problem here is the fragility of the
CLI's spec parser, and the real fix is to implement a better spec
parser, as #218 attempted to do.  That effort should be completed to
resolve all like issues that may be found in the future.
