### PR TITLE
fix: Use top-level `readOnly` value when reading arguments from refs

### DIFF
--- a/test/linodes/linodes.bats
+++ b/test/linodes/linodes.bats
@@ -21,6 +21,12 @@ teardown() {
     fi
 }
 
+@test "it should not allow you to update a linode with an image" {
+    run linode-cli linodes update --help
+
+    refute_output --partial "--image"
+}
+
 @test "it should create linodes with a label" {
     run linode-cli linodes create \
         --type g6-standard-2 \


### PR DESCRIPTION
## 📝 Description

This pull request fixes an issue that would cause certain `readOnly` fields to display as valid updatable fields. For example, `linode-cli linodes update` supported the `--image` field despite this field being read-only.

## ✔️ How to Test

```
cd test
bats linodes/linodes.bats
```
