### PR TITLE
fix: Add `linodecli.configuration` to setup.py packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
     packages=[
         "linodecli",
         "linodecli.plugins",
+        "linodecli.configuration"
     ],
     license="BSD 3-Clause License",
     install_requires=[


### PR DESCRIPTION
## 📝 Description

This change alters `setup.py` to include the new `linodecli.configuration` package. This should resolve errors when attempting to run the E2E test suite or running the CLI after a `make install`

## ✔️ How to Test

```
make install
linode-cli linodes ls
```
