### PR TITLE
doc: Add CONTRIBUTING.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: input
+    id: cli-version
+    attributes:
+      label: CLI Version
+      description: What version of linode-cli are you running? `linode-cli -v`
+      placeholder: linode-cli 5.24.0 Built off spec version 4.138.0
+    validations:
+      required: true
+  - type: textarea
+    id: resources
+    attributes:
+      label: Command
+      description: The command executed to encounter this bug. Please ensure that all sensitive data has been removed.
+      placeholder: |
+        volumes attach
+        linodes create
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: The output of the command affected by the bug. Please ensure that all sensitive data has been removed.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: If you are able to reproduce this issue, please list the steps below.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -17,8 +17,7 @@ body:
       label: Command
       description: The command executed to encounter this bug. Please ensure that all sensitive data has been removed.
       placeholder: |
-        volumes attach
-        linodes create
+        linode-cli linodes create --type g6-standard-1 --region us-southeast
   - type: textarea
     id: output
     attributes:
@@ -43,5 +42,3 @@ body:
     attributes:
       label: Steps to Reproduce
       description: If you are able to reproduce this issue, please list the steps below.
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,17 @@
+name: Enhancement
+description: Request a feature
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like this feature to do in detail?
+    validations:
+      required: true
+  - type: textarea
+    id: usage
+    attributes:
+      label: Potential Usage Example
+      description: A small codeblock example of how this feature will be used.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing Guidelines
+
+:+1::tada: First off, we appreciate you taking the time to contribute! THANK YOU! :tada::+1:
+
+We put together the handy guide below to help you get support for your work. Read on!
+
+## I Just Want to Ask the Maintainers a Question
+
+The [Linode Community](https://www.linode.com/community/questions/) is a great place to get additional support.
+
+## How Do I Submit A (Good) Bug Report or Feature Request
+
+Please open a [GitHub issue](../../issues/new/choose) to report bugs or suggest features.
+
+Please accurately fill out the appropriate GitHub issue form.
+
+When filing an issue or feature request, help us avoid duplication and redundant effort -- check existing open or recently closed issues first.
+
+Detailed bug reports and requests are easier for us to work with. Please include the following in your issue:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made, relevant to the bug
+* Anything unusual about your environment or deployment
+* Screenshots and code samples where illustrative and helpful
+
+## How to Open a Pull Request
+
+We follow the [fork and pull model](https://opensource.guide/how-to-contribute/#opening-a-pull-request) for open source contributions.
+
+Tips for a faster merge:
+* address one feature or bug per pull request.
+* large formatting changes make it hard for us to focus on your work.
+* follow language coding conventions.
+* make sure that tests pass.
+* make sure your commits are atomic, [addressing one change per commit](https://chris.beams.io/posts/git-commit/).
+* add tests!
+
+## Code of Conduct
+
+This project follows the [Linode Community Code of Conduct](https://www.linode.com/community/questions/conduct).
+
+## Vulnerability Reporting
+
+If you discover a potential security issue in this project we ask that you notify Linode Security via our [vulnerability reporting process](https://hackerone.com/linode). Please do **not** create a public github issue.
+
+## Licensing
+
+See the [LICENSE file](/LICENSE) for our project's licensing.

--- a/README.rst
+++ b/README.rst
@@ -396,6 +396,10 @@ Contributing
 This CLI is generated based on the OpenAPI specification for Linode's API.  As
 such, many changes are made directly to the spec.
 
+Please follow the `Contributing Guidelines`_ when making a contribution.
+
+.. _Contributing Guidelines: https://github.com/linode/linode-cli/blob/master/CONTRIBUTING.md
+
 Specification Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This change adds the standard Linode `CONTRIBUTING.md` file as well as various templates for creating issues. This follows the layout of other Linode org repositories (see: [terraform-provider-linode](https://github.com/linode/terraform-provider-linode), [ansible_linode](https://github.com/linode/ansible_linode))