### PR TITLE
bug: Remove commands with no actions from recognized commands

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -302,6 +302,15 @@ class CLI:
                         allowed_defaults=allowed_defaults,
                     )
 
+        # remove any empty commands (those that have no actions)
+        to_remove = []
+        for command, actions in self.ops.items():
+            if len(actions) == 0:
+                to_remove.append(command)
+
+        for command in to_remove:
+            del self.ops[command]
+
         # hide the base_url from the spec away
         self.ops['_base_url'] = spec['servers'][0]['url']
         self.ops['_spec_version'] = spec['info']['version']


### PR DESCRIPTION
Related to https://github.com/linode/linode-api-docs/pull/581

It is possible that every operation in a path is skipped in the CLI via
the `x-linode-cli-skip` spec extension.  In this case, that path's
command should not be present in the CLI at all, as it would have no
actions associated to it.  The above-linked PR introduces the first
paths that are entirely skipped in this way.

This change removes all empty commands from the CLI after building the
entire command/action structure.
