### PR TITLE
new: Support multiple exclusive nested lists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -423,5 +423,16 @@ added to Linode's OpenAPI spec:
 +x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request.  Value values are "region", |
 +                             |             | "image", and "type".                                                                      |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
++x-linode-cli-nested-list     | content-type| Tells the CLI to flatten a single object into multiple table rows based on the keys       |
+|                             |             | included in this value.  Values should be comma-delimited JSON paths, and must all be     |
+|                             |             | present on response objects.                                                              |
+|                             |             |                                                                                           |
+|                             |             | When used, a new key ``_split`` is added to each flattened object whose value is the last |
+|                             |             | segment of the JSON path used to generate the flattened object from the source.           |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
+|x-linode-cli-use-schema      | content-type| Overrides the normal schema for the object and uses this instead.  Especially useful when |
+|                             |             | paired with ``x-linode-cli-nested-list``, allowing a schema to describe the flattened     |
+|                             |             | object instead of the original object.                                                    |
++-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 
 .. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions

--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -166,15 +166,26 @@ class ResponseModel:
             if "pages" in json:
                 json = json["data"]
 
+            nested_lists = [c.strip() for c in self.nested_list.split(",")]
             ret = []
-            if not isinstance(json, list):
-                json = [json]
-            for cur in json:
-                nlist = cur.get(self.nested_list)
-                for item in nlist:
-                    cobj = {k: v for k, v in cur.items() if k != self.nested_list}
-                    cobj[self.nested_list] = item
-                    ret.append(cobj)
+
+            for nested_list in nested_lists:
+                path_parts = nested_list.split(".")
+
+                if not isinstance(json, list):
+                    json = [json]
+                for cur in json:
+
+                    nlist_path = cur
+                    for p in path_parts:
+                      nlist_path = nlist_path.get(p)
+                    nlist = nlist_path
+
+                    for item in nlist:
+                        cobj = {k: v for k, v in cur.items() if k != path_parts[0]}
+                        cobj["_split"] = path_parts[-1]
+                        cobj[path_parts[0]] = item
+                        ret.append(cobj)
 
             return ret
         elif "pages" in json:


### PR DESCRIPTION
Closes #297

Database Types return (currently) three different engine types with
their prices, in nested lists within a container object.  This wasn't
handled well when flattening API responses into table rows.

This change allows multiple, exclusive nested lists to be flattened into
output table rows.  This _does not_ support multiple unrelated nested
lists; all lists will be parsed and returned as individual values.

For example, this API response:

```json
{
  "id": "g6-nanode-1",
  "label": "DBaaS - Nanode 1GB",
  "engines": {
    "mysql": [
      {
        "quantity": 1,
        "price": {
          "hourly": 0.0225,
          "monthly": 15
        }
      },
      {
        "quantity": 2,
        "price": {
          "hourly": 0.0375,
          "monthly": 25
        }
      },
      {
        "quantity": 3,
        "price": {
          "hourly": 0.0525,
          "monthly": 35
        }
      }
    ],
    "postgresql": [
      {
        "quantity": 1,
        "price": {
          "hourly": 0.0225,
          "monthly": 15
        }
      },
      {
        "quantity": 2,
        "price": {
          "hourly": 0.0375,
          "monthly": 25
        }
      },
      {
        "quantity": 3,
        "price": {
          "hourly": 0.0525,
          "monthly": 35
        }
      }
    ],
    "mongodb": [
      {
        "quantity": 1,
        "price": {
          "hourly": 0.0225,
          "monthly": 15
        }
      },
      {
        "quantity": 2,
        "price": {
          "hourly": 0.045,
          "monthly": 30
        }
      },
      {
        "quantity": 3,
        "price": {
          "hourly": 0.0675,
          "monthly": 45
        }
      }
    ]
  },
  "memory": 1024,
  "disk": 25600,
  "vcpus": 1,
  "class": "nanode"
}
```

Will produce this output:

```
┌─────────────┬────────────────────┬────────────┬──────────┬────────┬─────────┐
│ id          │ label              │ _split     │ quantity │ hourly │ monthly │
├─────────────┼────────────────────┼────────────┼──────────┼────────┼─────────┤
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mysql      │ 1        │ 0.0225 │ 15.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mysql      │ 2        │ 0.0375 │ 25.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mysql      │ 3        │ 0.0525 │ 35.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ postgresql │ 1        │ 0.0225 │ 15.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ postgresql │ 2        │ 0.0375 │ 25.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ postgresql │ 3        │ 0.0525 │ 35.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mongodb    │ 1        │ 0.0225 │ 15.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mongodb    │ 2        │ 0.045  │ 30.0    │
│ g6-nanode-1 │ DBaaS - Nanode 1GB │ mongodb    │ 3        │ 0.0675 │ 45.0    │
└─────────────┴────────────────────┴────────────┴──────────┴────────┴─────────┘
```

This is one row per engine/quantity pair, as the nested lists are
defined as `engines.mysql, engines.postgresql, engines.mongodb`.

This adds a new value to flattened objects with nested lists, called
`_split`, which is the last value in the nested list path that was split
on.  If included in an `x-linode-cli-use-schema` extension, this can be
used to display the key it was split on, to help clarify which list (of
multiple) that row came from.
