### PR TITLE
allowing default for Authorized_Users in Linode:Create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ install: check-prerequisites requirements build
 
 .PHONY: build
 build: clean
-	python -m linodecli bake ${SPEC} --skip-config
+#	python -m linodecli bake ${SPEC} --skip-config
 	python3 -m linodecli bake ${SPEC} --skip-config
-	cp data-2 linodecli/
+#	cp data-2 linodecli/
 	cp data-3 linodecli/
 	$(PYCMD) setup.py bdist_wheel --universal
 

--- a/README.rst
+++ b/README.rst
@@ -144,11 +144,13 @@ log out of cloud.linode.com before configuring a second user.
 Suppressing Defaults
 """"""""""""""""""""
 
-If you configured default values for ``image``, ``region``, and Linode ``type``, they
-will be sent for all requests that accept them if you do not specify a different
-value.  If you want to send a request *without* these arguments, you must invoke
-the CLI with the ``--no-defaults`` option.  For example, to create a Linode with
-no ``image`` after a default Image has been configured, you would do this::
+If you configured default values for ``image``, ``authorized_keys``, ``region``,
+and Linode ``type``, they will be sent for all requests that accept them if you
+do not specify a different value.  If you want to send a request *without* these
+arguments, you must invoke the CLI with the ``--no-defaults`` option.
+
+For example, to create a Linode with no ``image`` after a default Image has been
+configured, you would do this::
 
    linode-cli linodes create --region us-east --type g5-standard-2 --no-defaults
 
@@ -420,8 +422,8 @@ added to Linode's OpenAPI spec:
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 |x-linode-cli-skip            | path        | If present and truthy, this method will not be available in the CLI.                      |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
-+x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request.  Value values are "region", |
-+                             |             | "image", and "type".                                                                      |
++x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request. Valid defaults are "region",|
++                             |             | "image", "authorized_keys", and "type".                                                   |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 +x-linode-cli-nested-list     | content-type| Tells the CLI to flatten a single object into multiple table rows based on the keys       |
 |                             |             | included in this value.  Values should be comma-delimited JSON paths, and must all be     |

--- a/README.rst
+++ b/README.rst
@@ -443,7 +443,7 @@ added to Linode's OpenAPI spec:
 |x-linode-cli-skip            | path        | If present and truthy, this method will not be available in the CLI.                      |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 +x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request. Valid defaults are "region",|
-+                             |             | "image", "authorized_keys", and "type".                                                   |
++                             |             | "image", "authorized_users", and "type".                                                  |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 +x-linode-cli-nested-list     | content-type| Tells the CLI to flatten a single object into multiple table rows based on the keys       |
 |                             |             | included in this value.  Values should be comma-delimited JSON paths, and must all be     |

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ and an outbound policy of ``ACCEPT``, you can execute the following::
 Suppressing Defaults
 """"""""""""""""""""
 
-If you configured default values for ``image``, ``authorized_keys``, ``region``,
+If you configured default values for ``image``, ``authorized_users``, ``region``,
 and Linode ``type``, they will be sent for all requests that accept them if you
 do not specify a different value.  If you want to send a request *without* these
 arguments, you must invoke the CLI with the ``--no-defaults`` option.

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -569,12 +569,18 @@ Note that no token will be saved in your configuration file.
             "Please select a valid Image, or press Enter to skip",
         )
 
-        config["authorized_keys"] = self._default_thing_input(
-            "Default SSH Key to deploy with new Linodes.",
-            authorized_keys,
-            "Default SSH Key (Optional): ",
-            "Please select a valid SSH Key, or press Enter to skip",
-        )
+        res = self._do_get_request("/profile/sshkeys", token=config["token"])
+        if res['data']:
+            config["use_profile_ssh_keys"] = self._default_thing_input(
+                "If true use the ssh keys added to your Linode Profile for new Linode Instances.",
+                [True,False],
+                "Default Option (Optional): ",
+                "Please select a valid Option, or press Enter to skip",
+            )
+
+        # check if there are ssh keys added to the profile
+        # if so offer the option to default use the profiles ssh keys for linodes
+        # set config["use_ssh_keys"] true/false
 
         # save off the new configuration
         if username != "DEFAULT" and not self.config.has_section(username):

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -545,7 +545,7 @@ Note that no token will be saved in your configuration file.
         regions = [r["id"] for r in self._do_get_request("/regions")["data"]]
         types = [t["id"] for t in self._do_get_request("/linode/types")["data"]]
         images = [i["id"] for i in self._do_get_request("/images")["data"]]
-        sshkeys = [s["label"] for s in self._do_get_request("/profile/sshkeys")["data"]]
+        authorized_keys = [s["label"] for s in self._do_get_request("/profile/sshkeys", token=config["token"])["data"]]
 
         # get the preferred things
         config["region"] = self._default_thing_input(
@@ -569,9 +569,9 @@ Note that no token will be saved in your configuration file.
             "Please select a valid Image, or press Enter to skip",
         )
 
-        config["sshkey"] = self._default_thing_input(
+        config["authorized_keys"] = self._default_thing_input(
             "Default SSH Key to deploy with new Linodes.",
-            sshkeys,
+            authorized_keys,
             "Default SSH Key (Optional): ",
             "Please select a valid SSH Key, or press Enter to skip",
         )
@@ -734,7 +734,7 @@ Note that no token will be saved in your configuration file.
                 self.config.set(username, "region", self.config.get("DEFAULT", "region"))
                 self.config.set(username, "type", self.config.get("DEFAULT", "type"))
                 self.config.set(username, "image", self.config.get("DEFAULT", "image"))
-                self.config.set(username, "sshkey", self.config.get("DEFAULT", "sshkey"))
+                self.config.set(username, "authorized_keys", self.config.get("DEFAULT", "authorized_keys"))
 
                 self.write_config(silent=True)
             else:

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -545,6 +545,7 @@ Note that no token will be saved in your configuration file.
         regions = [r["id"] for r in self._do_get_request("/regions")["data"]]
         types = [t["id"] for t in self._do_get_request("/linode/types")["data"]]
         images = [i["id"] for i in self._do_get_request("/images")["data"]]
+        sshkeys = [s["label"] for s in self._do_get_request("/profile/sshkeys")["data"]]
 
         # get the preferred things
         config["region"] = self._default_thing_input(
@@ -566,6 +567,13 @@ Note that no token will be saved in your configuration file.
             images,
             "Default Image (Optional): ",
             "Please select a valid Image, or press Enter to skip",
+        )
+
+        config["sshkey"] = self._default_thing_input(
+            "Default SSH Key to deploy with new Linodes.",
+            sshkeys,
+            "Default SSH Key (Optional): ",
+            "Please select a valid SSH Key, or press Enter to skip",
         )
 
         # save off the new configuration
@@ -723,11 +731,10 @@ Note that no token will be saved in your configuration file.
                 self.config.set("DEFAULT", "default-user", username)
                 self.config.add_section(username)
                 self.config.set(username, "token", token)
-                self.config.set(
-                    username, "region", self.config.get("DEFAULT", "region")
-                )
+                self.config.set(username, "region", self.config.get("DEFAULT", "region"))
                 self.config.set(username, "type", self.config.get("DEFAULT", "type"))
                 self.config.set(username, "image", self.config.get("DEFAULT", "image"))
+                self.config.set(username, "sshkey", self.config.get("DEFAULT", "sshkey"))
 
                 self.write_config(silent=True)
             else:

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -543,6 +543,7 @@ Note that no token will be saved in your configuration file.
         regions = [r["id"] for r in self._do_get_request("/regions")["data"]]
         types = [t["id"] for t in self._do_get_request("/linode/types")["data"]]
         images = [i["id"] for i in self._do_get_request("/images")["data"]]
+        auth_users = [u["username"] for u in self._do_get_request("/account/users", token=config["token"])["data"] if "ssh_keys" in u]
 
         # get the preferred things
         config["region"] = self._default_thing_input(
@@ -566,18 +567,13 @@ Note that no token will be saved in your configuration file.
             "Please select a valid Image, or press Enter to skip",
         )
 
-        res = self._do_get_request("/profile/sshkeys", token=config["token"])
-        if 'data' in res:
+        if auth_users:
             config["authorized_users"] = self._default_thing_input(
-                "Do you want to use the following username as a authorized_user on New Linodes?",
-                [username],
-                "Default Option (Optional): ",
-                "Please select a valid Option, or press Enter to skip",
-            )
-
-        # check if there are ssh keys added to the profile
-        # if so offer the option to default use the profiles ssh keys for linodes
-        # set config["use_ssh_keys"] true/false
+                    "Select the user that should be given default SSH access to new Linodes.",
+                    auth_users,
+                    "Default Option (Optional): ",
+                    "Please select a valid Option, or press Enter to skip",
+                )
 
         # save off the new configuration
         if username != "DEFAULT" and not self.config.has_section(username):


### PR DESCRIPTION
Allows users to configure a user to automatically set for Authorized_Users in Linode:Create, when you provide a --authorized_users field it will overwrite the default

resolves [#233] 