### PR TITLE
new: Add support for human-readable markdown in summaries

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -10,6 +10,7 @@ from sys import version_info
 
 from .api_request import do_request
 from .configuration import CLIConfig
+from .helpers import filter_markdown_links
 from .operation import CLIArg, CLIOperation, URLParam
 from .output import OutputHandler, OutputMode
 from .response import ModelAttr, ResponseModel
@@ -234,7 +235,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
                         action_aliases = action[1:]
                         action = action[0]
 
-                    summary = data[m].get("summary") or ""
+                    summary = filter_markdown_links(data[m].get("summary")) or ""
 
                     # Resolve the documentation URL
                     docs_url = None
@@ -360,7 +361,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
                         new_arg = CLIArg(
                             info["name"],
                             info["type"],
-                            info["desc"].split(".")[0] + ".",
+                            filter_markdown_links(info["desc"].split(".")[0] + "."),
                             arg,
                             info["format"],
                             list_item=info.get("list_item"),

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -3,6 +3,7 @@ Various helper functions shared across multiple CLI components.
 """
 
 import os
+import re
 from urllib.parse import urlparse
 
 API_HOST_OVERRIDE = os.getenv("LINODE_CLI_API_HOST")
@@ -27,3 +28,26 @@ def handle_url_overrides(url):
     return parsed_url._replace(
         **{k: v for k, v in overrides.items() if v is not None}
     ).geturl()
+
+
+def filter_markdown_links(text):
+    """
+    Returns the given text with Markdown links converted to human-readable links.
+    """
+
+    result = text
+
+    # Find all Markdown links
+    r = re.compile(r"\[(?P<text>.*?)]\((?P<link>.*?)\)")
+
+    for match in r.finditer(text):
+        url = match.group("link")
+
+        # Expand the URL if necessary
+        if url.startswith("/"):
+            url = f"https://linode.com{url}"
+
+        # Replace with more readable text
+        result = result.replace(match.group(), f"{match.group('text')} ({url})")
+
+    return result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,14 @@
+from linodecli.helpers import filter_markdown_links
+
+
+class TestHelpers:
+    """
+    Unit tests for linodecli.helpers
+    """
+
+    def test_markdown_links(self):
+        original_text = "Here's [a relative link](/docs/cool) and [an absolute link](https://cloud.linode.com)."
+        expected_text = "Here's a relative link (https://linode.com/docs/cool) " \
+                        "and an absolute link (https://cloud.linode.com)."
+
+        assert filter_markdown_links(original_text) == expected_text


### PR DESCRIPTION
## 📝 Description

This pull request adds support for human-readable markdown links in summaries for both commands and arguments.

For example:
```
Here's [a relative link](/docs/cool) and [an absolute link](https://cloud.linode.com).
```
becomes:
```
Here's a relative link (https://linode.com/docs/cool) and an absolute link (https://cloud.linode.com).
```

## ✔️ How to Test

```
make test
```
