### PR TITLE
Fix Landing Page Path

### DIFF
--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -2,7 +2,6 @@
 Helper functions for configuration related to auth
 """
 
-import os
 import re
 import socket
 import sys

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -4,10 +4,11 @@ Helper functions for configuration related to auth
 
 import os
 import re
-import sys
 import socket
+import sys
 import webbrowser
 from http import server
+from pathlib import Path
 
 import requests
 
@@ -71,7 +72,7 @@ def _check_full_access(base_url, token):
 
 def _username_for_token(base_url, token):
     """
-    A helper function that returns the username assocaited with a token by
+    A helper function that returns the username associated with a token by
     requesting it from the API
     """
     u = _do_get_request(base_url, "/profile", token=token, exit_on_error=False)
@@ -142,10 +143,7 @@ def _handle_oauth_callback():
     them to a locally-hosted page that captures teh token
     """
     # load up landing page HTML
-    landing_page_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "oauth-landing-page.html"
-    )
-
+    landing_page_path = Path(__file__).parent.parent / "oauth-landing-page.html"
     try:
         with open(landing_page_path, encoding="utf-8") as f:
             landing_page = f.read()


### PR DESCRIPTION
We have a landing page in `linodecli/oauth-landing-page.html` but it was never used due to an incorrect path.
This PR fixes this issue and display it instead of the hard coded default landing page in the source code.

Another thing is that we can use Python's [`pathlib`](https://docs.python.org/3/library/pathlib.html) to replace the lower-level operating system APIs `os.path` for files and path manipulations in most situations, which makes it simplify and easy to understand.