### PR TITLE
Bump Python version requirement to 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,6 @@ setup(
         ]
     },
     data_files=get_baked_files(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
 )


### PR DESCRIPTION
## 📝 Description

The status of Python 3.6 is end of life, and may contains unfixed security issues and other bugs.
https://devguide.python.org/versions/#unsupported-versions

Other cloud provider's tools such as AWS and Azure dropped Python 3.6 support.
https://github.com/aws/aws-cli/blob/dd48afaaa8b9e682579b1a35109d910ca78aae01/setup.py#L51
https://github.com/Azure/azure-cli/blob/c02d63182860feab89da2502c46bae008b7a3fa2/src/azure-cli/setup.py#L176

It is the time for us to make an similar decision.