### PR TITLE
Fix Unit Test

### DIFF
--- a/tests/unit/configuration.py
+++ b/tests/unit/configuration.py
@@ -236,7 +236,7 @@ authorized_users = cli-dev2"""
             patch("builtins.input", mock_input),
             contextlib.redirect_stdout(io.StringIO()),
             patch("linodecli.configuration._check_browsers", lambda: False),
-            patch.dict(os.environ, {}),
+            patch.dict(os.environ, {}, clear=True),
             requests_mock.Mocker() as m,
         ):
             m.get(f"{self.base_url}/profile", json={"username": "cli-dev"})


### PR DESCRIPTION
## 📝 Description

Before this fix, if you set `LINODE_CLI_TOKEN` in your environment, the unit test would fail because it assumes that the token is not set and the cli would take input for the token.

## ✔️ How to Test

`make test`
`export LINODE_CLI_TOKEN=<your token>`
`make test` (this may fail in the old version)