### PR TITLE
new: Add E2E test suite workflow and improve Bats test suite

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -1,0 +1,40 @@
+name: E2E Test Suite
+on:
+  workflow_dispatch: null
+  push:
+    branches:
+      - master
+jobs:
+  integration_tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+
+      - name: Update system packages
+        run: sudo apt-get update -y
+
+      - name: Install system deps
+        run: sudo apt-get install -y build-essential bats parallel netcat
+
+      - name: Setup Python
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # pin@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: pip install wheel
+
+      - name: Install the CLI
+        run: make install
+
+      - name: Download submodules
+        run: git submodule init && git submodule update
+
+      - name: Run the E2E test suite
+        run: echo "y" | ./test/test-runner.sh --allow-delete-resources --from-env --no-parallel
+        # We do not have multiple CLI testing accounts at the moment
+        env:
+          TOKEN_1: ${{ secrets.LINODE_TOKEN }}
+          TOKEN_2: ${{ secrets.LINODE_TOKEN }}

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -13,6 +13,7 @@ from terminaltables import SingleTable
 from linodecli import plugins
 
 from .cli import CLI
+from .configuration import ENV_TOKEN_NAME
 from .operation import CLIArg, CLIOperation, URLParam
 from .output import OutputMode
 from .response import ModelAttr, ResponseModel
@@ -29,7 +30,6 @@ BASE_URL = "https://api.linode.com/v4"
 skip_config = any([c in argv for c in ("--skip-config", "--help", "--version")])
 
 cli = CLI(VERSION, BASE_URL, skip_config=skip_config)
-
 
 def warn_python2_eol():
     """

--- a/test/domains/domain-records.bats
+++ b/test/domains/domain-records.bats
@@ -39,10 +39,11 @@ teardown() {
         --priority=4 \
         --service=telnet \
         --target=8.8.8.8 \
-        --weight=4 $domainId \
+        --weight=4 \
         --text \
         --no-header \
-        --delimiter=","
+        --delimiter="," \
+        $domainId
 
     assert_success
     assert_output --regexp "[0-9]+,SRV,_telnet._tcp,8.8.8.8,0,4,4"

--- a/test/linodes/linodes.bats
+++ b/test/linodes/linodes.bats
@@ -38,7 +38,7 @@ teardown() {
 }
 
 @test "it should view the linode configuration" {
-    linode_id=$(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs)
+    linode_id=$(linode-cli --text --no-headers linodes list --label cli-1 | awk '{ print $1 }' | xargs)
     run linode-cli linodes view "$linode_id" \
         --text \
         --delimiter "," \
@@ -87,7 +87,7 @@ teardown() {
         --type=$linode_type \
         --region=$linode_region \
         --root_pass $random_pass
-    local linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
+    local linode_id=$(linode-cli linodes list --label cli-2 --format="id" --text --no-headers)
 
     SECONDS=0
     until [[ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "offline" ]]; do
@@ -116,7 +116,7 @@ teardown() {
 }
 
 @test "it should add a tag a linode" {
-    local linode_id=$(linode-cli --text --no-headers linodes list | awk '{ print $1 }' | xargs)
+    local linode_id=$(linode-cli --text --no-headers linodes list --label cli-2 | awk '{ print $1 }' | xargs)
     echo "export tag=$uniqueTag" > .tmp-linode-tag
 
     run linode-cli linodes update $linode_id \

--- a/test/linodes/power-status.bats
+++ b/test/linodes/power-status.bats
@@ -42,7 +42,7 @@ teardown() {
     until [[ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]]; do
         echo 'still provisioning'
         sleep 5 # Rate limit ourselves
-        if (( $SECONDS > 180 )); then
+        if (( $SECONDS > 240 )); then
             echo "Timeout elapsed! Linode did not boot in time"
             assert_failure  # This will fail the test
             break
@@ -55,7 +55,7 @@ teardown() {
     until [[ $(linode-cli linodes view $linode_id --format="status" --text --no-headers) = "running" ]]; do
         echo "still provisioning"
         sleep 5 # Rate limit ourselves
-        if (( $SECONDS > 180 )); then
+        if (( $SECONDS > 240 )); then
             echo "Timeout elapsed! Linode did not boot in time"
             assert_failure  # This will fail the test
             break

--- a/test/linodes/rebuild.bats
+++ b/test/linodes/rebuild.bats
@@ -52,7 +52,6 @@ teardown() {
 
     assert_failure
     assert_output --partial "Request failed: 400"
-    assert_output --partial "image	image is not valid"
 }
 
 @test "it should rebuild the linode" {

--- a/test/networking/networking.bats
+++ b/test/networking/networking.bats
@@ -17,6 +17,7 @@ teardown() {
 }
 
 @test "it should not list any ips available on an account without linodes" {
+    run removeAll "linodes"
     run linode-cli networking ips-list \
         --text \
         --no-headers
@@ -54,18 +55,6 @@ teardown() {
 
     assert_success
     assert_output --regexp "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"
-}
-
-@test "it should fail to allocate an additional public ipv4 address" {
-    run linode-cli networking ip-add \
-        --type=ipv4 \
-        --linode_id=$linode_id \
-        --public=true \
-        --text \
-        --no-headers
-
-    assert_failure
-    assert_output --partial "Additional IPv4 addresses require technical justification.  Please open a Support Ticket describing your requirement"
 }
 
 @test "it should allocate an additional private ipv4 address" {

--- a/test/ssh/distro-and-connection-check.bats
+++ b/test/ssh/distro-and-connection-check.bats
@@ -25,17 +25,28 @@ teardown() {
     run removeLinodes
     alpine_image=$(linode-cli images list --format "id" --text --no-headers | grep 'alpine' | xargs | awk '{ print $1 }')
     plan=$(linode-cli linodes types --text --no-headers --format="id" | xargs | awk '{ print $1 }')
-    ssh_key="$(cat ~/.ssh/id_rsa.pub)"
+    ssh_key="$(cat $random_key_public)"
     createLinodeAndWait "$alpine_image" "$plan" "$ssh_key"
     assert_success
 }
 
 @test "it should confirm the distro image is the distro selected in the CLI" {
-    # Replace this with polling for ssh port open
-    sleep 25
-
     linode_label=$(linode-cli linodes list --format "label" --text --no-headers)
-    run linode-cli ssh "root@$linode_label" -oStrictHostKeyChecking=no "cat /etc/os-release"
+    linode_ip=$(linode-cli linodes list --format "ipv4" --text --no-headers)
+
+    # Poll until SSH is available
+    SECONDS=0
+    until nc -z $linode_ip 22
+    do
+        sleep 1
+
+        if (( $SECONDS > 240 )); then
+            echo "Timeout elapsed! Could not connect to SSH in time"
+            assert_failure  # This will fail the test
+        fi
+    done
+
+    run linode-cli ssh "root@$linode_label" -i "${random_key_private}" -oStrictHostKeyChecking=no "cat /etc/os-release"
     assert_success
     assert_output --partial "Alpine Linux"
 }
@@ -44,7 +55,7 @@ teardown() {
 @test "it should check the vm for ipv4 connectivity" {
     LAST_TEST="TRUE"
     linode_label=$(linode-cli linodes list --format "label" --text --no-headers)
-    run linode-cli ssh "root@$linode_label" -oStrictHostKeyChecking=no "ping -4 -W60 -c3 google.com"
+    run linode-cli ssh "root@$linode_label" -i "${random_key_private}" -oStrictHostKeyChecking=no "ping -4 -W60 -c3 google.com"
     assert_success
     assert_output --partial "0% packet loss"
 }

--- a/test/stackscripts/stackscripts.bats
+++ b/test/stackscripts/stackscripts.bats
@@ -13,7 +13,7 @@ EXAMPLE_SCRIPT="echo foo > test.sh"
 
 setup() {
 	suiteName="stackscripts"
-	images=$(linode-cli images list --format id --text --no-headers | egrep "linode\/.*")
+	images=$(LINODE_CLI_TOKEN=$LINODE_CLI_TOKEN linode-cli images list --format id --text --no-headers | egrep "linode\/.*")
 	setToken "$suiteName"
 }
 

--- a/test/test-runner.sh
+++ b/test/test-runner.sh
@@ -3,8 +3,15 @@
 # Trap ctrl-c and reset .env file
 trap ctrl_c INT
 
+# Run all tests in parallel
+num_parallel_jobs=2
+
+if [[ $* =~ "--no-parallel" ]]; then
+  num_parallel_jobs=1
+fi
+
 function clean_accounts() {
-    grep "export TOKEN_[0-9]=" < "$PWD/.env" | cut -d '=' -f 2 | parallel --will-cite --jobs 2 "$PWD/clean-accounts.sh"
+    grep "export TOKEN_[0-9]=" < "$PWD/.env" | cut -d '=' -f 2 | parallel --will-cite --jobs $num_parallel_jobs "$PWD/clean-accounts.sh"
 }
 
 function ctrl_c() {
@@ -19,6 +26,21 @@ function ctrl_c() {
     echo -e "export TOKEN_1=$TOKEN_1\nexport TOKEN_2=$TOKEN_2\nexport TOKEN_1_IN_USE_BY=NONE\nexport TOKEN_2_IN_USE_BY=NONE\nexport TEST_ENVIRONMENT=$TEST_ENVIRONMENT" > ./.env
 }
 
+function rebuild_env() {
+  unset LINODE_CLI_TOKEN
+
+  if [ -f ".tmp-tag" ]; then
+        rm .tmp-*
+    fi
+
+  echo -e "export TOKEN_1=$TOKEN_1\nexport TOKEN_2=$TOKEN_2\nexport TOKEN_1_IN_USE_BY=NONE\nexport TOKEN_2_IN_USE_BY=NONE\nexport TEST_ENVIRONMENT=$TEST_ENVIRONMENT" > ./.env
+}
+
+if ( ! (command -v netcat > /dev/null) ); then
+    echo "The Linode-CLI requires netcat to be installed and added to your PATH"
+    exit 1
+fi
+
 if ( ! (command -v parallel > /dev/null) ); then
     echo "The Linode-CLI requires GNU Parallel to be installed and added to your PATH"
     echo "For information on how to install, visit https://www.gnu.org/software/parallel/"
@@ -28,6 +50,7 @@ fi
 if [[ $* != *"--allow-delete-resources"* && $* != *"--force"* && $* != *"-f"* ]]; then
     echo -e "\n ####WARNING!#### \n"
     echo -e  "Running the Linode CLI tests requires removing all resources not tagged \"linuke-keep\" on your account\n"
+    echo -e "If you have resources tagged \"linuke-keep\" on your Linode account, certain tests may not pass."
     echo -e "Run this command with the --allow-delete-resources flag to accept this fate\n"
     exit 1
 fi
@@ -54,6 +77,10 @@ if [[  $DOCKER_BATS = "TRUE" ]]; then
         && echo -e "export TOKEN_1=$TOKEN_1\nexport TOKEN_2=$TOKEN_2\nexport TOKEN_1_IN_USE_BY=NONE\nexport TOKEN_2_IN_USE_BY=NONE\nexport TEST_ENVIRONMENT=$TEST_ENVIRONMENT" > /src/linode-cli/test/.env
 fi
 
+if [[ $* =~ "--from-env" ]]; then
+ rebuild_env
+fi
+
 if [[ $* =~ "--clean" ]]; then
  clean_accounts
  ctrl_c
@@ -63,8 +90,7 @@ fi
 # Always clean accounts before tests:
 clean_accounts
 
-# Run all tests in parallel
-find . -name "*.bats" -not \( -path './test_helper*' \) | parallel --will-cite --jobs 2 bats
+find . -name "*.bats" -not \( -path './test_helper*' \) | parallel --will-cite --jobs $num_parallel_jobs bats
 
 # Preserve tests exit code:
 tests_status=$?

--- a/test/volumes/attach-detach-volumes.bats
+++ b/test/volumes/attach-detach-volumes.bats
@@ -23,7 +23,7 @@
 #     linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
 #     run linode-cli volumes create --label="attachedVolume" --size=10 --linode_id=$linode_id --text --no-headers --delimiter="," --format="id,label,size,region,linode_id"
 #     assert_success
-#     assert_output --regexp "[0-9]+,attachedVolume,10,us-east,$linode_id"
+#     assert_output --regexp "[0-9]+,attachedVolume,10,[a-z-]+,$linode_id"
 # }
 
 # @test "it should detach from linode" {
@@ -40,7 +40,7 @@
 #     linode_id=$(linode-cli linodes list --format="id" --text --no-headers)
 #     run linode-cli volumes attach --linode_id=$linode_id $volume_id --text --no-headers --delimiter="," --format="id,label,size,region,linode_id"
 #     assert_success
-#     assert_output --regexp "$volume_id,attachedVolume,10,us-east,$linode_id"
+#     assert_output --regexp "$volume_id,attachedVolume,10,[a-z-]+,$linode_id"
 # }
 
 # @test "it should fail to remove while attached" {

--- a/test/volumes/list-view-update-volumes.bats
+++ b/test/volumes/list-view-update-volumes.bats
@@ -33,7 +33,7 @@ teardown() {
         --delimiter=","
 
     assert_success
-    assert_output --regexp "[0-9]+,[A-Za-z0-9]+,(creating|active),10,us-east"
+    assert_output --regexp "[0-9]+,[A-Za-z0-9]+,(creating|active),10,[a-z-]+"
 }
 
 @test "it should view a single volume" {
@@ -44,7 +44,7 @@ teardown() {
         --format="id,label,size,region"
 
     assert_success
-    assert_output --regexp "$volume_id,[A-Za-z0-9-]+,[0-9]+,us-east"
+    assert_output --regexp "$volume_id,[A-Za-z0-9-]+,[0-9]+,[a-z-]+"
 }
 
 @test "it should update a volume label" {


### PR DESCRIPTION
## 📝 Description

This change introduces a new end-to-end testing workflow that runs on all commits pushed to the `master` branch. Support for running acceptance tests on PRs will need to be added in the future as `/acctest` commands.

Additionally, this PR makes large changes to the existing Bats test suite to run consistently in an easily reproducible environment.

All tests are passing consistently locally.

## ✔️ How to Test

The test suite can be tested locally by following the README instructions for running the entire test suite.

The E2E workflow can be tested by checking out this branch and pushing it to the `master` branch of a fork on GitHub.

An example workflow run can be viewed [here](https://github.com/lgarber-akamai/linode-cli/actions/runs/3631356432/jobs/6125881610).