### PR TITLE
new: Dynamically resolve latest GitHub OpenAPI spec URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 # Makefile for more convenient building of the Linode CLI and its baked content
 #
 
-SPEC ?= https://www.linode.com/docs/api/openapi.yaml
+SPEC_VERSION ?= latest
+ifndef SPEC
+override SPEC = $(shell ./resolve_spec_url ${SPEC_VERSION})
+endif
 
 install: check-prerequisites requirements build
 	ls dist/ | xargs -I{} pip3 install --force dist/{}

--- a/resolve_spec_url
+++ b/resolve_spec_url
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Usage:
+#   ./resolve_latest_spec
+#       Prints the URL of the latest Linode OpenAPI spec on GitHub
+import sys
+
+import requests
+
+LINODE_DOCS_REPO = "linode/linode-api-docs"
+
+
+def get_latest_tag():
+    data = requests.get(f"https://api.github.com/repos/{LINODE_DOCS_REPO}/releases/latest")
+    return data.json()["tag_name"]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Invalid number of arguments: {len(sys.argv)}", file=sys.stderr)
+        exit(1)
+
+    desired_version = sys.argv[1]
+
+    if desired_version.lower() == "latest":
+        desired_version = get_latest_tag()
+
+    print(f"https://raw.githubusercontent.com/{LINODE_DOCS_REPO}/{desired_version}/openapi.yaml")


### PR DESCRIPTION
## 📝 Description

This change alters the Makefile to dynamically resolve the latest OpenAPI spec URL from GitHub. This allows the CLI to be easily built from various spec versions and prevents any inconsistencies between GitHub and https://www.linode.com/docs/api/openapi.yaml.

Everything seems to work as intended from my local testing.

## ✔️ How to Test

### Build the CLI with the latest GitHub spec release

```
make build
```

### Build the CLI with a specific spec version

```
make SPEC_VERSION=v1.139.0 build
```

### Build the CLI from a custom spec URL

```
make SPEC=https://www.linode.com/docs/api/openapi.yaml build
```