### PR TITLE
Remove efforts to support Python <= 3.5

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -7,7 +7,7 @@ import argparse
 import os
 import sys
 from importlib import import_module
-from sys import argv, stderr, version_info
+from sys import argv
 
 import pkg_resources
 import requests
@@ -37,23 +37,6 @@ BASE_URL = "https://api.linode.com/v4"
 skip_config = any(c in argv for c in ["--skip-config", "--help", "--version"])
 
 cli = CLI(VERSION, handle_url_overrides(BASE_URL), skip_config=skip_config)
-
-
-def warn_python2_eol():
-    """
-    Prints a warning the first time each day that the CLI is used under python2.
-    This is included to help users upgrade to python3 before python2 support is
-    dropped in the CLI.
-    """
-    if version_info.major < 3:
-        print(
-            "You are running the Linode CLI using Python 2, which reached its end of life on "
-            "Jan 1st, 2020.  The Linode CLI will be dropping support for Python 2, and "
-            "upgrading your installation is strongly encouraged so that you can continue "
-            "to receive updates.\n\nFor information about upgrading your installation, see our "
-            "official guide:\n\nhttps://www.linode.com/docs/guides/upgrade-to-linode-cli-python-3/",
-            file=stderr,
-        )
 
 
 def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -205,9 +188,6 @@ def main():  # pylint: disable=too-many-locals,too-many-branches,too-many-statem
 
     cli.output_handler.suppress_warnings = parsed.suppress_warnings
     cli.output_handler.disable_truncation = parsed.no_truncation
-
-    if not cli.suppress_warnings:
-        warn_python2_eol()
 
     if parsed.as_user and not skip_config:
         # if they are acting as a non-default user, set it up early

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -13,8 +13,6 @@ from typing import Optional
 
 import requests
 
-PIP_CMD = "pip3"
-
 
 def do_request(
     ctx, operation, args, filter_header=None, skip_error_handling=False
@@ -228,7 +226,7 @@ def _attempt_warn_old_version(ctx, result):
                 f"The API responded with version {spec_version}, which is newer than "
                 f"the CLI's version of {ctx.spec_version}.  Please update the CLI to get "
                 "access to the newest features.  You can update with a "
-                f"simple `{PIP_CMD} install --upgrade linode-cli`",
+                "simple `pip3 install --upgrade linode-cli`",
                 file=sys.stderr,
             )
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -15,7 +15,6 @@ from .output import OutputHandler, OutputMode
 from .response import ModelAttr, ResponseModel
 
 METHODS = ("get", "post", "put", "delete")
-PIP_CMD = "pip3" if version_info.major == 3 else "pip"
 
 
 class CLI:  # pylint: disable=too-many-instance-attributes

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -2,16 +2,10 @@
 General helper functions for configuraiton
 """
 
+import configparser
 import os
 
 from .auth import _do_get_request
-
-try:
-    # python3
-    import configparser
-except ImportError:
-    # python2
-    import ConfigParser as configparser
 
 LEGACY_CONFIG_NAME = ".linode-cli"
 LEGACY_CONFIG_DIR = os.path.expanduser("~")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 terminaltables
 requests
 PyYAML
-enum34; python_version < '3.4'
-future; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,7 @@ setup(
         "terminaltables",
         "requests",
         "PyYAML",
-        "future; python_version <= '3.0.0'",
     ],
-    extras_require={
-        ":python_version<'3.4'": ["enum34"],
-    },
     entry_points={
         "console_scripts": [
             "linode-cli = linodecli:main",


### PR DESCRIPTION
## 📝 Description

We now require Python >= 3.6 in `setup.py`, so we can drop all the code that was for supporting Python 3.5 and lower versions.

## ✔️ How to Test

Run your favorite linode-cli commands