### PR TITLE
bug: Only allow requested defaults to actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -384,23 +384,26 @@ Specification Extensions
 In order to be more useful, the following `Specification Extensions`_ have been
 added to Linode's OpenAPI spec:
 
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|Attribute            | Location | Purpose                                                                                   |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-action  | method   | The action name for operations under this path. If not present, operationId is used.      |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-color   | property | If present, defines key-value pairs of property value: color.  Colors must be understood  |
-|                     |          | by colorclass.Color.  Must include a default.                                             |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-command | path     | The command name for operations under this path. If not present, "default" is used.       |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-display | property | If truthy, displays this as a column in output.  If a number, determines the ordering     |
-|                     |          | (left to right).                                                                          |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-format  | property | Overrides the "format" given in this property for the CLI only.  Valid values are `file`  |
-|                     |          | and `json`.                                                                               |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
-|x-linode-cli-skip    | path     | If present and truthy, this method will not be available in the CLI.                      |
-+---------------------+----------+-------------------------------------------------------------------------------------------+
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|Attribute                    | Location    | Purpose                                                                                   |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-action          | method      | The action name for operations under this path. If not present, operationId is used.      |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-color           | property    | If present, defines key-value pairs of property value: color.  Colors must be understood  |
+|                             |             | by colorclass.Color.  Must include a default.                                             |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-command         | path        | The command name for operations under this path. If not present, "default" is used.       |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-display         | property    | If truthy, displays this as a column in output.  If a number, determines the ordering     |
+|                             |             | (left to right).                                                                          |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-format          | property    | Overrides the "format" given in this property for the CLI only.  Valid values are `file`  |
+|                             |             | and `json`.                                                                               |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-skip            | path        | If present and truthy, this method will not be available in the CLI.                      |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
++x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request.  Value values are "region", |
++                             |             | "image", and "type".                                                                      |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -204,7 +204,10 @@ class CLI:
 
                     args = {}
                     required_fields = []
+                    allowed_defaults = None
                     if m in ('post','put') and 'requestBody' in data[m]:
+                        allowed_defaults = data[m]['requestBody'].get("x-linode-cli-allowed-defaults", None)
+
                         if 'application/json' in data[m]['requestBody']['content']:
                             body_schema = data[m]['requestBody']['content']['application/json']['schema']
 
@@ -286,7 +289,8 @@ class CLI:
 
                     self.ops[command][action] = CLIOperation(m, use_path, summary,
                                                              cli_args, response_model,
-                                                             use_params, use_servers)
+                                                             use_params, use_servers,
+                                                             allowed_defaults=allowed_defaults)
 
         # hide the base_url from the spec away
         self.ops['_base_url'] = spec['servers'][0]['url']
@@ -431,7 +435,7 @@ complete -F _linode_cli linode-cli""")
                     headers["X-Filter"] = json.dumps(filters)
         else:
             if self.defaults:
-                parsed_args = self.config.update(parsed_args)
+                parsed_args = self.config.update(parsed_args, operation.allowed_defaults)
 
             to_json = {k: v for k, v in vars(parsed_args).items() if v is not None}
 

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -116,7 +116,7 @@ class CLIConfig:
 
         return argparse.Namespace(**ns_dict)
 
-    def update(self, namespace):
+    def update(self, namespace, allowed_defaults):
         """
         This updates a Namespace (as returned by ArgumentParser) with config values
         if they aren't present in the Namespace already.
@@ -133,8 +133,12 @@ class CLIConfig:
             print("User {} is not configured.".format(username))
             sys.exit(1)
 
-        if self.config.has_section(username):
-            return self.update_namespace(namespace, dict(self.config.items(username)))
+        if self.config.has_section(username) and allowed_defaults:
+            update_dicts = {
+                default_key: self.config.get(username, default_key)
+                for default_key  in allowed_defaults if self.config.has_option(username, default_key)
+            }
+            return self.update_namespace(namespace, update_dicts)
         return namespace
 
     def get_token(self):

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -123,7 +123,7 @@ class CLIOperation:
     responses with the help of their ResponseModel
     """
     def __init__(self, method, url, summary, args, response_model,
-                 params, servers):
+                 params, servers, allowed_defaults = None):
         self.method = method
         self._url = url
         self.summary = summary
@@ -131,6 +131,7 @@ class CLIOperation:
         self.response_model = response_model
         self.params = params
         self.servers = servers
+        self.allowed_defaults = allowed_defaults
 
     @property
     def url(self):


### PR DESCRIPTION
This should fix the `linode-cli tickets create` action.

The Linode CLI, when being configured, accepts default values for
"region", "image", and "type".  These values were previously added to
every input for a PUT or POST endpoint, and then parsed out as normal.
This had the effect of defaulting those values to the configured
defaults for actions like `linodes create` or `nodebalancers create`
without additional interaction.

However, the `tickets create` action recently began accepting
`--region`, but only for certain types of tickets.  This caused ticket
creation to fail through the CLI if a default region was configured,
unless `--no-defaults` was given, or unless the specific ticket type was
being opened.

This change allows the spec to specify which actions should use which
defaults, allowing this problem to be resolved as well as avoiding it
for future changes to actions.

:warning: This requires a docs update to allow existing actions to
continue using their defaults.  Such a PR will be linked below.
