### PR TITLE
new: Distribute source dist through PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ install: check-prerequisites requirements build
 build: clean
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-3 linodecli/
-	python3 setup.py bdist_wheel --universal
+	python3 setup.py bdist_wheel
+	python3 setup.py sdist
 
 .PHONY: requirements
 requirements:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ def get_baked_files():
     if path.isfile("linode-cli.sh"):
         data_files.append(("/etc/bash_completion.d", ["linode-cli.sh"]))
 
+    data_files.append(("version", ["./version"]))
+    data_files.append(("resolve_spec_url", ["./resolve_spec_url"]))
+
     return data_files
 
 


### PR DESCRIPTION
## 📝 Description

This change alters the Makefile and `setup.py` to support building and publishing a source dist alongside the wheel file. 

The generated source dist has been tested against an Ubuntu 22.10 environment.

Resolves #328 