### PR TITLE
PEP518 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Pipfile*
 test/.env
 .tmp*
 MANIFEST
+venv

--- a/linodecli/plugins/obj.py
+++ b/linodecli/plugins/obj.py
@@ -345,8 +345,7 @@ def _do_multipart_upload(
                             time.sleep(retry_delay)
                             continue
                         raise
-                    else:
-                        break
+                    break
     except Exception:
         print("Upload failed!  Cleaning up!")
         upload.cancel_upload()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add [PEP 518](https://peps.python.org/pep-0518/) compliance by specifying build system.

See also: https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-pyproject-toml