### PR TITLE
doc: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## 📝 Description
+
+**What does this PR do and why is this change necessary?**
+
+## ✔️ How to Test
+
+**What are the steps to reproduce the issue or verify the changes?**
+
+**How do I run the relevant unit/integration tests?**
+
+## 📷 Preview
+
+**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**


### PR DESCRIPTION
## 📝 Description

This change adds a template that will be used by default on new pull requests. This is useful for standardizing the format of our PRs and encouraging detailed PR descriptions.