### PR TITLE
bug: Fix `linode-cli users view USERNAME`

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -279,10 +279,12 @@ class CLI:
                         cli_args.append(new_arg)
 
                     # looks for param names that will be obscured by args
-                    use_params = params[:]
+                    # clone the params since they're shared by all methods in this
+                    # path, and we only want to modify this method's params
+                    use_params = [c.clone() for c in params]
                     use_path = path
                     for p in use_params:
-                        if p.name in args.keys():
+                        if p.name in args.keys():# or (m == 'get' and p.name in model_attrs):
                             # if we found a parameter name that is also and argument name
                             # append an underscore to both the parameter name and the
                             # parameter name in the URL

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -114,6 +114,12 @@ class URLParam:
         self.name = name
         self.param_type = param_type
 
+    def clone(self):
+        """
+        Returns a new URLParam that is exactly like this one
+        """
+        return URLParam(self.name, self.param_type)
+
 
 class CLIOperation:
     """


### PR DESCRIPTION
In the process of attempting to free the namespace for CLI Args that
conflict with URL Params, I accidentally overwrote the stored param
string for all methods under a given path.  This caused the operation
`linode-cli users view` to have a param `username_`, but the URL to
continue to be `/account/users/{username}`, as the param's name was
updated when processing `linode-cli users update` (which has a
`--username` arg and a `username` param, causing the param to change to
`username_` and the url to change to `/account/users/{username_}`).

This change copies all params, so that when they are updated, only the
copy local to this method is updated.
