### PR TITLE
bug: Tests should accept new error output

### DIFF
--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -94,7 +94,7 @@ teardown() {
         --format="size"
 
     assert_failure
-    assert_output --partial "usage: linode-cli [-h] [--label label] [--tags tags] volumeId"
+    assert_output --partial "usage: linode-cli volumes update [-h] [--label label] [--tags tags] volumeId"
     assert_output --partial "linode-cli: error: unrecognized arguments: --size=15"
 }
 


### PR DESCRIPTION
This is related to https://github.com/linode/linode-cli/pull/274

In #274, I changed the output when a command is entered improperly to
include the command and action the CLI was processing when the error
occurred, which mimics what was entered on the terminal.  I didn't
realize tests were checking for the old output.

This change updates tests to look for the new output instead of the old
format.
