### PR TITLE
new: Add integration and unit tests for the `image-upload` plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ test:
 	python -m unittest tests/unit/*.py
 
 
+.PHONY: testint
+testint:
+	pytest tests/integration
+
+
 black:
 	black linodecli tests
 

--- a/Makefile
+++ b/Makefile
@@ -40,17 +40,20 @@ clean:
 	rm -f data-*
 	rm -rf dist
 
-.PHONY: test
-test: export LINODE_CLI_TEST_MODE = 1
-test:
+.PHONY: testunit
+testunit: export LINODE_CLI_TEST_MODE = 1
+testunit:
 	pytest tests/unit
 	python -m unittest tests/unit/*.py
-
 
 .PHONY: testint
 testint:
 	pytest tests/integration
 
+
+# Alias for unit; integration tests should be explicit
+.PHONY: test
+test: testunit
 
 black:
 	black linodecli tests

--- a/tests/integration/test_plugin_image_upload.py
+++ b/tests/integration/test_plugin_image_upload.py
@@ -1,0 +1,120 @@
+import json
+import os
+import subprocess
+import tempfile
+from typing import List
+
+import pytest
+from helpers import get_random_text
+
+REGION = "us-southeast"
+BASE_CMD = ["linode-cli", "image-upload", "--region", REGION]
+
+TEST_IMAGE_CONTENT = bytes(
+    [
+        0x1F,
+        0x8B,
+        0x08,
+        0x08,
+        0xBD,
+        0x5C,
+        0x91,
+        0x60,
+        0x00,
+        0x03,
+        0x74,
+        0x65,
+        0x73,
+        0x74,
+        0x2E,
+        0x69,
+        0x6D,
+        0x67,
+        0x00,
+        0x03,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    ]
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fake_image_file():
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        fp.write(TEST_IMAGE_CONTENT)
+        file_path = fp.name
+
+    yield file_path
+
+    os.remove(file_path)
+
+
+def exec_test_command(args: List[str]):
+    process = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+    )
+    return process
+
+
+def test_help():
+    process = exec_test_command(BASE_CMD + ["--help"])
+    output = process.stdout.decode()
+
+    assert process.returncode == 0
+    assert "positional arguments" in output
+    assert "optional arguments" in output
+
+
+def test_invalid_file(
+    fake_image_file,
+):
+    file_path = fake_image_file + "_fake"
+    process = exec_test_command(
+        BASE_CMD + ["--label", "notimportant", file_path]
+    )
+    output = process.stdout.decode()
+
+    assert process.returncode == 2
+    assert f"No file at {file_path}" in output
+
+
+def test_file_upload(
+    fake_image_file,
+):
+    file_path = fake_image_file
+    label = f"cli-test-{get_random_text()}"
+    description = "test description"
+
+    # Upload the test image
+    process = exec_test_command(
+        BASE_CMD + ["--label", label, "--description", description, file_path]
+    )
+
+    output = process.stdout.decode()
+
+    assert process.returncode == 0
+    assert label in output
+    assert description in output
+    assert "pending_upload" in output
+
+    # Get the new image from the API
+    process = exec_test_command(
+        ["linode-cli", "images", "ls", "--json", "--label", label]
+    )
+    assert process.returncode == 0
+
+    image = json.loads(process.stdout.decode())
+
+    assert image[0]["label"] in output
+
+    # Delete the image
+    process = exec_test_command(["linode-cli", "images", "rm", image[0]["id"]])
+    assert process.returncode == 0

--- a/tests/integration/test_plugin_image_upload.py
+++ b/tests/integration/test_plugin_image_upload.py
@@ -10,38 +10,10 @@ from helpers import get_random_text
 REGION = "us-southeast"
 BASE_CMD = ["linode-cli", "image-upload", "--region", REGION]
 
-TEST_IMAGE_CONTENT = bytes(
-    [
-        0x1F,
-        0x8B,
-        0x08,
-        0x08,
-        0xBD,
-        0x5C,
-        0x91,
-        0x60,
-        0x00,
-        0x03,
-        0x74,
-        0x65,
-        0x73,
-        0x74,
-        0x2E,
-        0x69,
-        0x6D,
-        0x67,
-        0x00,
-        0x03,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-    ]
+# A minimal gzipped image that will be accepted by the API
+TEST_IMAGE_CONTENT = (
+    b"\x1F\x8B\x08\x08\xBD\x5C\x91\x60\x00\x03\x74\x65\x73\x74\x2E\x69"
+    b"\x6D\x67\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 )
 
 

--- a/tests/integration/test_plugin_image_upload.py
+++ b/tests/integration/test_plugin_image_upload.py
@@ -41,8 +41,8 @@ def test_help():
     output = process.stdout.decode()
 
     assert process.returncode == 0
-    assert "positional arguments" in output
-    assert "optional arguments" in output
+    assert "The image file to upload" in output
+    assert "The region to upload the image to" in output
 
 
 def test_invalid_file(

--- a/tests/unit/test_plugin_image_upload.py
+++ b/tests/unit/test_plugin_image_upload.py
@@ -1,0 +1,126 @@
+import importlib
+from unittest.mock import patch
+
+from pytest import CaptureFixture
+
+from linodecli.plugins import PluginContext
+
+# Non-importable package name
+plugin = importlib.import_module("linodecli.plugins.image-upload")
+
+
+def test_print_help(capsys: CaptureFixture):
+    try:
+        plugin.call(["--help"], None)
+    except SystemExit as err:
+        assert err.code == 0
+
+    captured_text = capsys.readouterr().out
+    assert "positional arguments" in captured_text
+    assert "optional arguments" in captured_text
+
+
+def test_no_file(mock_cli, capsys: CaptureFixture):
+    try:
+        plugin.call(
+            ["--label", "cool", "blah.txt"],
+            PluginContext("REALTOKEN", mock_cli),
+        )
+    except SystemExit as err:
+        assert err.code == 2
+
+    captured_text = capsys.readouterr().out
+    assert "No file at blah.txt" in captured_text
+
+
+@patch("os.path.isfile", lambda a: True)
+@patch("os.path.getsize", lambda a: plugin.MAX_UPLOAD_SIZE + 1)
+def test_file_too_large(mock_cli, capsys: CaptureFixture):
+    args = ["--label", "cool", "blah.txt"]
+    ctx = PluginContext("REALTOKEN", mock_cli)
+
+    try:
+        plugin.call(args, ctx)
+    except SystemExit as err:
+        assert err.code == 2
+
+    captured_text = capsys.readouterr().out
+    assert "File blah.txt is too large" in captured_text
+
+
+@patch("os.path.isfile", lambda a: True)
+@patch("os.path.getsize", lambda a: 1)
+def test_unauthorized(mock_cli, capsys: CaptureFixture):
+    args = ["--label", "cool", "blah.txt"]
+
+    mock_cli.call_operation = lambda *a: (401, None)
+
+    ctx = PluginContext("REALTOKEN", mock_cli)
+
+    try:
+        plugin.call(args, ctx)
+    except SystemExit as err:
+        assert err.code == 3
+
+    captured_text = capsys.readouterr().out
+    assert "Your token was not authorized to use this endpoint" in captured_text
+
+
+@patch("os.path.isfile", lambda a: True)
+@patch("os.path.getsize", lambda a: 1)
+def test_non_beta(mock_cli, capsys: CaptureFixture):
+    args = ["--label", "cool", "blah.txt"]
+
+    mock_cli.call_operation = lambda *a: (404, None)
+
+    ctx = PluginContext("REALTOKEN", mock_cli)
+
+    try:
+        plugin.call(args, ctx)
+    except SystemExit as err:
+        assert err.code == 4
+
+    captured_text = capsys.readouterr().out
+    assert (
+        "It looks like you are not in the Machine Images Beta" in captured_text
+    )
+
+
+@patch("os.path.isfile", lambda a: True)
+@patch("os.path.getsize", lambda a: 1)
+def test_non_beta(mock_cli, capsys: CaptureFixture):
+    args = ["--label", "cool", "blah.txt"]
+
+    mock_cli.call_operation = lambda *a: (404, None)
+
+    ctx = PluginContext("REALTOKEN", mock_cli)
+
+    try:
+        plugin.call(args, ctx)
+    except SystemExit as err:
+        assert err.code == 4
+
+    captured_text = capsys.readouterr().out
+    assert (
+        "It looks like you are not in the Machine Images Beta" in captured_text
+    )
+
+
+@patch("os.path.isfile", lambda a: True)
+@patch("os.path.getsize", lambda a: 1)
+def test_failed_upload(mock_cli, capsys: CaptureFixture):
+    args = ["--label", "cool", "blah.txt"]
+    mock_cli.call_operation = lambda *a: (500, "it borked :(")
+
+    ctx = PluginContext("REALTOKEN", mock_cli)
+
+    try:
+        plugin.call(args, ctx)
+    except SystemExit as err:
+        assert err.code == 3
+
+    captured_text = capsys.readouterr().out
+    assert (
+        "Upload failed with status 500; response was it borked :("
+        in captured_text
+    )

--- a/tests/unit/test_plugin_image_upload.py
+++ b/tests/unit/test_plugin_image_upload.py
@@ -16,8 +16,8 @@ def test_print_help(capsys: CaptureFixture):
         assert err.code == 0
 
     captured_text = capsys.readouterr().out
-    assert "positional arguments" in captured_text
-    assert "optional arguments" in captured_text
+    assert "The image file to upload" in captured_text
+    assert "The region to upload the image to" in captured_text
 
 
 def test_no_file(mock_cli, capsys: CaptureFixture):


### PR DESCRIPTION
## 📝 Description

This change introduces unit and integration tests for the `image-upload` plugin. Additionally, it adds a `make testint` target for running integration tests.

## ✔️ How to Test

```
make testint
make testunit
```
