### PR TITLE
bug: Make tests more durable

### DIFF
--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -12,7 +12,8 @@ load '../common'
 setup() {
     suiteName="list-view-update-volumes"
     setToken "$suiteName"
-    export volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id")
+    # we only want a single volume id, so if there are more volumes on the account, just look at the first one
+    export volume_id=$(linode-cli volumes list --text --no-headers --delimiter="," --format="id" | head -n1)
 }
 
 teardown() {
@@ -22,10 +23,6 @@ teardown() {
         rm .tmp-volume-tag
         clearToken "$suiteName"
     fi
-}
-
-@test "remove volumes prior to tests" {
-    run removeVolumes
 }
 
 @test "it should list volumes" {


### PR DESCRIPTION
Tests regularly fail, delaying CLI releases, because there are other
Volumes on the test account, and commands referencing a `$volume_id` are
given a list of IDs instead of just the one they expect.

This change sets `$volume_id` to a single Volume's ID, which should
allow tests to continue even if there are unexpected volumes on the
account.
