### PR TITLE
ref: `master` -> `main` branch references

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 jobs:
   integration_tests:
     name: Run integration tests

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: null
   push:
     branches:
-      - master
+      - main
 jobs:
   integration_tests:
     name: Run integration tests

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   update_release_draft:

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ linode-cli
 
 The Linode Command Line Interface
 
-.. image:: https://raw.githubusercontent.com/linode/linode-cli/master/demo.gif
+.. image:: https://raw.githubusercontent.com/linode/linode-cli/main/demo.gif
 
 Installation
 ------------
@@ -353,7 +353,7 @@ Developing Plugins
 
 For information on how To write your own Third Party Plugin, see the `Plugins documentation`_.
 
-.. _Plugins documentation: https://github.com/linode/linode-cli/blob/master/linodecli/plugins/README.md
+.. _Plugins documentation: https://github.com/linode/linode-cli/blob/main/linodecli/plugins/README.md
 
 Building from Source
 --------------------
@@ -435,7 +435,7 @@ such, many changes are made directly to the spec.
 
 Please follow the `Contributing Guidelines`_ when making a contribution.
 
-.. _Contributing Guidelines: https://github.com/linode/linode-cli/blob/master/CONTRIBUTING.md
+.. _Contributing Guidelines: https://github.com/linode/linode-cli/blob/main/CONTRIBUTING.md
 
 Specification Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -476,4 +476,4 @@ added to Linode's OpenAPI spec:
 |                             |             | object instead of the original object.                                                    |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 
-.. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions
+.. _Specification Extensions: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#specificationExtensions

--- a/examples/third-party-plugin/example_third_party_plugin.py
+++ b/examples/third-party-plugin/example_third_party_plugin.py
@@ -2,7 +2,7 @@
 This file is an example third-party plugin.  See `the plugin docs`_ for more
 information.
 
-.. _the plugin docs: https://github.com/linode/linode-cli/blob/master/linodecli/plugins/README.md
+.. _the plugin docs: https://github.com/linode/linode-cli/blob/main/linodecli/plugins/README.md
 """
 
 #: This is the name the plugin will be invoked with once it's registered.  Note

--- a/linodecli/plugins/README.md
+++ b/linodecli/plugins/README.md
@@ -133,6 +133,6 @@ This directory contains two example plugins, `echo.py.example` and
 `regionstats.py.example`.  To run these, simply remove the `.example` at the end
 of the file and build the CLI as described above.
 
-[This directory](https://github.com/linode/linode-cli/tree/master/examples/third-party-plugin)
+[This directory](https://github.com/linode/linode-cli/tree/main/examples/third-party-plugin)
 contains an example Third Party Plugin module.  This module is installable and
 can be registered to the CLI.


### PR DESCRIPTION
## 📝 Description

This PR changes all references to the `master` branch to the `main` branch. This is a preemptive change for using a dev/main branch model.
