### PR TITLE
Fix Plugin Discover

### DIFF
--- a/linodecli/plugins/__init__.py
+++ b/linodecli/plugins/__init__.py
@@ -37,7 +37,7 @@ def is_plugin(f: Path):
 
 
 available_local = [
-    f.name for f in Path.iterdir(this_file.parent) if is_plugin(f)
+    f.stem for f in Path.iterdir(this_file.parent) if is_plugin(f)
 ]
 
 


### PR DESCRIPTION
## 📝 Description

Fixed an issue caused by my previous PR. The plugin name should not contains the extension of the file name (`.py`).