### PR TITLE
bug: Resolve references in references

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -94,7 +94,7 @@ class CLI:
         for arg, info in node.items():
             if "allOf" in info:
                 info = self._resolve_allOf(info["allOf"])
-            if "$ref" in info:
+            while "$ref" in info:
                 info = self._resolve_ref(info["$ref"])
             if "properties" in info:
                 self._parse_args(info["properties"], prefix=prefix + [arg], args=args)


### PR DESCRIPTION
This fixes the `linode-cli databases mysql-update` command.

This command accepts an array, called `--allow-list`.  This is
unremarkable, except that the spec nests this list under three layers of
references.  That's valid, but the CLI didn't handle it well.

This is one of the problems that a better spec parser would likely solve
for us immediately: https://github.com/linode/linode-cli/pull/218

This change repeatedly resolves references in args until there are none
left, handling layers of references for a single argument.
