### PR TITLE
linuke-keep safeguard for tests

### DIFF
--- a/test/clean-accounts.sh
+++ b/test/clean-accounts.sh
@@ -10,12 +10,12 @@ for i in "${CLEAN_TARGETS[@]}"; do
     deleteCmd="delete"
 
     if [ "${i}" = "stackscripts" ] || [ "${i}" = "images" ]; then
-        ENTITIES=( $(linode-cli "${i}" list --is_public false --text --no-headers --format "id" --delimiter " ") )
+        ENTITIES=( $(linode-cli "${i}" list --is_public false --text --no-headers --format "id,tags" --delimiter " " | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )
     elif [ "${i}" == "lke" ]; then
-        ENTITIES=( $(linode-cli "${i}" clusters-list --text --no-headers --format "id" --delimiter " ") )
+        ENTITIES=( $(linode-cli "${i}" clusters-list --text --no-headers --format "id,tags" --delimiter " " | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )
         deleteCmd="cluster-delete"
     else
-        ENTITIES=( $(linode-cli "${i}" list --text --no-headers --format "id" --delimiter " ") )
+        ENTITIES=( $(linode-cli "${i}" list --text --no-headers --format "id,tags" --delimiter " " | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )
     fi
 
     declare ENTITIES

--- a/test/common.bash
+++ b/test/common.bash
@@ -52,7 +52,7 @@ createVolume() {
 }
 
 shutdownLinodes() {
-    local linode_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs) )"
+    local linode_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers linodes list --format "id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )"
     local id
 
     for id in $linode_ids ; do
@@ -61,7 +61,7 @@ shutdownLinodes() {
 }
 
 removeLinodes() {
-    local linode_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs) )"
+    local linode_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers linodes list --format "id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )"
     local id
 
     for id in $linode_ids ; do
@@ -70,7 +70,7 @@ removeLinodes() {
 }
 
 removeDomains() {
-    local domain_ids="( $( linode-cli domains list --format "id" --text --no-headers ) )"
+    local domain_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers domains list --format "id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' |  xargs) )"
     local id
 
     for id in $domain_ids ; do
@@ -80,7 +80,7 @@ removeDomains() {
 }
 
 removeVolumes() {
-    local volume_ids="( $(linode-cli volumes list --text --no-headers --format="id" | xargs) )"
+    local volume_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers volumes list --format "id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' |  xargs) )"
     local id
 
     for id in $volume_ids ; do
@@ -89,7 +89,7 @@ removeVolumes() {
 }
 
 removeLkeClusters() {
-    local cluster_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers lke clusters-list | awk '{ print $1 }' | xargs) )"
+    local cluster_ids="( $(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli --text --no-headers lke clusters-list --format "id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' |  xargs) )"
     local id
 
     for id in $cluster_ids ; do
@@ -99,9 +99,9 @@ removeLkeClusters() {
 
 removeAll() {
     if [ "$1" = "stackscripts" ]; then
-        entity_ids="( $(linode-cli $1 list --is_public=false --text --no-headers --format="id" | xargs) )"
+        entity_ids="( $(linode-cli --is_public=false --text --no-headers $1 list --format="id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )"
     else
-        entity_ids="( $(linode-cli $1 list --text --no-headers --format="id" | xargs) )"
+        entity_ids="( $(linode-cli --text --no-headers $1 list --format="id,tags" | grep -v "linuke-keep" | awk '{ print $1 }' | xargs) )"
     fi
 
     local id

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -27,14 +27,14 @@ fi
 
 if [[ $* != *"--allow-delete-resources"* && $* != *"--force"* && $* != *"-f"* ]]; then
     echo -e "\n ####WARNING!#### \n"
-    echo -e  "Running the Linode CLI tests requires removing all resources on your account\n"
+    echo -e  "Running the Linode CLI tests requires removing all resources not tagged \"linuke-keep\" on your account\n"
     echo -e "Run this command with the --allow-delete-resources flag to accept this fate\n"
     exit 1
 fi
 
 if [[ $* =~ "--allow-delete-resources" ]]; then
     echo -e "\n\n"
-    read -p "WARNING: Running the Linode CLI tests will REMOVE ALL account data. Are you sure? (y/n) " -n 1 -r
+    read -p "WARNING: Running the Linode CLI tests will REMOVE ALL RESOURCES not tagged with \"linuke-keep\" on your account. Are you sure? (y/n) " -n 1 -r
     echo
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     	echo "Phew, that was a close one!"


### PR DESCRIPTION
Allows us to use "linuke-keep" tag on Linode objects to prevent it from being automatically deleted by a test. Useful for testing on a Linode Account that has long term configurations for other work.