### PR TITLE
bug: Fixed error output for CLI operations

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -289,10 +289,18 @@ class CLI:
                             use_path = use_path.replace("{"+p.name+"}", "{"+p.name+"_}")
                             p.name += '_'
 
-                    self.ops[command][action] = CLIOperation(m, use_path, summary,
-                                                             cli_args, response_model,
-                                                             use_params, use_servers,
-                                                             allowed_defaults=allowed_defaults)
+                    self.ops[command][action] = CLIOperation(
+                        command,
+                        action,
+                        m,
+                        use_path,
+                        summary,
+                        cli_args,
+                        response_model,
+                        use_params,
+                        use_servers,
+                        allowed_defaults=allowed_defaults,
+                    )
 
         # hide the base_url from the spec away
         self.ops['_base_url'] = spec['servers'][0]['url']

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -122,8 +122,10 @@ class CLIOperation:
     are responsible for parsing their own arguments and processing their
     responses with the help of their ResponseModel
     """
-    def __init__(self, method, url, summary, args, response_model,
+    def __init__(self, command, action, method, url, summary, args, response_model,
                  params, servers, allowed_defaults = None):
+        self.command = command
+        self.action = action
         self.method = method
         self._url = url
         self.summary = summary
@@ -149,7 +151,10 @@ class CLIOperation:
         list_items = []
 
         #  build an argparse
-        parser = argparse.ArgumentParser(description=self.summary)
+        parser = argparse.ArgumentParser(
+            prog="linode-cli {} {}".format(self.command, self.action),
+            description=self.summary,
+        )
         for param in self.params:
             parser.add_argument(param.name, metavar=param.name,
                                 type=TYPES[param.param_type])


### PR DESCRIPTION
Related to #273

Right now, the output you get when you call a CLI operation without
arguments is as follows:

```bash
$ linode-cli networking ip-update
usage: linode-cli [-h] [--rdns rdns] address
linode-cli: error: the following arguments are required: address
```

The "usage" line in that output is clearly wrong, as you did not invoke
`linode-cli` by itself.  This change adds the command/action you
provided into that output to make it display correctly:

```bash
$ linode-cli networking ip-update
usage: linode-cli networking ip-update [-h] [--rdns rdns] address
linode-cli networking ip-update: error: the following arguments are required: address
```
