### PR TITLE
fix: Only install from .whl in `make install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ override SPEC = $(shell ./resolve_spec_url ${SPEC_VERSION})
 endif
 
 install: check-prerequisites requirements build
-	ls dist/ | xargs -I{} pip3 install --force dist/{}
+	pip3 install --force dist/*.whl
 
 .PHONY: build
 build: clean


### PR DESCRIPTION
## 📝 Description

This pull request modifies the `make install` target to only install from the wheel package rather than from the source dist. This is necessary as installing from source dist may cause `permission denied` errors in CI.

## ✔️ How to Test

`make install`
