### PR TITLE
Updated --k8s-version in LKE test

### DIFF
--- a/test/lke/clusters.bats
+++ b/test/lke/clusters.bats
@@ -27,7 +27,7 @@ teardown() {
         --node_pools.type g6-standard-1 \
         --node_pools.count 1 \
         --node_pools.disks '[{"type":"ext4","size":1024}]' \
-        --k8s_version 1.19 \
+        --k8s_version 1.21 \
         --text \
         --delimiter "," \
         --no-headers \


### PR DESCRIPTION
Currently, this test is failing with an "k8s_version,k8s_version is not valid".
Sure enough, it looks like 1.19 was retired recently.

This change updates the tests to use 1.21, the most recent version.  In
the future they may even need to get this value dynamically.
