### PR TITLE
fix: Correct broken substring check in domain E2E test 

### DIFF
--- a/test/domains/master-domains.bats
+++ b/test/domains/master-domains.bats
@@ -39,7 +39,7 @@ teardown() {
 
 	assert_failure
 	assert_output --partial "Request failed: 400"
-	assert_output --partial "soa_email	SOA_Email required when type=master"
+	assert_output --partial "soa_email	soa_email required when type=master"
 }
 
 @test "it should create a master domain" {


### PR DESCRIPTION
## 📝 Description

This pull request corrects the `SOA_Email` substring check in the domain E2E test suite. This is in response to the corresponding Linode API change.
