### PR TITLE
fix: Gracefully handle empty endpoint responses

### DIFF
--- a/linodecli/response.py
+++ b/linodecli/response.py
@@ -79,7 +79,7 @@ class ModelAttr:
         # walk down json paths to find the value
         value = model
         for part in self.name.split("."):
-            if value is None:
+            if value is None or value == {}:
                 return None
             value = value[part]
 


### PR DESCRIPTION
This change adds an additional condition for gracefully handling empty (`{}`) endpoint dict responses. This resolves errors thrown when executing command such as `linode-cli longview plan-view` using the default plan type.

Resolves #220 