### PR TITLE
fix: Do not handle `--as-user` if config is not loaded

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -174,7 +174,7 @@ def main():
     if not cli.suppress_warnings:
         warn_python2_eol()
 
-    if parsed.as_user:
+    if parsed.as_user and not skip_config:
         # if they are acting as a non-default user, set it up early
         cli.config.set_user(parsed.as_user)
 


### PR DESCRIPTION
This change resolves an issue that suggests a user is not properly configured when the config is not properly loaded. Particularly, this affects `--help`, `--version`, and `--skip-config` flags when `--as-user` is defined.

Resolves #309 