### PR TITLE
output: print default values being used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,5 @@ check-prerequisites:
 clean:
 	rm -f linodecli/data-*
 	rm -f linode-cli.sh
-	rm -f dist/*
+	rm -f data-*
+	rm -rf dist

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -127,8 +127,8 @@ class CLIConfig:
             if k in ns_dict and ns_dict[k] is None:
                 warn_dict[k] = new_dict[k]
                 ns_dict[k] = new_dict[k]
-
-        print("using default values: {}, use --no-defaults flag to disable defaults".format(warn_dict))
+        if not any(x in ['--suppress-warnings', '--no-headers'] for x in sys.argv):
+            print("using default values: {}, use --no-defaults flag to disable defaults".format(warn_dict))
         return argparse.Namespace(**ns_dict)
 
     def update(self, namespace, allowed_defaults):

--- a/linodecli/configuration.py
+++ b/linodecli/configuration.py
@@ -115,14 +115,17 @@ class CLIConfig:
         then reconstruct it with the exploded dict.
         """
         ns_dict = vars(namespace)
+        warn_dict = {}
         for k in new_dict:
             if k.startswith("plugin-"):
                 # plugins set config options that start with 'plugin-' - these don't
                 # get included in the updated namespace
                 continue
             if k in ns_dict and ns_dict[k] is None:
+                warn_dict[k] = new_dict[k]
                 ns_dict[k] = new_dict[k]
 
+        print("using default values: {}, use --no-defaults flag to disable defaults".format(warn_dict))
         return argparse.Namespace(**ns_dict)
 
     def update(self, namespace, allowed_defaults):


### PR DESCRIPTION
- warn users when using defaults which values are being used
- warning can be suppressed with `--no-headers` and `--suppress-warnings`
- added missing artifact to make clean

![example](https://user-images.githubusercontent.com/87780794/200411799-9d209cb8-de1d-4772-a15d-ea02e0889b52.png)

resolves [#58]