### PR TITLE
new: Add glob support for Windows file paths

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -3,7 +3,9 @@ Classes related to OpenAPI-defined operations and their arguments and parameters
 """
 
 import argparse
+import glob
 import json
+import platform
 from getpass import getpass
 from os import environ, path
 
@@ -72,6 +74,16 @@ class OptionalFromFileAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if isinstance(values, str):
             input_path = path.expanduser(values)
+
+            # Windows doesn't natively expand globs, so we should implement it here
+            if platform.system() == "Windows" and "*" in input_path:
+                results = glob.glob(input_path, recursive=True)
+
+                if len(results) < 1:
+                    raise argparse.ArgumentError("File matching pattern {} not found".format(input_path))
+
+                input_path = results[0]
+
             if path.exists(input_path) and path.isfile(input_path):
                 with open(input_path) as f:
                     data = f.read()

--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -7,7 +7,9 @@ Usage:
 """
 
 import argparse
+import glob
 import os
+import platform
 from sys import exit
 
 import requests
@@ -102,6 +104,16 @@ def call(args, context):
 
     # make sure the file exists and is ready to upload
     filepath = os.path.expanduser(parsed.file)
+
+    # Windows doesn't natively expand globs, so we should implement it here
+    if platform.system() == "Windows" and "*" in filepath:
+        results = glob.glob(filepath, recursive=True)
+
+        if len(results) < 1:
+            print("No file found matching pattern {}".format(filepath))
+            exit(2)
+
+        filepath = results[0]
 
     if not os.path.isfile(filepath):
         print("No file at {}; must be a path to a valid file.".format(filepath))

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -1,7 +1,9 @@
 import argparse
 import getpass
+import glob
 import math
 import os
+import platform
 import socket
 import sys
 import time
@@ -235,6 +237,15 @@ def upload_object(get_client, args):
     for c in parsed.file:
         # find the object
         file_path = os.path.expanduser(c)
+
+        # Windows doesn't natively expand globs, so we should implement it here
+        if platform.system() == "Windows" and "*" in file_path:
+            results = glob.glob(file_path, recursive=True)
+            if len(results) < 1:
+                print("No file found matching pattern {}".format(file_path))
+                exit(5)
+
+            file_path = results[0]
 
         if not os.path.isfile(file_path):
             print("No file {}".format(file_path))


### PR DESCRIPTION
## 📝 Description

This change allows Windows users to specify globs/wildcards when referencing local file paths. This is necessary as by default, Windows expects individual applications to handle parsing wildcards.

## ✔️ How to Test

On a Windows machine, attempt to upload a file using a glob:

```
linode-cli obj put mydirectory/*.txt mybucket
```
