### PR TITLE
fix: Add packaging to install_requires and drop version specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 terminaltables
 requests
 PyYAML
-packaging>=23.0
+packaging

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "terminaltables",
         "requests",
         "PyYAML",
+        "packaging"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## 📝 Description

This change adds the `packaging` package to `install_requires` and drops the version specifier from requirements.txt.

Thanks @okoriko!
