### PR TITLE
Put obj Plugin Integration Test Files in a Tempfile Directory

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,9 +6,12 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from itertools import count
+from pathlib import Path
 from random import randint
+from typing import Callable, Optional
 
 import pytest
+from helpers import get_random_text
 
 from linodecli import ENV_TOKEN_NAME
 
@@ -59,3 +62,29 @@ def token():
             f"Token is required in the environment as {ENV_TOKEN_NAME}"
         )
     return token
+
+
+@pytest.fixture
+def generate_test_files(name_generator: Callable[[str], str]):
+    """
+    Return a function that can generate files with random text.
+    """
+    test_files_dir = tempfile.TemporaryDirectory()
+
+    def _generate_test_files(
+        num: Optional[int] = 1, content: Optional[str] = None
+    ):
+        if content is None:
+            content = f"Linode CLI integration test\n{get_random_text(100)}\n"
+        file_paths = [
+            Path(test_files_dir.name) / f"{name_generator('test-file')}.txt"
+            for _ in range(num)
+        ]
+        file_paths = [f.resolve() for f in file_paths]
+        for f in file_paths:
+            with open(f, "w") as f:
+                f.write(content)
+        return file_paths
+
+    yield _generate_test_files
+    test_files_dir.cleanup()

--- a/tests/integration/fixture_types.py
+++ b/tests/integration/fixture_types.py
@@ -1,0 +1,7 @@
+"""
+Complicated type alias for fixtures and other stuff.
+"""
+from pathlib import Path
+from typing import Callable, List, Optional
+
+GetTestFileType = Callable[[Optional[int], Optional[str]], List[Path]]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,8 +1,7 @@
 import random
 import time
-from pathlib import Path
 from string import ascii_lowercase
-from typing import Callable, Optional
+from typing import Callable
 
 BASE_URL = "https://api.linode.com/v4/"
 
@@ -11,22 +10,6 @@ COMMAND_JSON_OUTPUT = ["--suppress-warnings", "--no-defaults", "--json"]
 
 def get_random_text(length: int = 10):
     return "".join(random.choice(ascii_lowercase) for i in range(length))
-
-
-def create_file_random_text(
-    name_generator: Callable,
-    dir_path: Optional[Path] = None,
-    filename: Optional[str] = None,
-):
-    if not dir_path:
-        dir_path = Path(__file__).parent
-    if not filename:
-        filename = f"{name_generator('test-file')}.txt"
-    content = "Linode CLI integration test\n" f"{get_random_text(100)}\n"
-    file_path = dir_path / filename
-    with open(file_path, "w") as f:
-        f.write(content + "\n")
-    return file_path.resolve()
 
 
 def wait_for_condition(interval: int, timeout: int, condition: Callable):

--- a/tests/integration/test_obj_plugin.py
+++ b/tests/integration/test_obj_plugin.py
@@ -6,7 +6,8 @@ from typing import Callable, List, Optional, Set
 
 import pytest
 import requests
-from helpers import BASE_URL, create_file_random_text
+from fixture_types import GetTestFileType
+from helpers import BASE_URL
 from pytest import MonkeyPatch
 
 from linodecli.configuration.auth import _do_request
@@ -57,6 +58,8 @@ def keys(token: str):
 
 
 def patch_keys(keys: Keys, monkeypatch: MonkeyPatch):
+    assert keys.access_key is not None
+    assert keys.secret_key is not None
     monkeypatch.setenv("LINODE_CLI_OBJ_ACCESS_KEY", keys.access_key)
     monkeypatch.setenv("LINODE_CLI_OBJ_SECRET_KEY", keys.secret_key)
 
@@ -91,13 +94,14 @@ def delete_bucket(bucket_name: str, force: bool = True):
 
 
 def test_obj_single_file_single_bucket(
-    name_generator: Callable,
+    name_generator: Callable[[str], str],
+    generate_test_files: GetTestFileType,
     created_buckets: Set[str],
     keys: Keys,
     monkeypatch: MonkeyPatch,
 ):
     patch_keys(keys, monkeypatch)
-    file_path = create_file_random_text(name_generator)
+    file_path = generate_test_files()[0]
     bucket_name = create_bucket(name_generator, created_buckets)
     exec_test_command(BASE_CMD + ["put", str(file_path), bucket_name])
     process = exec_test_command(BASE_CMD + ["la"])
@@ -133,7 +137,8 @@ def test_obj_single_file_single_bucket(
 
 
 def test_multi_files_multi_bucket(
-    name_generator: Callable,
+    name_generator: Callable[[str], str],
+    generate_test_files: GetTestFileType,
     created_buckets: Set[str],
     keys: Keys,
     monkeypatch: MonkeyPatch,
@@ -143,9 +148,7 @@ def test_multi_files_multi_bucket(
     bucket_names = [
         create_bucket(name_generator, created_buckets) for _ in range(number)
     ]
-    file_paths = [
-        create_file_random_text(name_generator) for _ in range(number)
-    ]
+    file_paths = generate_test_files(number)
     for bucket in bucket_names:
         for file in file_paths:
             process = exec_test_command(


### PR DESCRIPTION
## 📝 Description

Python `tempfile` module helps to clean up the generated files. Preventing junk files left when test cases fail.

## ✔️ How to Test

`make testint`
