### PR TITLE
Move consistent fixtures to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 import configparser
-import inspect
 import sys
-from functools import wraps
 
 import pytest
 

--- a/tests/test_api_request.py
+++ b/tests/test_api_request.py
@@ -12,7 +12,6 @@ from unittest.mock import patch, Mock
 import requests
 
 from linodecli import api_request
-from tests.test_populators import mock_cli, create_operation, list_operation
 
 
 class TestAPIRequest:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,6 @@ import pytest
 from terminaltables import SingleTable
 
 from linodecli import api_request, ModelAttr, ResponseModel, OutputMode
-from tests.test_populators import mock_cli, create_operation, list_operation, make_test_operation
 
 
 class TestCLI:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -6,7 +6,6 @@ import sys
 from terminaltables import SingleTable
 
 from linodecli import api_request, ModelAttr, ResponseModel, OutputMode
-from tests.test_populators import mock_cli, create_operation, list_operation
 
 
 class TestOutputHandler:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -6,7 +6,6 @@ from terminaltables import SingleTable
 
 from linodecli import api_request, ModelAttr, ResponseModel, OutputMode
 from linodecli.response import colorize_string
-from tests.test_populators import mock_cli, create_operation, list_operation
 
 
 class TestOutputHandler:


### PR DESCRIPTION
Putting global fixtures in `conftest.py` to allow pytest to automatically collect and use the fixtures without making manual imports.