### PR TITLE
Add default values for database engines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Suppressing Defaults
 """"""""""""""""""""
 
 If you configured default values for ``image``, ``authorized_users``, ``region``,
-and Linode ``type``, they will be sent for all requests that accept them if you
-do not specify a different value.  If you want to send a request *without* these
+database ``engine``, and Linode ``type``, they will be sent for all requests that accept them
+if you do not specify a different value.  If you want to send a request *without* these
 arguments, you must invoke the CLI with the ``--no-defaults`` option.
 
 For example, to create a Linode with no ``image`` after a default Image has been
@@ -474,7 +474,7 @@ added to Linode's OpenAPI spec:
 |x-linode-cli-skip            | path        | If present and truthy, this method will not be available in the CLI.                      |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 +x-linode-cli-allowed-defaults| requestBody | Tells the CLI what configured defaults apply to this request. Valid defaults are "region",|
-+                             |             | "image", "authorized_users", and "type".                                                  |
++                             |             | "image", "authorized_users", "engine", and "type".                                        |
 +-----------------------------+-------------+-------------------------------------------------------------------------------------------+
 +x-linode-cli-nested-list     | content-type| Tells the CLI to flatten a single object into multiple table rows based on the keys       |
 |                             |             | included in this value.  Values should be comma-delimited JSON paths, and must all be     |

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -100,7 +100,7 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
 
     # Merge defaults into body if applicable
     if ctx.defaults:
-        parsed_args = ctx.config.update(parsed_args, operation.allowed_defaults)
+        parsed_args = ctx.config.update(parsed_args, operation.allowed_defaults, operation.action)
 
     to_json = {k: v for k, v in vars(parsed_args).items() if v is not None}
 

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -100,7 +100,9 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
 
     # Merge defaults into body if applicable
     if ctx.defaults:
-        parsed_args = ctx.config.update(parsed_args, operation.allowed_defaults, operation.action)
+        parsed_args = ctx.config.update(
+            parsed_args, operation.allowed_defaults, operation.action
+        )
 
     to_json = {k: v for k, v in vars(parsed_args).items() if v is not None}
 

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -336,6 +336,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
         images = [
             i["id"] for i in _do_get_request(self.base_url, "/images")["data"]
         ]
+        engines = [
+            e["id"] for e in _do_get_request(self.base_url, "/engines")["data"]
+        ]
 
         is_full_access = _check_full_access(self.base_url, token)
 
@@ -376,6 +379,13 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             images,
             "Default Image (Optional): ",
             "Please select a valid Image, or press Enter to skip",
+        )
+
+        config["engine"] = _default_thing_input(
+            "Default Engine to create a new managed database.",
+            engines,
+            "Default Engine (Optional): ",
+            "Please select a valid Database Engine, or press Enter to skip",
         )
 
         if auth_users:

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -245,10 +245,13 @@ class CLIConfig:
             # different types of database creation use different endpoints,
             # so we need to set the default engine value based on the type
             elif key == "engine":
-                if action == "mysql-create" and self.config.has_option(username, "mysql_engine"):
+                if action == "mysql-create" and self.config.has_option(
+                    username, "mysql_engine"
+                ):
                     value = self.config.get(username, "mysql_engine")
-                elif action == "postgresql-create" and self.config.has_option(username, "postgresql_engine"):
-                    print(self.config.get(username, "postgresql_engine"))
+                elif action == "postgresql-create" and self.config.has_option(
+                    username, "postgresql_engine"
+                ):
                     value = self.config.get(username, "postgresql_engine")
             else:
                 value = ns_dict[key]
@@ -283,7 +286,7 @@ class CLIConfig:
 
     def configure(
         self,
-    ):  # pylint: disable=too-many-branches,too-many-statements
+    ):  # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         """
         This assumes we're running interactively, and prompts the user
         for a series of defaults in order to make future CLI calls
@@ -344,8 +347,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
         images = [
             i["id"] for i in _do_get_request(self.base_url, "/images")["data"]
         ]
-        engines_list = _do_get_request(
-            self.base_url, "/databases/engines")["data"]
+        engines_list = _do_get_request(self.base_url, "/databases/engines")[
+            "data"
+        ]
         mysql_engines = [
             e["id"] for e in engines_list if e["engine"] == "mysql"
         ]

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -118,7 +118,7 @@ def _default_thing_input(
     return ret
 
 
-def _handle_no_default_user(self):
+def _handle_no_default_user(self):  # pylint: disable=too-many-branches
     """
     Handle the case that there is no default user in the config
     """

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -156,7 +156,7 @@ def _handle_no_default_user(self):
                 if self.config.has_option("DEFAULT", "region"):
                     self.config.set(
                         username, "region", self.config.get("DEFAULT", "region")
-                    ),
+                    )
 
                 if self.config.has_option("DEFAULT", "type"):
                     self.config.set(

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -124,68 +124,69 @@ def _handle_no_default_user(self):
     """
     users = [c for c in self.config.sections() if c != "DEFAULT"]
 
-    if len(users) == 1:
-        # only one user configured - they're the default
-        self.config.set("DEFAULT", "default-user", users[0])
-        self.write_config()
-        return
-
-    if len(users) == 0:
-        # config is new or _really_ old
-        token = self.config.get("DEFAULT", "token")
-
-        if token is not None:
-            # there's a token in the config - configure that user
-            u = _do_get_request(
-                self.base_url, "/profile", token=token, exit_on_error=False
-            )
-
-            if "errors" in u:
-                # this token was bad - reconfigure
-                self.configure()
-                return
-
-            # setup config for this user
-            username = u["username"]
-
-            self.config.set("DEFAULT", "default-user", username)
-            self.config.add_section(username)
-            self.config.set(username, "token", token)
-
-            if self.config.has_option("DEFAULT", "region"):
-                self.config.set(
-                    username, "region", self.config.get("DEFAULT", "region")
-                )
-
-            if self.config.has_option("DEFAULT", "type"):
-                self.config.set(
-                    username, "type", self.config.get("DEFAULT", "type")
-                )
-
-            if self.config.has_option("DEFAULT", "image"):
-                self.config.set(
-                    username, "image", self.config.get("DEFAULT", "image")
-                )
-
-            if self.config.has_option("DEFAULT", "engine"):
-                self.config.set(
-                    username, "engine", self.config.get("DEFAULT", "engine")
-                )
-
-            if self.config.has_option("DEFAULT", "authorized_keys"):
-                self.config.set(
-                    username,
-                    "authorized_keys",
-                    self.config.get("DEFAULT", "authorized_keys"),
-                )
-
+    match len(users):
+        case 1:
+            # only one user configured - they're the default
+            self.config.set("DEFAULT", "default-user", users[0])
             self.write_config()
-        else:
-            # got nothin', reconfigure
-            self.configure()
+            return
 
-        # this should be handled
-        return
+        case 0:
+            # config is new or _really_ old
+            token = self.config.get("DEFAULT", "token")
+
+            if token is not None:
+                # there's a token in the config - configure that user
+                u = _do_get_request(
+                    self.base_url, "/profile", token=token, exit_on_error=False
+                )
+
+                if "errors" in u:
+                    # this token was bad - reconfigure
+                    self.configure()
+                    return
+
+                # setup config for this user
+                username = u["username"]
+
+                self.config.set("DEFAULT", "default-user", username)
+                self.config.add_section(username)
+                self.config.set(username, "token", token)
+
+                if self.config.has_option("DEFAULT", "region"):
+                    self.config.set(
+                        username, "region", self.config.get("DEFAULT", "region")
+                    ),
+
+                if self.config.has_option("DEFAULT", "type"):
+                    self.config.set(
+                        username, "type", self.config.get("DEFAULT", "type")
+                    )
+
+                if self.config.has_option("DEFAULT", "image"):
+                    self.config.set(
+                        username, "image", self.config.get("DEFAULT", "image")
+                    )
+
+                if self.config.has_option("DEFAULT", "engine"):
+                    self.config.set(
+                        username, "engine", self.config.get("DEFAULT", "engine")
+                    )
+
+                if self.config.has_option("DEFAULT", "authorized_keys"):
+                    self.config.set(
+                        username,
+                        "authorized_keys",
+                        self.config.get("DEFAULT", "authorized_keys"),
+                    )
+
+                self.write_config()
+            else:
+                # got nothin', reconfigure
+                self.configure()
+
+            # this should be handled
+            return
 
     # more than one user - prompt for the default
     print("Please choose the active user.  Configured users are:")

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -167,6 +167,11 @@ def _handle_no_default_user(self):
                     username, "image", self.config.get("DEFAULT", "image")
                 )
 
+            if self.config.has_option("DEFAULT", "engine"):
+                self.config.set(
+                    username, "engine", self.config.get("DEFAULT", "engine")
+                )
+
             if self.config.has_option("DEFAULT", "authorized_keys"):
                 self.config.set(
                     username,

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -124,69 +124,68 @@ def _handle_no_default_user(self):
     """
     users = [c for c in self.config.sections() if c != "DEFAULT"]
 
-    match len(users):
-        case 1:
-            # only one user configured - they're the default
-            self.config.set("DEFAULT", "default-user", users[0])
-            self.write_config()
-            return
+    if len(users) == 1:
+        # only one user configured - they're the default
+        self.config.set("DEFAULT", "default-user", users[0])
+        self.write_config()
+        return
 
-        case 0:
-            # config is new or _really_ old
-            token = self.config.get("DEFAULT", "token")
+    if len(users) == 0:
+        # config is new or _really_ old
+        token = self.config.get("DEFAULT", "token")
 
-            if token is not None:
-                # there's a token in the config - configure that user
-                u = _do_get_request(
-                    self.base_url, "/profile", token=token, exit_on_error=False
+        if token is not None:
+            # there's a token in the config - configure that user
+            u = _do_get_request(
+                self.base_url, "/profile", token=token, exit_on_error=False
+            )
+
+            if "errors" in u:
+                # this token was bad - reconfigure
+                self.configure()
+                return
+
+            # setup config for this user
+            username = u["username"]
+
+            self.config.set("DEFAULT", "default-user", username)
+            self.config.add_section(username)
+            self.config.set(username, "token", token)
+
+            if self.config.has_option("DEFAULT", "region"):
+                self.config.set(
+                    username, "region", self.config.get("DEFAULT", "region")
                 )
 
-                if "errors" in u:
-                    # this token was bad - reconfigure
-                    self.configure()
-                    return
+            if self.config.has_option("DEFAULT", "type"):
+                self.config.set(
+                    username, "type", self.config.get("DEFAULT", "type")
+                )
 
-                # setup config for this user
-                username = u["username"]
+            if self.config.has_option("DEFAULT", "image"):
+                self.config.set(
+                    username, "image", self.config.get("DEFAULT", "image")
+                )
 
-                self.config.set("DEFAULT", "default-user", username)
-                self.config.add_section(username)
-                self.config.set(username, "token", token)
+            if self.config.has_option("DEFAULT", "engine"):
+                self.config.set(
+                    username, "engine", self.config.get("DEFAULT", "engine")
+                )
 
-                if self.config.has_option("DEFAULT", "region"):
-                    self.config.set(
-                        username, "region", self.config.get("DEFAULT", "region")
-                    )
+            if self.config.has_option("DEFAULT", "authorized_keys"):
+                self.config.set(
+                    username,
+                    "authorized_keys",
+                    self.config.get("DEFAULT", "authorized_keys"),
+                )
 
-                if self.config.has_option("DEFAULT", "type"):
-                    self.config.set(
-                        username, "type", self.config.get("DEFAULT", "type")
-                    )
+            self.write_config()
+        else:
+            # got nothin', reconfigure
+            self.configure()
 
-                if self.config.has_option("DEFAULT", "image"):
-                    self.config.set(
-                        username, "image", self.config.get("DEFAULT", "image")
-                    )
-
-                if self.config.has_option("DEFAULT", "engine"):
-                    self.config.set(
-                        username, "engine", self.config.get("DEFAULT", "engine")
-                    )
-
-                if self.config.has_option("DEFAULT", "authorized_keys"):
-                    self.config.set(
-                        username,
-                        "authorized_keys",
-                        self.config.get("DEFAULT", "authorized_keys"),
-                    )
-
-                self.write_config()
-            else:
-                # got nothin', reconfigure
-                self.configure()
-
-            # this should be handled
-            return
+        # this should be handled
+        return
 
     # more than one user - prompt for the default
     print("Please choose the active user.  Configured users are:")

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -169,12 +169,16 @@ def _handle_no_default_user(self):  # pylint: disable=too-many-branches
 
             if self.config.has_option("DEFAULT", "mysql_engine"):
                 self.config.set(
-                    username, "mysql_engine", self.config.get("DEFAULT", "mysql_engine")
+                    username,
+                    "mysql_engine",
+                    self.config.get("DEFAULT", "mysql_engine"),
                 )
 
             if self.config.has_option("DEFAULT", "postgresql_engine"):
                 self.config.set(
-                    username, "postgresql_engine", self.config.get("DEFAULT", "postgresql_engine")
+                    username,
+                    "postgresql_engine",
+                    self.config.get("DEFAULT", "postgresql_engine"),
                 )
 
             if self.config.has_option("DEFAULT", "authorized_keys"):

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -167,9 +167,14 @@ def _handle_no_default_user(self):  # pylint: disable=too-many-branches
                     username, "image", self.config.get("DEFAULT", "image")
                 )
 
-            if self.config.has_option("DEFAULT", "engine"):
+            if self.config.has_option("DEFAULT", "mysql_engine"):
                 self.config.set(
-                    username, "engine", self.config.get("DEFAULT", "engine")
+                    username, "mysql_engine", self.config.get("DEFAULT", "mysql_engine")
+                )
+
+            if self.config.has_option("DEFAULT", "postgresql_engine"):
+                self.config.set(
+                    username, "postgresql_engine", self.config.get("DEFAULT", "postgresql_engine")
                 )
 
             if self.config.has_option("DEFAULT", "authorized_keys"):

--- a/tests/unit/configuration.py
+++ b/tests/unit/configuration.py
@@ -32,13 +32,15 @@ type = g6-nanode-1
 image = linode/alpine3.16
 plugin-testplugin-testkey = plugin-test-value
 authorized_users = cli-dev
+engine = mysql/8.0.26
 
 [cli-dev2]
 token = {test_token}2
 region = us-east
 type = g6-nanode-1
 image = linode/alpine3.16
-authorized_users = cli-dev2"""
+authorized_users = cli-dev2
+engine = mysql/8.0.26"""
 
     def _build_test_config(self, config=mock_config_file, base_url=base_url):
         """
@@ -259,6 +261,9 @@ authorized_users = cli-dev2"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
+                f"{self.base_url}/engines", json={"data": [{"id": "test-engine"}]}
+            )
+            m.get(
                 f"{self.base_url}/account/users",
                 json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
@@ -268,6 +273,7 @@ authorized_users = cli-dev2"""
         self.assertEqual(conf.get_value("token"), "test-token")
         self.assertEqual(conf.get_value("image"), "test-image")
         self.assertEqual(conf.get_value("region"), "test-region")
+        self.assertEqual(conf.get_value("engine"), "test-engine")
         self.assertEqual(conf.get_value("authorized_users"), "cli-dev")
 
     def test_configure_default_terminal(self):
@@ -306,6 +312,9 @@ authorized_users = cli-dev2"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
+                f"{self.base_url}/engines", json={"data": [{"id": "test-engine"}]}
+            )
+            m.get(
                 f"{self.base_url}/account/users",
                 json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
@@ -314,5 +323,6 @@ authorized_users = cli-dev2"""
         self.assertEqual(conf.get_value("type"), "test-type")
         self.assertEqual(conf.get_value("image"), "test-image")
         self.assertEqual(conf.get_value("region"), "test-region")
+        self.assertEqual(conf.get_value("engine"), "test-engine")
         self.assertEqual(conf.get_value("authorized_users"), "cli-dev")
         self.assertEqual(conf.config.get("DEFAULT", "default-user"), "DEFAULT")

--- a/tests/unit/configuration.py
+++ b/tests/unit/configuration.py
@@ -261,7 +261,8 @@ engine = mysql/8.0.26"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
-                f"{self.base_url}/engines", json={"data": [{"id": "test-engine"}]}
+                f"{self.base_url}/engines",
+                json={"data": [{"id": "test-engine"}]},
             )
             m.get(
                 f"{self.base_url}/account/users",
@@ -312,7 +313,8 @@ engine = mysql/8.0.26"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
-                f"{self.base_url}/engines", json={"data": [{"id": "test-engine"}]}
+                f"{self.base_url}/engines",
+                json={"data": [{"id": "test-engine"}]},
             )
             m.get(
                 f"{self.base_url}/account/users",

--- a/tests/unit/configuration.py
+++ b/tests/unit/configuration.py
@@ -122,8 +122,7 @@ mysql_engine = mysql/8.0.26"""
 
         with patch("linodecli.configuration.open", mock_open()):
             conf.set_default_user("cli-dev2")
-        self.assertEqual(conf.config.get(
-            "DEFAULT", "default-user"), "cli-dev2")
+        self.assertEqual(conf.config.get("DEFAULT", "default-user"), "cli-dev2")
 
     def test_get_token(self):
         """
@@ -183,7 +182,9 @@ mysql_engine = mysql/8.0.26"""
         parser.add_argument("--authorized_users")
         parser.add_argument("--plugin-testplugin-testkey")
         parser.add_argument("--engine")
-        ns = parser.parse_args(["--testkey", "testvalue", "--engine", "mysql/new-test-engine"])
+        ns = parser.parse_args(
+            ["--testkey", "testvalue", "--engine", "mysql/new-test-engine"]
+        )
 
         conf.username = "tester"
         conf.config.add_section("tester")
@@ -196,7 +197,7 @@ mysql_engine = mysql/8.0.26"""
             "newkey",
             "authorized_users",
             "plugin-testplugin-testkey",
-            "engine"
+            "engine",
         ]
 
         f = io.StringIO()
@@ -273,13 +274,19 @@ mysql_engine = mysql/8.0.26"""
             )
             m.get(
                 f"{self.base_url}/databases/engines",
-                json={"data": [{"id": "mysql/test-engine", "engine": "mysql"},
-                               {"id": "postgresql/test-engine", "engine": "postgresql"}]},
+                json={
+                    "data": [
+                        {"id": "mysql/test-engine", "engine": "mysql"},
+                        {
+                            "id": "postgresql/test-engine",
+                            "engine": "postgresql",
+                        },
+                    ]
+                },
             )
             m.get(
                 f"{self.base_url}/account/users",
-                json={
-                    "data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
+                json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
             conf.configure()
 
@@ -290,7 +297,9 @@ mysql_engine = mysql/8.0.26"""
         self.assertEqual(conf.get_value("authorized_users"), "cli-dev")
         # make sure that we set the default engine value according to type of database
         self.assertEqual(conf.get_value("mysql_engine"), "mysql/test-engine")
-        self.assertEqual(conf.get_value("postgresql_engine"), "postgresql/test-engine")
+        self.assertEqual(
+            conf.get_value("postgresql_engine"), "postgresql/test-engine"
+        )
 
     def test_configure_default_terminal(self):
         """
@@ -329,13 +338,19 @@ mysql_engine = mysql/8.0.26"""
             )
             m.get(
                 f"{self.base_url}/databases/engines",
-                json={"data": [{"id": "mysql/test-engine", "engine": "mysql"},
-                               {"id": "postgresql/test-engine", "engine": "postgresql"}]},
+                json={
+                    "data": [
+                        {"id": "mysql/test-engine", "engine": "mysql"},
+                        {
+                            "id": "postgresql/test-engine",
+                            "engine": "postgresql",
+                        },
+                    ]
+                },
             )
             m.get(
                 f"{self.base_url}/account/users",
-                json={
-                    "data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
+                json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
             conf.configure()
 
@@ -346,4 +361,6 @@ mysql_engine = mysql/8.0.26"""
         self.assertEqual(conf.config.get("DEFAULT", "default-user"), "DEFAULT")
         # make sure that we set the default engine value according to type of database
         self.assertEqual(conf.get_value("mysql_engine"), "mysql/test-engine")
-        self.assertEqual(conf.get_value("postgresql_engine"), "postgresql/test-engine")
+        self.assertEqual(
+            conf.get_value("postgresql_engine"), "postgresql/test-engine"
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,6 +16,7 @@ region = us-southeast
 image = linode/ubuntu21.10
 token = notafaketoken
 type = g6-nanode-1
+mysql_engine = mysql/8.0.26
 """
 
 

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -63,7 +63,12 @@ class TestAPIRequest:
         )
         assert (
             json.dumps(
-                {"generic_arg": "foo", "region": "us-southeast", "engine": "mysql/8.0.26"})
+                {
+                    "generic_arg": "foo",
+                    "region": "us-southeast",
+                    "engine": "mysql/8.0.26",
+                }
+            )
             == result
         )
 
@@ -130,8 +135,7 @@ class TestAPIRequest:
             "linodecli.api_request.requests.post", validate_http_request
         ):
             result = api_request.do_request(
-                mock_cli, create_operation, [
-                    "--generic_arg", "foobar", "12345"]
+                mock_cli, create_operation, ["--generic_arg", "foobar", "12345"]
             )
 
         assert result == mock_response

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -54,16 +54,16 @@ class TestAPIRequest:
         assert "> " in output
 
     def test_build_request_body(self, mock_cli, create_operation):
-        create_operation.allowed_defaults = ["region"]
-
+        create_operation.allowed_defaults = ["region", "engine"]
+        create_operation.action = "mysql-create"
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
-            SimpleNamespace(generic_arg="foo", region=None),
+            SimpleNamespace(generic_arg="foo", region=None, engine=None),
         )
-
         assert (
-            json.dumps({"generic_arg": "foo", "region": "us-southeast"})
+            json.dumps(
+                {"generic_arg": "foo", "region": "us-southeast", "engine": "mysql/8.0.26"})
             == result
         )
 
@@ -130,7 +130,8 @@ class TestAPIRequest:
             "linodecli.api_request.requests.post", validate_http_request
         ):
             result = api_request.do_request(
-                mock_cli, create_operation, ["--generic_arg", "foobar", "12345"]
+                mock_cli, create_operation, [
+                    "--generic_arg", "foobar", "12345"]
             )
 
         assert result == mock_response


### PR DESCRIPTION
## 📝 Description

Add the default values for database engines in CLI config. https://jira.linode.com/browse/TPT-1676 

## ✔️ How to Test

`make testunit`

Create MySQL and PostgreSQL database separately use default values including engine:
![Pasted Graphic](https://user-images.githubusercontent.com/127243817/230231195-29948195-a102-44ba-9888-82b7436c9ff7.jpg)


Overwrite the engine value:
![image](https://user-images.githubusercontent.com/127243817/230231180-95d7b7b3-e3b0-4a98-bfd6-73bc7e94ef26.png)

