### PR TITLE
fix: null values for defaults in spec

### DIFF
--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -236,7 +236,9 @@ class CLIConfig:
             if self.config.has_option(username, key):
                 value = self.config.get(username, key)
             else:
-                value = allowed_defaults[key]
+                value = ns_dict[key]
+            if not value:
+                continue
             if key == "authorized_users":
                 ns_dict[key] = [value]
                 warn_dict[key] = [value]

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -206,7 +206,7 @@ class CLIConfig:
     # TODO: this is more of an argparsing function than it is a config function
     # might be better to move this to argparsing during refactor and just have
     # configuration return defaults or keys or something
-    def update(self, namespace, allowed_defaults):
+    def update(self, namespace, allowed_defaults): #pylint: disable=too-many-branches
         """
         This updates a Namespace (as returned by ArgumentParser) with config values
         if they aren't present in the Namespace already.

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -178,15 +178,17 @@ authorized_users = cli-dev2"""
         parser.add_argument('--plugin-testplugin-testkey')
         ns = parser.parse_args(['--testkey', 'testvalue'])
 
-        update_dict = {
-            'newkey': 'newvalue',
-            'authorized_users': ['user1'],
-            'plugin-testplugin-testkey': 'plugin-value',
-        }
+        conf.username = 'tester'
+        conf.config.add_section('tester')
+        conf.config.set('tester', 'token', 'testtoken')
+        conf.config.set('tester', 'newkey', 'newvalue')
+        conf.config.set('tester', 'authorized_users', 'tester')
+        conf.config.set('tester', 'plugin-testplugin-testkey', 'plugin-value')
+        allowed_defaults = {'newkey', 'authorized_users', 'plugin-testplugin-testkey'}
 
         f = io.StringIO()
         with contextlib.redirect_stdout(f):
-            result = vars(conf.update(ns, update_dict))
+            result = vars(conf.update(ns, allowed_defaults))
 
         self.assertTrue("--no-defaults" in f.getvalue())
         self.assertEqual(result.get("newkey"), "newvalue")


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

If the default value isn't set in the config or provided as a argument it will cause a error.
Now it checks if neither are provided and ignores it.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

remove a default value from your config and attempt to create a instance

resolves [#378]