### PR TITLE
fix: Drop VOLUME from OCI image

### DIFF
--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -16,11 +16,10 @@ FROM python:3.9-slim-buster
 
 COPY --from=builder /src/dist /dist
 
-RUN pip3 install boto /dist/*.whl boto==2.49.0
+RUN pip3 install /dist/*.whl boto==2.49.0
 
 RUN useradd -ms /bin/bash cli
 USER cli:cli
 
-VOLUME /home/cli/.config
 
 ENTRYPOINT ["linode-cli"]


### PR DESCRIPTION
This change drops the `VOLUME` instruction from the `Dockerfile-release` file. This is necessary as this instruction often caused permission errors in certain configurations. Users are still able to handle config persistence using volume mounts.