### PR TITLE
new: Allow API overrides through the environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,18 @@ the ``obj`` plugin that ships with the CLI.  To do so, simply set
 appropriate values.  This allows using Linode Object Storage through the CLI
 without having a configuration file, which is desirable in some situations.
 
+Configurable API URL
+""""""""""""""""""""
+
+In some cases you may want to run linode-cli against a non-default Linode API URL.
+This can be done using the following environment variables to override certain segments of the target API URL.
+
+* ``LINODE_CLI_API_HOST`` - The host of the Linode API instance (e.g. ``api.linode.com``)
+
+* ``LINODE_CLI_API_VERSION`` - The Linode API version to use (e.g. ``v4beta``)
+
+* ``LINODE_CLI_API_SCHEME`` - The request scheme to use (e.g. ``https``)
+
 Multiple Users
 ^^^^^^^^^^^^^^
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -22,19 +22,21 @@ from .operation import CLIArg, CLIOperation, URLParam
 from .output import OutputMode
 from .response import ModelAttr, ResponseModel
 from .completion import bake_completions, get_completions
+from .helpers import handle_url_overrides
 
 # this might not be installed at the time of building
 try:
     VERSION = pkg_resources.require("linode-cli")[0].version
 except:
     VERSION = "building"
-BASE_URL = os.getenv("LINODE_CLI_API_URL", "https://api.linode.com/v4")
+
+BASE_URL = "https://api.linode.com/v4"
 
 
 # if any of these arguments are given, we don't need to prompt for configuration
 skip_config = any(c in argv for c in ["--skip-config", "--help", "--version"])
 
-cli = CLI(VERSION, BASE_URL, skip_config=skip_config)
+cli = CLI(VERSION, handle_url_overrides(BASE_URL), skip_config=skip_config)
 
 
 def warn_python2_eol():

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -28,7 +28,7 @@ try:
     VERSION = pkg_resources.require("linode-cli")[0].version
 except:
     VERSION = "building"
-BASE_URL = "https://api.linode.com/v4"
+BASE_URL = os.getenv("LINODE_CLI_API_URL", "https://api.linode.com/v4")
 
 
 # if any of these arguments are given, we don't need to prompt for configuration

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -1,3 +1,7 @@
+"""
+Various helper functions shared across multiple CLI components.
+"""
+
 import os
 from urllib.parse import urlparse
 

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -1,0 +1,23 @@
+import os
+from urllib.parse import urlparse
+
+API_HOST_OVERRIDE = os.getenv("LINODE_CLI_API_HOST")
+API_VERSION_OVERRIDE = os.getenv("LINODE_CLI_API_VERSION")
+API_SCHEME_OVERRIDE = os.getenv("LINODE_CLI_API_SCHEME")
+
+
+def handle_url_overrides(url):
+    """
+    Returns the URL with the API URL environment overrides applied.
+    """
+
+    parsed_url = urlparse(url)
+
+    overrides = {
+        'netloc': API_HOST_OVERRIDE,
+        'path': API_VERSION_OVERRIDE,
+        'scheme': API_SCHEME_OVERRIDE
+    }
+
+    # Apply overrides
+    return parsed_url._replace(**{k: v for k, v in overrides.items() if v is not None}).geturl()

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -5,13 +5,11 @@ Classes related to OpenAPI-defined operations and their arguments and parameters
 import argparse
 import glob
 import json
-import os
 import platform
 from getpass import getpass
 from os import environ, path
 
-
-ENV_API_URL_OVERRIDE = "LINODE_CLI_API_URL"
+from linodecli.helpers import handle_url_overrides
 
 
 def parse_boolean(value):
@@ -187,7 +185,8 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
         """
         Returns the full URL for this resource based on servers and endpoint
         """
-        base_url = os.getenv(ENV_API_URL_OVERRIDE, self.servers[0])
+        base_url = handle_url_overrides(self.servers[0])
+
         return base_url + "/" + self._url
 
     def parse_args(

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -5,9 +5,13 @@ Classes related to OpenAPI-defined operations and their arguments and parameters
 import argparse
 import glob
 import json
+import os
 import platform
 from getpass import getpass
 from os import environ, path
+
+
+ENV_API_URL_OVERRIDE = "LINODE_CLI_API_URL"
 
 
 def parse_boolean(value):
@@ -183,7 +187,7 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
         """
         Returns the full URL for this resource based on servers and endpoint
         """
-        base_url = self.servers[0]
+        base_url = os.getenv(ENV_API_URL_OVERRIDE, self.servers[0])
         return base_url + "/" + self._url
 
     def parse_args(

--- a/test/cli/help.bats
+++ b/test/cli/help.bats
@@ -35,3 +35,4 @@ setup() {
     assert_output --partial "You may filter results with:"
     assert_output --partial "--tags"
 }
+

--- a/test/cli/host-overrides.bats
+++ b/test/cli/host-overrides.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load '../common'
+
+# ##################################################################
+# #  WARNING: THIS TEST WILL DELETE ALL OF YOUR LINODES            #
+# #  WARNING: USE A SEPARATE TEST ACCOUNT WHEN RUNNING THESE TESTS #
+# ##################################################################
+
+setup() {
+    suiteName="help"
+    setToken "$suiteName"
+    export timestamp=$(date +%s)
+    clean_linodes="FALSE"
+}
+
+@test "it should fail to access an invalid host" {
+    export LINODE_CLI_API_HOST=wrongapi.linode.com
+    run linode-cli linodes ls
+
+    assert_failure
+    assert_output --partial "wrongapi.linode.com"
+}
+
+@test "it should use v4beta when override is set" {
+    export LINODE_CLI_API_VERSION=v4beta
+    run linode-cli linodes ls --debug
+
+    assert_success
+    assert_output --partial "v4beta"
+}
+
+@test "it should fail to access an invalid api scheme" {
+    export LINODE_CLI_API_SCHEME=ssh
+    run linode-cli linodes ls
+
+    assert_failure
+    assert_output --partial "ssh"
+}

--- a/test/cli/host-overrides.bats
+++ b/test/cli/host-overrides.bats
@@ -37,5 +37,5 @@ setup() {
     run linode-cli linodes ls
 
     assert_failure
-    assert_output --partial "ssh"
+    assert_output --partial "ssh://"
 }


### PR DESCRIPTION
## 📝 Description

This change introduces a few new environment variables for dynamically controlling the target Linode API instance:

- `LINODE_CLI_API_HOST`
- `LINODE_CLI_API_VERSION`
- `LINODE_CLI_API_SCHEME`

These environment variables affect the API URL for both configuration and operations.