### PR TITLE
add examples from docs

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -559,13 +559,13 @@ def main():
                             arg.description,
                         )
                     )
-                    arg_example = f' --{arg.path}="{arg.example}"'
+                    arg_example = ' --{}="{}"'.format(arg.path, arg.example)
                     examples.append(arg_example)
                 example = "".join(examples)
                 print()
                 print("Example:")
                 print(
-                    f"  linode-cli {parsed.command} {parsed.action} {example}", end=""
+                    "  linode-cli {} {} {}".format(parsed.command, parsed.action, example)
                 )
 
             elif operation.method == "get" and parsed.action == "list":

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -547,7 +547,6 @@ def main():
             print(operation.summary)
             print()
             if operation.args:
-                examples = []
                 print("Arguments:")
                 for arg in sorted(operation.args, key=lambda s: not s.required):
                     print(
@@ -559,14 +558,10 @@ def main():
                             arg.description,
                         )
                     )
-                    arg_example = ' --{}="{}"'.format(arg.path, arg.example)
-                    examples.append(arg_example)
-                example = "".join(examples)
-                print()
-                print("Example:")
-                print(
-                    "  linode-cli {} {} {}".format(parsed.command, parsed.action, example)
-                )
+                if operation.example:
+                    print()
+                    print("Example:")
+                    print(operation.example)
 
             elif operation.method == "get" and parsed.action == "list":
                 filterable_attrs = [

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -547,6 +547,7 @@ def main():
             print(operation.summary)
             print()
             if operation.args:
+                examples = []
                 print("Arguments:")
                 for arg in sorted(operation.args, key=lambda s: not s.required):
                     print(
@@ -558,6 +559,15 @@ def main():
                             arg.description,
                         )
                     )
+                    arg_example = f' --{arg.path}="{arg.example}"'
+                    examples.append(arg_example)
+                example = "".join(examples)
+                print()
+                print("Example:")
+                print(
+                    f"  linode-cli {parsed.command} {parsed.action} {example}", end=""
+                )
+
             elif operation.method == "get" and parsed.action == "list":
                 filterable_attrs = [
                     attr for attr in operation.response_model.attrs if attr.filterable

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -107,6 +107,7 @@ class CLI:
             args[path] = {
                 "type": info.get("type") or "string",
                 "desc": info.get("description") or "",
+                "example": info.get("example") or "",
                 "name": arg,
                 "format": info.get("x-linode-cli-format", info.get("format", None)),
             }
@@ -317,6 +318,7 @@ class CLI:
                             info["desc"].split(".")[0] + ".",
                             arg,
                             info["format"],
+                            info["example"],
                             list_item=info.get("list_item"),
                         )
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -107,7 +107,6 @@ class CLI:
             args[path] = {
                 "type": info.get("type") or "string",
                 "desc": info.get("description") or "",
-                "example": info.get("example") or "",
                 "name": arg,
                 "format": info.get("x-linode-cli-format", info.get("format", None)),
             }
@@ -210,6 +209,13 @@ class CLI:
                         continue
 
                     summary = data[m].get("summary") or ""
+                    example = None
+
+                    if "x-code-samples" in data[m]:
+                        for c in data[m]["x-code-samples"]:
+                            if "lang" in c and c["lang"].lower() == "cli" and "source" in c:
+                                example = c["source"]
+                                break
 
                     use_servers = (
                         [c["url"] for c in data[m]["servers"]]
@@ -318,7 +324,6 @@ class CLI:
                             info["desc"].split(".")[0] + ".",
                             arg,
                             info["format"],
-                            info["example"],
                             list_item=info.get("list_item"),
                         )
 
@@ -358,6 +363,7 @@ class CLI:
                         use_params,
                         use_servers,
                         allowed_defaults=allowed_defaults,
+                        example=example,
                     )
 
         # remove any empty commands (those that have no actions)

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -99,11 +99,14 @@ class CLIArg:
     are defined in a requestBody in the api spec.
     """
 
-    def __init__(self, name, arg_type, description, path, arg_format, list_item=None):
+    def __init__(
+        self, name, arg_type, description, path, arg_format, example, list_item=None
+    ):
         self.name = name
         self.arg_type = arg_type
         self.arg_format = arg_format
         self.description = description.replace("\n", "").replace("\r", "")
+        self.example = example
         self.path = path
         self.arg_item_type = None  # populated during baking for arrays
         self.required = False  # this is set during baking
@@ -178,6 +181,7 @@ class CLIOperation:
         parser = argparse.ArgumentParser(
             prog="linode-cli {} {}".format(self.command, self.action),
             description=self.summary,
+            example=self.example,
         )
         for param in self.params:
             parser.add_argument(

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -100,13 +100,12 @@ class CLIArg:
     """
 
     def __init__(
-        self, name, arg_type, description, path, arg_format, example, list_item=None
+        self, name, arg_type, description, path, arg_format, list_item=None
     ):
         self.name = name
         self.arg_type = arg_type
         self.arg_format = arg_format
         self.description = description.replace("\n", "").replace("\r", "")
-        self.example = example
         self.path = path
         self.arg_item_type = None  # populated during baking for arrays
         self.required = False  # this is set during baking
@@ -150,6 +149,7 @@ class CLIOperation:
         params,
         servers,
         allowed_defaults=None,
+        example=None,
     ):
         self.command = command
         self.action = action
@@ -161,6 +161,7 @@ class CLIOperation:
         self.params = params
         self.servers = servers
         self.allowed_defaults = allowed_defaults
+        self.example = example
 
     @property
     def url(self):


### PR DESCRIPTION
- feat: add examples from OAS to --help prompt
- Still haven't dropped python2 support yet :(
- Use examples from the API Docs if present
