### PR TITLE
ci: init github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: ci
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build'
+        required: true
+
+jobs:
+  bake:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.x', '3.x']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+      - run: python -m linodecli bake "https://raw.githubusercontent.com/linode/linode-api-docs/${{ github.event.inputs.version }}/openapi.yaml" --skip-config
+      - uses: actions/upload-artifact@v2
+        with:
+          name: baked-pickle-${{ matrix.python-version }}
+          path: data-[23]
+
+  build:
+    needs:
+      - bake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - uses: actions/download-artifact@v2
+        with:
+          path: linodecli
+      - run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          python setup.py bdist_wheel --universal
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*


### PR DESCRIPTION
This initializes the github workflow to build the linode-cli wheel. It
does not handle distribution of the package.

It can be triggered at any time by inputting the spec version to build in the Actions workflow and starting the job.

Example run: https://github.com/stvnjacobs/linode-cli/actions/runs/1594022100

Opening as a draft, as there are a few rough spots:
- I like the idea of putting in the spec version, as it allows for some level of control. That being said, it does add some friction. Looking at the release process here, though, it appears that tags are being applied anyway, so there is some manual intervention. We could always pull from the latest release of the docs repo, if we want.
- This does not publish. It's only one more step to do so, but I just wanted to get feedback before adding pubilshing steps.
- It does not use the Makefile or run the tests. The Makefile wants both python interpreters available, but that is not how GitHub actions or other tooling like tox works. The tests require a cacert.pem file which is not part of this repository.