### PR TITLE
new: Add support for explicit nullable arguments

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -14,7 +14,7 @@ from requests import Response
 
 from linodecli.helpers import API_CA_PATH
 
-from .baked.operation import OpenAPIOperation
+from .baked.operation import ExplicitNullValue, OpenAPIOperation
 from .helpers import handle_url_overrides
 
 
@@ -194,7 +194,19 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
             parsed_args, operation.allowed_defaults, operation.action
         )
 
-    to_json = {k: v for k, v in vars(parsed_args).items() if v is not None}
+    to_json = {}
+
+    for k, v in vars(parsed_args).items():
+        # Skip null values
+        if v is None:
+            continue
+
+        # Explicitly include ExplicitNullValues
+        if isinstance(v, ExplicitNullValue):
+            to_json[k] = None
+            continue
+
+        to_json[k] = v
 
     expanded_json = {}
 

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -378,7 +378,7 @@ class OpenAPIOperation:
                         "--" + arg.path,
                         metavar=arg.name,
                         action="append",
-                        type=TYPES[arg.item_type],
+                        type=arg_type_handler,
                     )
                 elif arg.list_item:
                     parser.add_argument(

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -364,12 +364,13 @@ class OpenAPIOperation:
                 if arg.read_only:
                     continue
 
-                arg_type_handler = TYPES[
+                arg_type = (
                     arg.item_type if arg.datatype == "array" else arg.datatype
-                ]
+                )
+                arg_type_handler = TYPES[arg_type]
 
                 if arg.nullable:
-                    arg_type_handler = wrap_parse_nullable_value(arg.datatype)
+                    arg_type_handler = wrap_parse_nullable_value(arg_type)
 
                 if arg.datatype == "array":
                     # special handling for input arrays

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -402,7 +402,11 @@ class OpenAPIOperation:
 
         return list_items
 
-    def _handle_list_items(self, list_items, parsed):
+    @staticmethod
+    def _handle_list_items(
+        list_items,
+        parsed,
+    ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         lists = {}
         # group list items as expected
         for arg_name, list_name in list_items:
@@ -464,9 +468,7 @@ class OpenAPIOperation:
 
         return parsed
 
-    def parse_args(
-        self, args
-    ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    def parse_args(self, args):
         """
         Given sys.argv after the operation name, parse args based on the params
         and args of this operation

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -65,6 +65,9 @@ class OpenAPIRequestArg:
         #: The path of the path element in the schema.
         self.prefix = prefix
 
+        #: Whether null is an acceptable value for this attribute
+        self.nullable = schema.nullable
+
         # handle the type for list values if this is an array
         if self.datatype == "array" and schema.items:
             self.item_type = schema.items.type

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -85,3 +85,15 @@ components:
           x-linode-filterable: true
           type: string
           description: The region
+        nullable_int:
+          type: integer
+          nullable: true
+          description: An arbitrary nullable int
+        nullable_string:
+          type: string
+          nullable: true
+          description: An arbitrary nullable string
+        nullable_float:
+          type: number
+          nullable: true
+          description: An arbitrary nullable float

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -57,6 +57,30 @@ class TestAPIRequest:
     def test_build_request_body(self, mock_cli, create_operation):
         create_operation.allowed_defaults = ["region", "engine"]
         create_operation.action = "mysql-create"
+
+        result = api_request._build_request_body(
+            mock_cli,
+            create_operation,
+            SimpleNamespace(
+                generic_arg="foo",
+                region=None,
+                engine=None,
+            ),
+        )
+        assert (
+            json.dumps(
+                {
+                    "generic_arg": "foo",
+                    "region": "us-southeast",
+                    "engine": "mysql/8.0.26",
+                }
+            )
+            == result
+        )
+
+    def test_build_request_body_null_field(self, mock_cli, create_operation):
+        create_operation.allowed_defaults = ["region", "engine"]
+        create_operation.action = "mysql-create"
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
@@ -79,7 +103,11 @@ class TestAPIRequest:
             == result
         )
 
-        # The nullable field should be excluded
+    def test_build_request_body_non_null_field(
+        self, mock_cli, create_operation
+    ):
+        create_operation.allowed_defaults = ["region", "engine"]
+        create_operation.action = "mysql-create"
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
@@ -87,6 +115,7 @@ class TestAPIRequest:
                 generic_arg="foo",
                 region=None,
                 engine=None,
+                nullable_int=12345,
             ),
         )
         assert (
@@ -95,6 +124,7 @@ class TestAPIRequest:
                     "generic_arg": "foo",
                     "region": "us-southeast",
                     "engine": "mysql/8.0.26",
+                    "nullable_int": 12345,
                 }
             )
             == result

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 import requests
 
 from linodecli import api_request
+from linodecli.baked.operation import ExplicitNullValue
 
 
 class TestAPIRequest:
@@ -59,7 +60,34 @@ class TestAPIRequest:
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
-            SimpleNamespace(generic_arg="foo", region=None, engine=None),
+            SimpleNamespace(
+                generic_arg="foo",
+                region=None,
+                engine=None,
+                nullable_int=ExplicitNullValue(),
+            ),
+        )
+        assert (
+            json.dumps(
+                {
+                    "generic_arg": "foo",
+                    "region": "us-southeast",
+                    "engine": "mysql/8.0.26",
+                    "nullable_int": None,
+                }
+            )
+            == result
+        )
+
+        # The nullable field should be excluded
+        result = api_request._build_request_body(
+            mock_cli,
+            create_operation,
+            SimpleNamespace(
+                generic_arg="foo",
+                region=None,
+                engine=None,
+            ),
         )
         assert (
             json.dumps(

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,6 +1,7 @@
 import argparse
 
 from linodecli.baked import operation
+from linodecli.baked.operation import ExplicitNullValue
 
 
 class TestOperation:
@@ -127,3 +128,33 @@ class TestOperation:
         )
 
         assert getattr(result, "path") == "/path/get"
+
+    def test_parse_args_nullable_string(self, create_operation):
+        result = create_operation.parse_args(
+            ["--nullable_string", "null", "--region", "null"]
+        )
+        assert result.region == "null"
+        assert isinstance(result.nullable_string, ExplicitNullValue)
+
+        result = create_operation.parse_args(["--nullable_string", "foobar"])
+        assert result.nullable_string == "foobar"
+
+    def test_parse_args_nullable_integer(self, create_operation):
+        result = create_operation.parse_args(
+            ["--nullable_int", "null", "--region", "null"]
+        )
+        assert result.region == "null"
+        assert isinstance(result.nullable_int, ExplicitNullValue)
+
+        result = create_operation.parse_args(["--nullable_int", "456"])
+        assert result.nullable_int == 456
+
+    def test_parse_args_nullable_float(self, create_operation):
+        result = create_operation.parse_args(
+            ["--nullable_float", "null", "--region", "null"]
+        )
+        assert result.region == "null"
+        assert isinstance(result.nullable_float, ExplicitNullValue)
+
+        result = create_operation.parse_args(["--nullable_float", "456.123"])
+        assert result.nullable_float == 456.123


### PR DESCRIPTION
## 📝 Description

This change allows users to specify `null` as a value for fields that are marked as `nullable` in the API spec. This is useful for situations where the API may have certain functionality tied to having a certain value be explicitly `null` (e.g. RDNS resets)

e.g.
```bash
linode-cli networking ip-update --rdns null 127.0.0.1
```

**NOTE: This will need to be partially reworked after the spec parser refactor, but the change should be relatively straightforward.**

Resolves #266 

## ✔️ How to Test

```
make testunit
```
