### PR TITLE
feat: add examples from OAS to --help prompt

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -559,13 +559,13 @@ def main():
                             arg.description,
                         )
                     )
-                    arg_example = f' --{arg.path}="{arg.example}"'
+                    arg_example = ' --{}="{}"'.format(arg.path, arg.example)
                     examples.append(arg_example)
                 example = "".join(examples)
                 print()
                 print("Example:")
                 print(
-                    f"  linode-cli {parsed.command} {parsed.action} {example}", end=""
+                    "  linode-cli {} {} {}".format(parsed.command, parsed.action, example)
                 )
 
             elif operation.method == "get" and parsed.action == "list":

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -547,6 +547,7 @@ def main():
             print(operation.summary)
             print()
             if operation.args:
+                examples = []
                 print("Arguments:")
                 for arg in sorted(operation.args, key=lambda s: not s.required):
                     print(
@@ -558,6 +559,15 @@ def main():
                             arg.description,
                         )
                     )
+                    arg_example = f' --{arg.path}="{arg.example}"'
+                    examples.append(arg_example)
+                example = "".join(examples)
+                print()
+                print("Example:")
+                print(
+                    f"  linode-cli {parsed.command} {parsed.action} {example}", end=""
+                )
+
             elif operation.method == "get" and parsed.action == "list":
                 filterable_attrs = [
                     attr for attr in operation.response_model.attrs if attr.filterable

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -107,6 +107,7 @@ class CLI:
             args[path] = {
                 "type": info.get("type") or "string",
                 "desc": info.get("description") or "",
+                "example": info.get("example") or "",
                 "name": arg,
                 "format": info.get("x-linode-cli-format", info.get("format", None)),
             }
@@ -317,6 +318,7 @@ class CLI:
                             info["desc"].split(".")[0] + ".",
                             arg,
                             info["format"],
+                            info["example"],
                             list_item=info.get("list_item"),
                         )
 

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -99,11 +99,14 @@ class CLIArg:
     are defined in a requestBody in the api spec.
     """
 
-    def __init__(self, name, arg_type, description, path, arg_format, list_item=None):
+    def __init__(
+        self, name, arg_type, description, path, arg_format, example, list_item=None
+    ):
         self.name = name
         self.arg_type = arg_type
         self.arg_format = arg_format
         self.description = description.replace("\n", "").replace("\r", "")
+        self.example = example
         self.path = path
         self.arg_item_type = None  # populated during baking for arrays
         self.required = False  # this is set during baking
@@ -178,6 +181,7 @@ class CLIOperation:
         parser = argparse.ArgumentParser(
             prog="linode-cli {} {}".format(self.command, self.action),
             description=self.summary,
+            example=self.example,
         )
         for param in self.params:
             parser.add_argument(


### PR DESCRIPTION
This will output the examples provided in the openapi spec to the --help prompt. For example:

```
linodecli linodes create --help 
linode-cli linodes create
Linode Create

Arguments:
  --type: (required) The [Linode Type](/docs/api/linode-types/#types-list) of the Linode you are creating.
...

Example:
  linode-cli linodes create  --type="g6-standard-2" --region="us-east" --image="linode/debian9" --root_pass="aComplexP@ssword" --authorized_keys="['ssh-rsa AAAA_valid_public_ssh_key_123456785== user@their-computer']" --authorized_users="['myUser', 'secondaryUser']" --stackscript_id="10079" --stackscript_data="{'gh_username': 'linode'}" --booted="" --backup_id="1234" --backups_enabled="" --swap_size="512" --label="linode123" --tags="['example tag', 'another example']" --group="Linode-Group" --private_ip="True" --interfaces.label="example-interface" --interfaces.ipam_address="10.0.0.1/24" --interfaces.purpose="vlan"
```