### PR TITLE
bug: Fix image-upload plugin

### DIFF
--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -82,7 +82,7 @@ def call(args, context):
     parsed = parser.parse_args(args)
 
     # get default region populated
-    context.client.config.update(parsed)
+    context.client.config.update(parsed, ["region"])
 
     # make sure the file exists and is ready to upload
     filepath = os.path.expanduser(parsed.file)


### PR DESCRIPTION
Closes #262

Looks like in https://github.com/linode/linode-cli/pull/257 I changed
the signature of this function, and didn't realize I was using it in a
plugin, which caused the plugin to break.

This change adds the correct allowed default for this function (we want
default regions for image uploads).
