### PR TITLE
fix: Fix broken assertion in OBJ test

### DIFF
--- a/tests/test_plugin_obj.py
+++ b/tests/test_plugin_obj.py
@@ -10,5 +10,5 @@ def test_print_help(capsys: CaptureFixture):
     assert parser.format_help() in captured_text.out
     assert (
         "See --help for individual commands for more information"
-        in captured_text
+        in captured_text.out
     )


### PR DESCRIPTION
## 📝 Description

This change fixes a broken assertion in the `test_print_help` test.

## ✔️ How to Test

```
make test
```