### PR TITLE
new: Add support for action aliasing

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -519,7 +519,8 @@ def main():
             print("linode-cli {} [ACTION]".format(parsed.command))
             print()
             print("Available actions: ")
-            content = [[action, op.summary] for action, op in actions.items()]
+
+            content = [[', '.join([action, *op.action_aliases]), op.summary] for action, op in actions.items()]
 
             header = ["action", "summary"]
             table = SingleTable([header] + content)

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -18,7 +18,7 @@ from .response import ModelAttr, ResponseModel
 
 METHODS = ("get", "post", "put", "delete")
 PIP_CMD = "pip3" if version_info.major == 3 else "pip"
-ACTION_SEPARATOR = ", "
+ACTION_DELIMITER = ", "
 
 class CLI:
     """
@@ -347,7 +347,7 @@ class CLI:
                             )
                             p.name += "_"
 
-                    self.ops[command][ACTION_SEPARATOR.join(action)] = CLIOperation(
+                    self.ops[command][ACTION_DELIMITER.join(action)] = CLIOperation(
                         command,
                         action[0],
                         m,
@@ -417,7 +417,7 @@ complete -F _linode_cli linode-cli"""
                 # Ensure that action aliases are separated
                 command=op, actions=" ".join([
                     act for action_key in actions.keys()
-                    for act in action_key.split(ACTION_SEPARATOR)])
+                    for act in action_key.split(ACTION_DELIMITER)])
             )
             for op, actions in self.ops.items()
         ]
@@ -683,7 +683,7 @@ complete -F _linode_cli linode-cli"""
 
         operation = None
         for name, op in self.ops[command].items():
-            if action in name.split(ACTION_SEPARATOR):
+            if action in name.split(ACTION_DELIMITER):
                 operation = op
 
         if operation is None:

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -207,6 +207,9 @@ class CLI:
                         print("warn: no operationId for {} {}".format(m.upper(), path))
                         continue
 
+                    if not isinstance(action, list):
+                        action = [action]
+
                     summary = data[m].get("summary") or ""
 
                     use_servers = (
@@ -344,9 +347,9 @@ class CLI:
                             )
                             p.name += "_"
 
-                    self.ops[command][action] = CLIOperation(
+                    self.ops[command][', '.join(action)] = CLIOperation(
                         command,
-                        action,
+                        action[0],
                         m,
                         use_path,
                         summary,
@@ -668,14 +671,19 @@ complete -F _linode_cli linode-cli"""
         Given a command, action, and remaining kwargs, finds and executes the
         action
         """
+
         if command not in self.ops:
             print("Command not found: {}".format(command))
             exit(1)
-        elif action not in self.ops[command]:
+
+        operation = None
+        for name, op in self.ops[command].items():
+            if action in name.split(', '):
+                operation = op
+
+        if operation is None:
             print("No action {} for command {}".format(action, command))
             exit(1)
-
-        operation = self.ops[command][action]
 
         result = self.do_request(operation, args)
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -211,6 +211,7 @@ class CLI:
                     if isinstance(action, list):
                         if len(action) < 1:
                             print("warn: empty list for action {}".format(m.upper()))
+                            continue
 
                         action_aliases = action[1:]
                         action = action[0]

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -18,7 +18,7 @@ from .response import ModelAttr, ResponseModel
 
 METHODS = ("get", "post", "put", "delete")
 PIP_CMD = "pip3" if version_info.major == 3 else "pip"
-
+ACTION_SEPARATOR = ", "
 
 class CLI:
     """
@@ -347,7 +347,7 @@ class CLI:
                             )
                             p.name += "_"
 
-                    self.ops[command][', '.join(action)] = CLIOperation(
+                    self.ops[command][ACTION_SEPARATOR.join(action)] = CLIOperation(
                         command,
                         action[0],
                         m,
@@ -414,14 +414,19 @@ complete -F _linode_cli linode-cli"""
 
         command_blocks = [
             command_template.safe_substitute(
-                command=op, actions=" ".join([act for act in actions.keys()])
+                # Ensure that action aliases are separated
+                command=op, actions=" ".join([
+                    v for act in actions.keys()
+                    for v in act.split(ACTION_SEPARATOR)])
             )
             for op, actions in self.ops.items()
         ]
+
         rendered = completion_template.safe_substitute(
             actions=" ".join(self.ops.keys()),
             command_items="\n        ".join(command_blocks),
         )
+
         return rendered
 
     def bake_completions(self):
@@ -678,7 +683,7 @@ complete -F _linode_cli linode-cli"""
 
         operation = None
         for name, op in self.ops[command].items():
-            if action in name.split(', '):
+            if action in name.split(ACTION_SEPARATOR):
                 operation = op
 
         if operation is None:

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -416,8 +416,8 @@ complete -F _linode_cli linode-cli"""
             command_template.safe_substitute(
                 # Ensure that action aliases are separated
                 command=op, actions=" ".join([
-                    v for act in actions.keys()
-                    for v in act.split(ACTION_SEPARATOR)])
+                    act for action_key in actions.keys()
+                    for act in action_key.split(ACTION_SEPARATOR)])
             )
             for op, actions in self.ops.items()
         ]

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -146,6 +146,7 @@ class CLIOperation:
         params,
         servers,
         allowed_defaults=None,
+        action_aliases=None,
     ):
         self.command = command
         self.action = action
@@ -157,6 +158,7 @@ class CLIOperation:
         self.params = params
         self.servers = servers
         self.allowed_defaults = allowed_defaults
+        self.action_aliases = action_aliases or []
 
     @property
     def url(self):


### PR DESCRIPTION
This change adds support for aliasing actions by defining multiple values for the `x-linode-cli-action` in the API spec.

For example, for GET `/linode/instances`:

```
x-linode-cli-action:
  - list
  - ls
```

would allow users to run either

```
linode-cli linodes ls
```

or 

```
linode-cli linodes list
```

Additionally, all aliases will be displayed on the help page as shown below:

![image](https://user-images.githubusercontent.com/114949949/199532107-5044c554-6fbe-4704-9033-daed2d21efde.png)

See #149, https://github.com/linode/linode-api-docs/pull/708
