### PR TITLE
new: Warn python2 users of planned dropping of support

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -40,8 +40,8 @@ def warn_python2_eol():
     """
     if version_info.major < 3:
         print(
-            "You are running the Linode CLI using python 2, which reached its end of life on "
-            "Jan 1st, 2020.  The Linode CLI will be dropping support for python 2, and "
+            "You are running the Linode CLI using Python 2, which reached its end of life on "
+            "Jan 1st, 2020.  The Linode CLI will be dropping support for Python 2, and "
             "upgrading your installation is strongly encouraged so that you can continue "
             "to receive updates.\n\nFor information about upgrading your installation, see "
             "our official guide:\n\nhttps://www.linode.com/docs/guides/upgrade-to-linode-cli-python-3/",

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -5,7 +5,7 @@ import argparse
 from importlib import import_module
 import os
 import pkg_resources
-from sys import argv, exit
+from sys import argv, exit, version_info, stderr
 
 import requests
 import yaml
@@ -30,6 +30,24 @@ BASE_URL = 'https://api.linode.com/v4'
 skip_config = any([c in argv for c in ('--skip-config', '--help', '--version')])
 
 cli = CLI(VERSION, BASE_URL, skip_config=skip_config)
+
+
+def warn_python2_eol():
+    """
+    Prints a warning the first time each day that the CLI is used under python2.
+    This is included to help users upgrade to python3 before python2 support is
+    dropped in the CLI.
+    """
+    if version_info.major < 3:
+        print(
+            "You are running the Linode CLI using python 2, which reached its end of life on "
+            "Jan 1st, 2020.  The Linode CLI will be dropping support for python 2, and "
+            "upgrading your installation is strongly encouraged so that you can continue "
+            "to receive updates.\n\nFor information about upgrading your installation, see "
+            "our official guide:\n\nhttps://www.linode.com/docs/guides/upgrade-to-linode-cli-python-3/",
+            file=stderr,
+        )
+
 
 def main():
     ## Command Handling
@@ -103,6 +121,9 @@ def main():
     cli.suppress_warnings = parsed.suppress_warnings
     cli.page = parsed.page
     cli.debug_request = parsed.debug
+
+    if not cli.suppress_warnings:
+        warn_python2_eol()
 
     if parsed.as_user:
         # if they are acting as a non-default user, set it up early


### PR DESCRIPTION
Python 2 was sunset on Jan 1st, 2020.  We have continued to support
python2 this long because many users still use it, however as python3
support has grown and libraries continue dropping support for python2,
it is becoming increasingly difficult to maintain the CLI with python2
supported.

This change adds a warning to users running the CLI under python2 that
support will be dropped in a future version, and includes a link to our
official guide on how to upgrade your installation.  As usual,
`--suppress-warnings` silences this warning, and the warning is output
to `stderr` to allow users to redirect `2>/dev/null` to ignore it as
well.

In the last version that supports python2, this warning will be changed
to note that support _has been_ dropped, and that upgrading to a python3
install is required to continue receiving updates.

I implemented this to print the warning on every request, however I also
considered having this warning only display on the first request of a
given day.  I'm open to opinions on this.

This additional output could break scripted installations, for example
those doing something like `linode-cli linodes list --text --format
'id,ipv4 | something` if those installations do not already ignore
stderr/suppress warnings.  I find this to be unlikely, as the CLI
already prints warnings when an update is available, so anything that's
been running unmonitored for any amount of time would already break if
warning output wasn't being handled.  Again, opinions are welcome.
