### PR TITLE
fix: Add support for `--help` pages on aliased commands

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -512,42 +512,46 @@ def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
             sys.exit(0)
 
     # handle a help for an action
-    if parsed.command is not None and parsed.action is not None and parsed.help:
-        if parsed.command in cli.ops and parsed.action in cli.ops[parsed.command]:
-            operation = cli.ops[parsed.command][parsed.action]
-            print(f"linode-cli {parsed.command} {parsed.action}", end="")
-            for param in operation.params:
-                # clean up parameter names - we add an '_' at the end of them
-                # during baking if it conflicts with the name of an argument.
-                # Remove the trailing underscores on output (they're not
-                # important to the end user).
-                pname = param.name.upper()
-                if pname[-1] == "_":
-                    pname = pname[:-1]
-                print(f" [{pname}]", end="")
-            print()
-            print(operation.summary)
-            if operation.docs_url:
-                print(f"API Documentation: {operation.docs_url}")
-            print()
-            if operation.args:
-                print("Arguments:")
-                for arg in sorted(operation.args, key=lambda s: not s.required):
-                    is_required = (
-                        "(required) "
-                        if operation.method in {"post", "put"} and arg.required
-                        else ""
-                    )
-                    print(f"  --{arg.path}: {is_required}{arg.description}")
-            elif operation.method == "get" and parsed.action == "list":
-                filterable_attrs = [
-                    attr for attr in operation.response_model.attrs if attr.filterable
-                ]
+    try:
+        parsed_operation = cli._find_operation(parsed.command, parsed.action)
+    except ValueError:
+        # No operation was found
+        parsed_operation = None
 
-                if filterable_attrs:
-                    print("You may filter results with:")
-                    for attr in filterable_attrs:
-                        print(f"  --{attr.name}")
+    if parsed_operation is not None and parsed.help:
+        print(f"linode-cli {parsed.command} {parsed.action}", end="")
+        for param in parsed_operation.params:
+            # clean up parameter names - we add an '_' at the end of them
+            # during baking if it conflicts with the name of an argument.
+            # Remove the trailing underscores on output (they're not
+            # important to the end user).
+            pname = param.name.upper()
+            if pname[-1] == "_":
+                pname = pname[:-1]
+            print(f" [{pname}]", end="")
+        print()
+        print(parsed_operation.summary)
+        if parsed_operation.docs_url:
+            print(f"API Documentation: {parsed_operation.docs_url}")
+        print()
+        if parsed_operation.args:
+            print("Arguments:")
+            for arg in sorted(parsed_operation.args, key=lambda s: not s.required):
+                is_required = (
+                    "(required) "
+                    if parsed_operation.method in {"post", "put"} and arg.required
+                    else ""
+                )
+                print(f"  --{arg.path}: {is_required}{arg.description}")
+        elif parsed_operation.method == "get" and parsed_operation.action == "list":
+            filterable_attrs = [
+                attr for attr in parsed_operation.response_model.attrs if attr.filterable
+            ]
+
+            if filterable_attrs:
+                print("You may filter results with:")
+                for attr in filterable_attrs:
+                    print(f"  --{attr.name}")
         sys.exit(0)
 
     if parsed.command is not None and parsed.action is not None:

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -513,7 +513,7 @@ def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
 
     # handle a help for an action
     try:
-        parsed_operation = cli._find_operation(parsed.command, parsed.action)
+        parsed_operation = cli.find_operation(parsed.command, parsed.action)
     except ValueError:
         # No operation was found
         parsed_operation = None

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -443,7 +443,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
         """
 
         try:
-            operation = self._find_operation(command, action)
+            operation = self.find_operation(command, action)
         except ValueError as e:
             print(e, file=sys.stderr)
             sys.exit(1)
@@ -490,7 +490,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
 
         return result.status_code, result.json()
 
-    def _find_operation(self, command, action):
+    def find_operation(self, command, action):
         """
         Finds the corresponding operation for the given command and action.
         """

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -503,7 +503,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
             return command_dict[action]
 
         # Find the matching alias
-        for op in self.ops[command].values():
+        for op in command_dict.values():
             if action in op.action_aliases:
                 return op
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-pylint
+pylint==2.15.10
 pytest==7.2.1

--- a/test/cli/help.bats
+++ b/test/cli/help.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+# ##################################################################
+# #  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+# #  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+# ##################################################################
+
+setup() {
+    suiteName="help"
+    setToken "$suiteName"
+    export timestamp=$(date +%s)
+    clean_linodes="FALSE"
+}
+
+@test "it should display a help page for non-aliased actions" {
+    run linode-cli linodes list --help
+
+    assert_success
+    assert_output --partial "Linodes List"
+    assert_output --partial "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
+    assert_output --partial "You may filter results with:"
+    assert_output --partial "--tags"
+}
+
+@test "it should display a help page for aliased actions" {
+    run linode-cli linodes ls --help
+
+    assert_success
+    assert_output --partial "Linodes List"
+    assert_output --partial "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
+    assert_output --partial "You may filter results with:"
+    assert_output --partial "--tags"
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,14 +34,14 @@ class TestCLI:
             },
         }
 
-        assert mock_cli._find_operation("foo", "list") == target_operation
-        assert mock_cli._find_operation("foo", "ls") == target_operation
-        assert mock_cli._find_operation("cool", "list") == other_operation
-        assert mock_cli._find_operation("cool", "ls") == other_operation
+        assert mock_cli.find_operation("foo", "list") == target_operation
+        assert mock_cli.find_operation("foo", "ls") == target_operation
+        assert mock_cli.find_operation("cool", "list") == other_operation
+        assert mock_cli.find_operation("cool", "ls") == other_operation
 
         with pytest.raises(ValueError, match=r"Command not found: *"):
-            mock_cli._find_operation("bad", "list")
+            mock_cli.find_operation("bad", "list")
 
         with pytest.raises(ValueError, match=r"No action *"):
-            mock_cli._find_operation("foo", "cool")
-            mock_cli._find_operation("cool", "cool")
+            mock_cli.find_operation("foo", "cool")
+            mock_cli.find_operation("cool", "cool")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,47 @@
+import contextlib
+import copy
+import io
+
+import pytest
+from terminaltables import SingleTable
+
+from linodecli import api_request, ModelAttr, ResponseModel, OutputMode
+from tests.test_populators import mock_cli, create_operation, list_operation, make_test_operation
+
+
+class TestCLI:
+    """
+    Unit tests for linodecli.cli
+    """
+
+    def test_find_operation(self, mock_cli, list_operation):
+        target_operation = list_operation
+        target_operation.command = "foo"
+        target_operation.action = "list"
+        target_operation.action_aliases = ["ls"]
+
+        other_operation = copy.deepcopy(list_operation)
+        other_operation.command = "cool"
+        other_operation.action = "list"
+        other_operation.action_aliases = ["ls"]
+
+        mock_cli.ops = {
+            "foo": {
+                "list": target_operation
+            },
+            "cool": {
+                "list": other_operation
+            },
+        }
+
+        assert mock_cli._find_operation("foo", "list") == target_operation
+        assert mock_cli._find_operation("foo", "ls") == target_operation
+        assert mock_cli._find_operation("cool", "list") == other_operation
+        assert mock_cli._find_operation("cool", "ls") == other_operation
+
+        with pytest.raises(ValueError, match=r"Command not found: *"):
+            mock_cli._find_operation("bad", "list")
+
+        with pytest.raises(ValueError, match=r"No action *"):
+            mock_cli._find_operation("foo", "cool")
+            mock_cli._find_operation("cool", "cool")


### PR DESCRIPTION
## 📝 Description

This change fixes an issue that would prevent aliased actions from displaying `--help` pages. Additionally, this pull request breaks out operation discovery logic into a `find_operation` CLI method.

Resolves #351 

## ✔️ How to Test

```
make test
cd test && bats ./cli/help.bats
```