### PR TITLE
new: Add support for `/acctest` command

### DIFF
--- a/.github/workflows/e2e-suite-pr-command.yml
+++ b/.github/workflows/e2e-suite-pr-command.yml
@@ -1,0 +1,29 @@
+name: AccTest Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  acctest-command:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Generate App Installation Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.DX_ACCTEST_APP_ID }}
+          private_key: ${{ secrets.DX_ACCTEST_PRIV_KEY }}
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v1
+        env:
+          TOKEN: ${{ steps.generate_token.outputs.token }}
+        with:
+          token: ${{ env.TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: acctest
+          named-args: true
+          permission: write

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -19,7 +19,7 @@ jobs:
         id: validate-tests
         with:
           text: ${{ github.event.client_payload.slash_command.tests }}
-          regex: '[^a-z0-9-:.\/]'  # Tests validation
+          regex: '[^a-z0-9_-:.\/]'  # Tests validation
           flags: gi
 
       # Check out merge commit

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
     types: [acctest-command]
 
-name: Run Integration Tests
+name: PR E2e Tests
 
 jobs:
   # Maintainer has commented /acctest on a pull request

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -19,7 +19,7 @@ jobs:
         id: validate-tests
         with:
           text: ${{ github.event.client_payload.slash_command.tests }}
-          regex: '[^a-z0-9\_-:.\/]'  # Tests validation
+          regex: '[^a-z0-9-:.\/_]'  # Tests validation
           flags: gi
 
       # Check out merge commit

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python deps
-        run: pip install -r requirements.txt -r requirements-dev.txt wheel
+        run: pip install -r requirements.txt -r requirements-dev.txt wheel boto
 
       - name: Install the CLI
         run: make install

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -19,7 +19,7 @@ jobs:
         id: validate-tests
         with:
           text: ${{ github.event.client_payload.slash_command.tests }}
-          regex: '[^a-z0-9_-:.\/]'  # Tests validation
+          regex: '[^a-z0-9\_-:.\/]'  # Tests validation
           flags: gi
 
       # Check out merge commit

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python deps
-        run: pip install wheel
+        run: pip install -r requirements.txt -r requirements-dev.txt wheel
 
       - name: Install the CLI
         run: make install

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -3,7 +3,7 @@ on:
   repository_dispatch:
     types: [acctest-command]
 
-name: PR E2e Tests
+name: PR E2E Tests
 
 jobs:
   # Maintainer has commented /acctest on a pull request

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -1,0 +1,81 @@
+on:
+  pull_request:
+  repository_dispatch:
+    types: [acctest-command]
+
+name: Run Integration Tests
+
+jobs:
+  # Maintainer has commented /acctest on a pull request
+  integration-fork:
+    runs-on: ubuntu-latest
+    if:
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.sha != '' &&
+      github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.sha
+
+    steps:
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: validate-tests
+        with:
+          text: ${{ github.event.client_payload.slash_command.tests }}
+          regex: '[^a-z0-9-:.\/]'  # Tests validation
+          flags: gi
+
+      # Check out merge commit
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.slash_command.sha }}
+
+      - name: Update system packages
+        run: sudo apt-get update -y
+
+      - name: Install system deps
+        run: sudo apt-get install -y build-essential
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Python deps
+        run: pip install wheel
+
+      - name: Install the CLI
+        run: make install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: make INTEGRATION_TEST_PATH="${{ github.event.client_payload.slash_command.tests }}" testint
+        if: ${{ steps.validate-tests.outputs.match == '' }}
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
+
+      - uses: actions/github-script@v5
+        id: update-check-run
+        if: ${{ always() }}
+        env:
+          number: ${{ github.event.client_payload.pull_request.number }}
+          job: ${{ github.job }}
+          conclusion: ${{ job.status }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+            return result;

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Makefile for more convenient building of the Linode CLI and its baked content
 #
 
+INTEGRATION_TEST_PATH :=
+
 SPEC_VERSION ?= latest
 ifndef SPEC
 override SPEC = $(shell ./resolve_spec_url ${SPEC_VERSION})
@@ -48,7 +50,7 @@ testunit:
 
 .PHONY: testint
 testint:
-	pytest tests/integration
+	pytest tests/integration/${INTEGRATION_TEST_PATH}
 
 
 # Alias for unit; integration tests should be explicit


### PR DESCRIPTION
## 📝 Description

This change adds support for the `/acctest` command, which allows maintainers to run integration tests on PRs using a command and commit hash. This implementation mimics the implementation for other DX-owned repos (terraform-provider-linode, ansible_linode, etc.)

The following environment variables will need to be added to the secrets of this repository:
- DX_ACCTEST_APP_ID
- DX_ACCTEST_PRIV_KEY

**NOTE: This change excludes bats tests due to the planned removal of bats in the near future. See #394**

## ✔️ How to Test

```
/acctest sha=mycommitsha
```

```
/acctest sha=mycommitsha tests=test_plugin_image_upload.py::test_file_upload
```

See https://github.com/lgarber-akamai/linode-cli/pull/1