### PR TITLE
Adding completion for Fish Shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,9 @@ for example to generate completions for bash run::
 The output of this command is suitable to be included in the relevant completion
 files to enable command completion on your shell.
 
-Currently supports Bash and Fish.
+Currently supports bash and fish.
+
+Use ``bashcompinit`` on zsh with the bash completions for support on zsh shells.
 
 Environment Variables
 """""""""""""""""""""

--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ for example to generate completions for bash run::
 The output of this command is suitable to be included in the relevant completion
 files to enable command completion on your shell.
 
-Currently supports bash and fish.
+This command currently supports completions bash and fish shells.
 
 Use ``bashcompinit`` on zsh with the bash completions for support on zsh shells.
 

--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,8 @@ for example to generate completions for bash run::
 The output of this command is suitable to be included in the relevant completion
 files to enable command completion on your shell.
 
+Currently supports Bash and Fish.
+
 Environment Variables
 """""""""""""""""""""
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -366,21 +366,21 @@ def main():
                 "Currently, only completions for bash and fish are available."
             )
             exit(0)
+
+        completions = ""
+
         if parsed.action == "bash":
-            # generate and print completions, then exit
             completions = cli.get_bash_completions()
-            print(completions)
-            exit(0)
-        if parsed.action == "fish":
+        elif parsed.action == "fish":
             completions = cli.get_fish_completions()
-            print(completions)
-            exit(0)
         else:
             print(
                 "Completions are only available for bash and fish at this time.  To retrieve "
                 "these, please invoke as `linode-cli completion bash` or `linode-cli completion fish`."
             )
             exit(1)
+        print(completions)
+        exit(0)
 
     # handle a help for the CLI
     if parsed.command is None or (parsed.command is None and parsed.help):

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -354,18 +354,22 @@ def main():
             print()
             print(
                 "Prints shell completions for the requested shell to stdout. "
-                "Currently, only completions for bash are available."
+                "Currently, only completions for bash and fish are available."
             )
             exit(0)
         if parsed.action == "bash":
             # generate and print completions, then exit
-            completions = cli.get_completions()
+            completions = cli.get_bash_completions()
+            print(completions)
+            exit(0)
+        if parsed.action == "fish":
+            completions = cli.get_fish_completions()
             print(completions)
             exit(0)
         else:
             print(
-                "Completions are only available for bash at this time.  To retrieve "
-                "these, please invoke as `linode-cli completion bash`."
+                "Completions are only available for bash and fish at this time.  To retrieve "
+                "these, please invoke as `linode-cli completion bash` or `linode-cli completion fish`."
             )
             exit(1)
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -402,11 +402,11 @@ class CLI:
         """
         completion_template = Template(
                 """# This is a generated file! Do not modify!
-complete -c linode-cli -n "not __fish_seen_subcommand_from $subcommands" -x -a '$subcommands'
+complete -c linode-cli -n "not __fish_seen_subcommand_from $subcommands" -x -a '$subcommands --help'
 $command_items""")
 
         command_template = Template(
-            """complete -c linode-cli -n "__fish_seen_subcommand_from $command" -x -a '$actions'"""
+            """complete -c linode-cli -n "__fish_seen_subcommand_from $command" -x -a '$actions --help'"""
         )
 
         command_blocks = [


### PR DESCRIPTION
## 📝 Description

adds tab completions for Fish shell
added a note to the README about using `bashcompinit` to use existing bash tab completion to generate Zsh completion!

## ✔️ How to Test

linode-cli completion fish

resolves: #194 and #281
shoutout to @someguy123 for the find!