### PR TITLE
fix: Properly bake version for `sdist` targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@ build
 dist
 *.egg-info
 linode-cli.sh
+baked_version
 data-2
 data-3
 .DS_STORE
 Pipfile*
 test/.env
 .tmp*
+MANIFEST

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
+include linodecli/data-3
+include linodecli/oauth-landing-page.html
+include linode-cli.sh
 include baked_version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-include linodecli/data-3
-include linodecli/oauth-landing-page.html
-include linode-cli.sh
+include baked_version

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ check-prerequisites:
 .PHONY: clean
 clean:
 	rm -f linodecli/data-*
-	rm -f linode-cli.sh
+	rm -f linode-cli.sh baked_version
 	rm -f data-*
 	rm -rf dist

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ def get_baked_files():
     if path.isfile("linode-cli.sh"):
         data_files.append(("/etc/bash_completion.d", ["linode-cli.sh"]))
 
-    data_files.append(("version", ["./version"]))
-    data_files.append(("resolve_spec_url", ["./resolve_spec_url"]))
-
     return data_files
 
 
@@ -36,9 +33,37 @@ def get_version():
     return subprocess.check_output(["./version"]).decode("utf-8").rstrip()
 
 
+def get_baked_version():
+    """
+    Attempts to read the version from the baked_version file
+    """
+    with open("./baked_version", "r", encoding="utf-8") as f:
+        result = f.read()
+
+    return result
+
+
+def bake_version(v):
+    """
+    Writes the given version to the baked_version file
+    """
+    with open("./baked_version", "w", encoding="utf-8") as f:
+        f.write(v)
+
+
+# If there's already a baked version, use it.
+# This is useful for installing from an SDist.
+# NOTE: baked_version is deleted when running `make clean`.
+if path.isfile("baked_version"):
+    version = get_baked_version()
+else:
+    # Otherwise, retrieve and bake the version as normal
+    version = get_version()
+    bake_version(version)
+
 setup(
     name="linode-cli",
-    version=get_version(),
+    version=version,
     description="CLI for the Linode API",
     long_description=long_description,
     author="Linode",

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,13 @@ def bake_version(v):
         f.write(v)
 
 
-# If there's already a baked version, use it.
-# This is useful for installing from an SDist.
-# NOTE: baked_version is deleted when running `make clean`.
+# If there's already a baked version, use it rather than attempting
+# to resolve the version from env.
+# This is useful for installing from an SDist where the version
+# cannot be dynamically resolved.
+#
+# NOTE: baked_version is deleted when running `make build` and `make install`,
+# so it should always be recreated during the build process.
 if path.isfile("baked_version"):
     version = get_baked_version()
 else:


### PR DESCRIPTION
## 📝 Description

This change modifies `setup.py` to bake the CLI version into `sdist` target archive. This is necessary as the CLI cannot infer the version when install from the source dist by default.

This change has been tested against the existing GHA release workflows.

## ✔️ How to Test

```
make build && pip install --force dist/*.tar.gz
```

You can also test a pre-built source distribution using the following command

```
pip install --force --no-binary all linode-cli-testrelease
```