### PR TITLE
bug: Fix SignatureDoesNotMatch when putting files with special characters

### DIFF
--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -15,6 +15,12 @@ from terminaltables import SingleTable
 from math import ceil
 from linodecli.configuration import input_helper
 
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    # python2
+    from urllib import quote_plus
+
 
 ENV_ACCESS_KEY_NAME = "LINODE_CLI_OBJ_ACCESS_KEY"
 ENV_SECRET_KEY_NAME = "LINODE_CLI_OBJ_SECRET_KEY"
@@ -229,7 +235,7 @@ def upload_object(get_client, args):
 
     for filename, file_path in to_upload:
         k = Key(bucket)
-        k.key = filename
+        k.key = quote_plus(filename)
 
         print(filename)
         k.set_contents_from_filename(file_path, cb=_progress, num_cb=100, policy=policy)


### PR DESCRIPTION
Related to #277

@mechpaul discovered that putting filenames with some special
characters, such as `\` and `$` using the `obj` plugin returns a
SignatureDoesNotMatch error.

To reproduce:

```bash
$ echo "test" > 'test$file\name'
$ python3 -m linodecli obj put 'test$file\name' some-bucket
```

This change properly quotes the URLs such that these characters are
accepted in keys.
