### PR TITLE
new: Add support for result output truncation

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -151,6 +151,12 @@ def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
         "This is useful for scripting the CLI's behavior.",
     )
     parser.add_argument(
+        "--no-truncation",
+        action="store_true",
+        default=False,
+        help="Prevent the truncation of long values in command outputs.",
+    )
+    parser.add_argument(
         "--version",
         "-v",
         action="store_true",
@@ -185,9 +191,13 @@ def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
 
     cli.defaults = not parsed.no_defaults
     cli.suppress_warnings = parsed.suppress_warnings
+
     cli.page = parsed.page
     cli.page_size = parsed.page_size
     cli.debug_request = parsed.debug
+
+    cli.output_handler.suppress_warnings = parsed.suppress_warnings
+    cli.output_handler.disable_truncation = parsed.no_truncation
 
     if not cli.suppress_warnings:
         warn_python2_eol()

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -20,7 +20,7 @@ class OutputMode(Enum):
     markdown = 4
 
 
-class OutputHandler:  # pylint: disable=too-few-public-methods
+class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """
     Handles formatting the output of commands used in Linode CLI
     """
@@ -189,7 +189,10 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
         """
         content = self._build_output_content(
             data, columns,
-            value_transform=lambda attr, v: self._attempt_truncate_value(attr.render_value(v, colorize=False)))
+            value_transform=lambda attr, v: self._attempt_truncate_value(
+                attr.render_value(v, colorize=False)
+            )
+        )
 
         if header:
             print("| " + " | ".join([str(c) for c in header]) + " |", file=to)

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -2,6 +2,7 @@
 Handles formatting the output of commands used in Linode CLI
 """
 import json
+import sys
 from enum import Enum
 from sys import stdout
 
@@ -31,12 +32,21 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
         headers=True,
         pretty_json=False,
         columns=None,
+        disable_truncation=False,
+        truncation_length=64,
+        suppress_warnings=False,
     ):
         self.mode = mode
         self.delimiter = delimiter
         self.pretty_json = pretty_json
         self.headers = headers
         self.columns = columns
+        self.disable_truncation = disable_truncation
+        self.truncation_length = truncation_length
+        self.suppress_warnings = suppress_warnings
+
+        # Used to track whether a warning has already been printed
+        self.has_warned = False
 
     def print(
         self, response_model, data, title=None, to=stdout, columns=None
@@ -110,7 +120,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
         content = self._build_output_content(
             data, columns,
             header=header,
-            value_transform=lambda attr, v: attr.render_value(v))
+            value_transform=lambda attr, v: self._attempt_truncate_value(attr.render_value(v)))
 
         tab = SingleTable(content)
 
@@ -179,7 +189,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
         """
         content = self._build_output_content(
             data, columns,
-            value_transform=lambda attr, v: attr.render_value(v, colorize=False))
+            value_transform=lambda attr, v: self._attempt_truncate_value(attr.render_value(v, colorize=False)))
 
         if header:
             print("| " + " | ".join([str(c) for c in header]) + " |", file=to)
@@ -205,6 +215,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
             content = [header]
 
         # We're not using models here
+        # We won't apply transforms here since no formatting is being applied
         if isinstance(columns[0], str):
             return content + data
 
@@ -212,3 +223,25 @@ class OutputHandler:  # pylint: disable=too-few-public-methods
             content.append([value_transform(attr, model) for attr in columns])
 
         return content
+
+    def _attempt_truncate_value(self, value):
+        if self.disable_truncation:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if len(value) < self.truncation_length:
+            return value
+
+        if not self.suppress_warnings and not self.has_warned:
+            print(
+                "Certain values in this output have been truncated. "
+                "To disable output truncation, use --no-truncation. "
+                "Alternatively, use the --json or --text output modes, "
+                "or disable warnings using --suppress-warnings.",
+                file=sys.stderr
+            )
+            self.has_warned = True
+
+        return f"{value[:self.truncation_length]}..."


### PR DESCRIPTION
## 📝 Description

This pull request adds support for automatically truncating data for tabular output formats. Additionally, this change adds a `--no-truncation` field to disable this functionality.

e.g.

```
linode-cli lke kubeconfig-view 90162
Certain values in this output have been truncated. To disable output truncation, use --no-truncation. Alternatively, use the --json or --text output modes, or disable warnings using --suppress-warnings.
┌─────────────────────────────────────────────────────────────────────┐
│ kubeconfig                                                          │
├─────────────────────────────────────────────────────────────────────┤
│ CmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KCmNs... │
└─────────────────────────────────────────────────────────────────────┘
```

Blocked by #349 

## ✔️ How to Test

```
make test
```
