### PR TITLE
fix: Allow '(required)' on help page for put endpoints

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -553,7 +553,7 @@ def main():
                         "  --{}: {}{}".format(
                             arg.path,
                             "(required) "
-                            if operation.method == "post" and arg.required
+                            if operation.method in {"post", "put"} and arg.required
                             else "",
                             arg.description,
                         )


### PR DESCRIPTION
Although uncommon, there are a few cases where `PUT` endpoints have required fields. This change allows those fields to be properly represented in the `--help` page for update operations.