### PR TITLE
fix: Install `boto` in OCI image Dockerfile

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -16,7 +16,7 @@ FROM python:3.9-slim-buster
 
 COPY --from=builder /src/dist /dist
 
-RUN pip3 install /dist/*.whl
+RUN pip3 install boto /dist/*.whl boto==2.49.0
 
 RUN useradd -ms /bin/bash cli
 USER cli:cli


### PR DESCRIPTION
This change installs the `boto` package during the OCI image build process. This is necessary for running the `obj` plugin. 