### PR TITLE
fix: Use `GITHUB_TOKEN` in `make install` to prevent rate-limiting from GitHub

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Package
         run: make install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run the unit test suite
         run: make test


### PR DESCRIPTION
## 📝 Description

This change adds the GITHUB_TOKEN environment variable to the `make install` command in the unit test GitHub Action. This should prevent rate-limiting and make the unit test workflow more reliable.
