### PR TITLE
draft: adding retry for common errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,14 @@ in addition to its normal output.  If these warnings can interfere with your
 scripts or you otherwise want them disabled, simply add the ``--suppress-warnings``
 flag to prevent them from being emitted.
 
+Automatic Retry
+"""""""""""""""
+
+Sometimes the API responds with a error that can be ignored. For example a timeout
+or nginx response that can't be parsed correctly, by default the CLI will retry
+calls on these errors we've identified. If you'd like to disable this behavior for
+any reason use the ``--no-retry`` flag.
+
 Shell Completion
 """"""""""""""""
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -142,6 +142,11 @@ def main():
         "This is useful for scripting the CLI's behavior.",
     )
     parser.add_argument(
+        "--no-retry",
+        action="store_true",
+        help="Skip retrying on common errors like timeouts.",
+    )
+    parser.add_argument(
         "--version",
         "-v",
         action="store_true",
@@ -175,10 +180,11 @@ def main():
         cli.output_handler.columns = parsed.format
 
     cli.defaults = not parsed.no_defaults
-    cli.suppress_warnings = parsed.suppress_warnings
+    cli.debug_request = parsed.debug
+    cli.no_retry = parsed.no_retry
     cli.page = parsed.page
     cli.page_size = parsed.page_size
-    cli.debug_request = parsed.debug
+    cli.suppress_warnings = parsed.suppress_warnings
 
     if not cli.suppress_warnings:
         warn_python2_eol()

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -711,15 +711,16 @@ complete -F _linode_cli linode-cli"""
         if response.status_code == 408:
             # request timed out
             return True
-        if (response.status_code == 503
-        and response.header.get("X-Maintenance-Mode")):
-            # API is in Maintenance Mode
-            return True
-        if (response.status_code == 400
-        and response.header.get("Server") == "nginx"
-        and response.header.get("Content-Type") == "text/html"):
-            # nginx html response
-            return True
+        if response.headers:
+            if (response.status_code == 503
+            and response.headers.get("X-Maintenance-Mode")):
+                # API is in Maintenance Mode
+                return True
+            if (response.status_code == 400
+            and response.headers.get("Server") == "nginx"
+            and response.headers.get("Content-Type") == "text/html"):
+                # nginx html response
+                return True
 
         return False
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -37,6 +37,7 @@ class CLI:
         self.spec_version = "None"
         self.suppress_warnings = False
         self.no_retry = False
+        self.retry_count = 0
 
         self.output_handler = OutputHandler()
         self.config = CLIConfig(self.base_url, skip_config=skip_config)
@@ -606,7 +607,10 @@ complete -F _linode_cli linode-cli"""
         if self.debug_request:
             self.print_response_debug_info(result)
 
-        if self._check_retry(result) and self.no_retry:
+        if (self._check_retry(result)
+        and self.no_retry
+        and self.retry_count < 3):
+            self.retry_count += 1
             self.do_request(operation, args, filter_header, skip_error_handling)
 
         if not self.suppress_warnings:

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -36,6 +36,7 @@ class CLI:
         self.base_url = base_url
         self.spec_version = "None"
         self.suppress_warnings = False
+        self.no_retry = False
 
         self.output_handler = OutputHandler()
         self.config = CLIConfig(self.base_url, skip_config=skip_config)
@@ -605,7 +606,7 @@ complete -F _linode_cli linode-cli"""
         if self.debug_request:
             self.print_response_debug_info(result)
 
-        if self._check_retry(result):
+        if self._check_retry(result) and self.no_retry:
             self.do_request(operation, args, filter_header, skip_error_handling)
 
         if not self.suppress_warnings:

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -4,6 +4,7 @@ Responsible for managing spec and routing commands to operations.
 
 import pickle
 import json
+import time
 import sys
 import re
 import os


### PR DESCRIPTION
DRAFT

## 📝 Description

**What does this PR do and why is this change necessary?**

Adding retry functionality for common random errors sent by the API
- 400: Bad Request with nginx headers
- 408: Request Timeout
- 503: Service Unavailable, X-Maintenance-Mode is set

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**
