### PR TITLE
new: Link to endpoint documentation in command help page

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -543,6 +543,8 @@ def main():
                 print(" [{}]".format(pname), end="")
             print()
             print(operation.summary)
+            if operation.docs_url:
+                print(f"API Documentation: {operation.docs_url}")
             print()
             if operation.args:
                 print("Arguments:")

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -220,12 +220,12 @@ class CLI:
                     summary = data[m].get("summary") or ""
 
                     # Resolve the documentation URL
+                    docs_url = None
                     tags = data[m].get("tags")
                     if tags is not None and len(tags) > 0 and len(summary) > 0:
                         tag_path = self._flatten_url_path(tags[0])
                         summary_path = self._flatten_url_path(summary)
-
-                        summary += f"\nAPI Documentation: https://www.linode.com/docs/api/{tag_path}/#{summary_path}"
+                        docs_url = f"https://www.linode.com/docs/api/{tag_path}/#{summary_path}"
 
                     use_servers = (
                         [c["url"] for c in data[m]["servers"]]
@@ -372,6 +372,7 @@ class CLI:
                         response_model,
                         use_params,
                         use_servers,
+                        docs_url=docs_url,
                         allowed_defaults=allowed_defaults,
                         action_aliases=action_aliases,
                     )

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import re
 from distutils.version import LooseVersion, StrictVersion
-from string import Template, digits, ascii_lowercase
+from string import Template
 from sys import exit, prefix, stderr, version_info
 
 import requests

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -145,6 +145,7 @@ class CLIOperation:
         response_model,
         params,
         servers,
+        docs_url=None,
         allowed_defaults=None,
         action_aliases=None,
     ):
@@ -157,6 +158,7 @@ class CLIOperation:
         self.response_model = response_model
         self.params = params
         self.servers = servers
+        self.docs_url = docs_url
         self.allowed_defaults = allowed_defaults
         self.action_aliases = action_aliases or []
 


### PR DESCRIPTION
This change allows the CLI to automatically bake API documentation URLs into command help pages. This is useful for providing additional documentation that may not already be available through the help page.

![image](https://user-images.githubusercontent.com/26882005/200626593-b964f09b-4cb6-4641-8c3c-4020a00571cc.png)

Resolves #247