### PR TITLE
new: Add support for publishing to PyPI through GHA

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Added'
+    label: 'added-feature'
+  - title: '🧰 Changed'
+    label: 'changed'
+  - title: "⚠️ Deprecated"
+    label: "deprecated"
+  - title: "⚠️ Removed"
+    label: "removed"
+  - title: '🐛 Bug Fixes'
+    label: 'bugfix'
+  - title: "⚠️ Security"
+    label: "security"
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+no-changes-template: "- No changes"
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/oci-build.yml
+++ b/.github/workflows/oci-build.yml
@@ -1,8 +1,8 @@
 name: OCI Image Publish
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+' # We only want to run on version tags
+  workflow_dispatch: null
+  release:
+    types: [ published ]
 jobs:
   oci_publish:
     name: Build and publish the OCI image
@@ -10,6 +10,11 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # pin@v2
+
+      - name: setup python 3
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # pin@v2
+        with:
+          python-version: '3.x'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # pin@v2
@@ -23,6 +28,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # This is necessary as we want to ensure that version tags
+      # are properly formatted before passing them into the
+      # DockerFile.
+      - name: Get CLI version
+        run: |
+          export CLI_VERSION=$(./version)
+          echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_OUTPUT
+        env:
+          LINODE_CLI_VERSION: ${{ github.event.release.tag_name }}
+        id: cli_version
+
       - name: Build and push to DockerHub
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # pin@v3
         with:
@@ -30,4 +46,5 @@ jobs:
           file: Dockerfile-release
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: linode/cli:${{ github.ref_name }},linode/cli:latest
+          tags: linode/cli:${{ steps.cli_version.outputs.CLI_VERSION }},linode/cli:latest
+          build-args: linode_cli_version=${{ steps.cli_version.outputs.CLI_VERSION }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,38 @@
+name: release
+on:
+  workflow_dispatch: null
+  release:
+    types: [ published ]
+jobs:
+  pypi-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - name: Update system packages
+        run: sudo apt-get update -y
+
+      - name: Install make
+        run: sudo apt-get install -y build-essential
+
+      - name: Setup Python
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # pin@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: pip install wheel
+
+      - name: Install package requirements
+        run: make requirements
+
+      - name: Build the package
+        run: make build
+        env:
+          LINODE_CLI_VERSION: ${{ github.event.release.tag_name }}
+
+      - name: Publish the release artifacts to PyPI
+        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 # pin@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,5 +1,7 @@
 FROM python:3.9-slim-buster AS builder
 
+ARG linode_cli_version
+
 WORKDIR /src
 
 COPY requirements.txt .
@@ -10,7 +12,7 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN make build
+RUN LINODE_CLI_VERSION=$linode_cli_version make build
 
 FROM python:3.9-slim-buster
 
@@ -20,6 +22,5 @@ RUN pip3 install /dist/*.whl boto==2.49.0
 
 RUN useradd -ms /bin/bash cli
 USER cli:cli
-
 
 ENTRYPOINT ["linode-cli"]

--- a/version
+++ b/version
@@ -9,9 +9,24 @@ import subprocess
 import sys
 from distutils.version import LooseVersion
 
+ENV_LINODE_CLI_VERSION = "LINODE_CLI_VERSION"
+
+
+def get_version_env():
+    return os.getenv(ENV_LINODE_CLI_VERSION)
+
 
 def get_version(ref="HEAD"):
-    describe = call('git describe {} --tags'.format(ref))
+    # We want to override the version if an environment variable is specified.
+    # This is useful for certain release and testing pipelines.
+    describe = get_version_env()
+
+    if describe is None:
+        describe = call('git describe {} --tags'.format(ref))
+
+    # Strip the `v` prefix if specified
+    if describe.startswith("v"):
+        describe = describe[1:]
 
     parts = LooseVersion(describe).version[:3]
     return tuple(parts)


### PR DESCRIPTION
## 📝 Description

This change automates CLI releases through GitHub actions. This includes a release drafter, a new workflow for publishing releases to PyPI, and various changes to the existing OCI publish workflow.

**Releases should be cut using the following steps:**
1. A release is drafted automatically after every commit to `master`
2. Once a release is ready to be cut, a maintainer can simply modify and publish the release drafted in step 1.
3. After the release is published, two jobs will spawn to publish the release artifacts to DockerHub and PyPI respectively.

This release process requires a `PYPI_API_TOKEN` secret be exposed with access to only the `linode-cli` package.

This workflow has been tested against a fork of `linode-cli`.

## ✔️ How to Test

In a private fork of this repo, push up the code from this branch to master. This fork must have the following secrets: `PYPI_API_TOKEN`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`. These secrets should contain credentials for personal PyPI and DockerHub accounts.

In order to prevent attempting to push to the official DockerHub image and PyPI package, the following lines should be altered:

- oci-build.yml line 49
  - Image tags should be under your personal account (e.g. `tags: myaccount/cli:${{ steps.cli_version.outputs.CLI_VERSION }},myaccount/cli:latest`
- setup.py line 37
  -  The package name should be set to an arbitrary unused name (e.g. `linode-cli-publish-test`)

After these changes are pushed up, you should be able to publish an arbitrary release following the steps above.