### PR TITLE
Replace terminaltables with rich

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -9,7 +9,6 @@ import sys
 from sys import argv
 
 import pkg_resources
-from terminaltables import SingleTable
 from rich.table import Table
 from rich import print as rprint
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -10,6 +10,8 @@ from sys import argv
 
 import pkg_resources
 from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 from linodecli import plugins
 
@@ -234,8 +236,10 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
             for action, op in cli.ops[parsed.command].items()
         ]
 
-        table = SingleTable([["action", "summary"]] + content)
-        print(table.table)
+        table = Table("action", "summary")
+        for row in content:
+            table.add_row(*row)
+        rprint(table)
         sys.exit(0)
 
     if parsed.command is not None and parsed.action is not None:

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -9,8 +9,8 @@ import sys
 from sys import argv
 
 import pkg_resources
-from rich.table import Table
 from rich import print as rprint
+from rich.table import Table
 
 from linodecli import plugins
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -283,10 +283,10 @@ def help_with_ops(ops, config):
         if plugin_content[i + 3 :]:
             plugin_proc.append(plugin_content[i + 3 :])
 
-        plugin_table = SingleTable(plugin_proc)
-        plugin_table.inner_heading_row_border = False
-
-        print(plugin_table.table)
+        plugin_table = Table(show_header=False)
+        for plugin in proc:
+            plugin_table.add_row(*plugin)
+        rprint(plugin_table)
 
     print("\nTo reconfigure, call `linode-cli configure`")
     print(

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -9,8 +9,8 @@ from importlib import import_module
 
 import requests
 import yaml
-from rich.table import Table
 from rich import print as rprint
+from rich.table import Table
 
 from linodecli import plugins
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -284,7 +284,7 @@ def help_with_ops(ops, config):
             plugin_proc.append(plugin_content[i + 3 :])
 
         plugin_table = Table(show_header=False)
-        for plugin in proc:
+        for plugin in plugin_content:
             plugin_table.add_row(*plugin)
         rprint(plugin_table)
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -234,9 +234,10 @@ def help_with_ops(ops, config):
     # commands to manage CLI users (don't call out to API)
     print("\nCLI user management commands:")
     um_commands = [["configure", "set-user", "show-users"], ["remove-user"]]
-    table = SingleTable(um_commands)
-    table.inner_heading_row_border = False
-    print(table.table)
+    table = Table(show_header=False)
+    for cmd in um_commands:
+        table.add_row(*cmd)
+    rprint(table)
 
     # commands to manage plugins (don't call out to API)
     print("\nCLI Plugin management commands:")

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -9,7 +9,8 @@ from importlib import import_module
 
 import requests
 import yaml
-from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 from linodecli import plugins
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -284,7 +284,7 @@ def help_with_ops(ops, config):
             plugin_proc.append(plugin_content[i + 3 :])
 
         plugin_table = Table(show_header=False)
-        for plugin in plugin_content:
+        for plugin in plugin_proc:
             plugin_table.add_row(*plugin)
         rprint(plugin_table)
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -265,9 +265,10 @@ def help_with_ops(ops, config):
     if content[i + 3 :]:
         proc.append(content[i + 3 :])
 
-    table = SingleTable(proc)
-    table.inner_heading_row_border = False
-    print(table.table)
+    table = Table(show_header=False)
+    for cmd in proc:
+        table.add_row(*cmd)
+    rprint(table)
 
     # plugins registered to the CLI (do arbitrary things)
     if plugins.available(config):

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -250,9 +250,10 @@ def help_with_ops(ops, config):
     # other CLI commands
     print("\nOther CLI commands:")
     other_commands = [["completion"]]
-    table = SingleTable(other_commands)
-    table.inner_heading_row_border = False
-    print(table.table)
+    table = Table(show_header=False)
+    for cmd in other_commands:
+        table.add_row(*cmd)
+    rprint(table)
 
     # commands generated from the spec (call the API directly)
     print("\nAvailable commands:")

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -242,9 +242,10 @@ def help_with_ops(ops, config):
     # commands to manage plugins (don't call out to API)
     print("\nCLI Plugin management commands:")
     pm_commands = [["register-plugin", "remove-plugin"]]
-    table = SingleTable(pm_commands)
-    table.inner_heading_row_border = False
-    print(table.table)
+    table = Table(show_header=False)
+    for cmd in pm_commands:
+        table.add_row(*cmd)
+    rprint(table)
 
     # other CLI commands
     print("\nOther CLI commands:")

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -6,7 +6,8 @@ import sys
 from enum import Enum
 from sys import stdout
 
-from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 
 class OutputMode(Enum):

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -6,11 +6,10 @@ import sys
 from enum import Enum
 from sys import stdout
 
+from rich import box
+from rich import print as rprint
 from rich.table import Table
 from rich.text import Text
-from rich import print as rprint
-from rich import box
-
 
 
 class OutputMode(Enum):

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -6,7 +6,6 @@ import sys
 from enum import Enum
 from sys import stdout
 
-from terminaltables import SingleTable
 from rich.table import Table
 from rich import print as rprint
 

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -6,6 +6,7 @@ import sys
 from enum import Enum
 from sys import stdout
 
+from terminaltables import SingleTable
 from rich.table import Table
 from rich import print as rprint
 
@@ -135,15 +136,17 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             ),
         )
 
-        tab = SingleTable(content)
+        tab = Table(*content[0])
+        for row in content[1:]:
+            tab.add_row(*row)
 
         if title is not None:
             tab.title = title
 
         if not self.headers:
-            tab.inner_heading_row_border = False
+            tab.show_header = False
 
-        print(tab.table, file=to)
+        rprint(tab, file=to)
 
     def _delimited_output(self, header, data, columns, to):
         """

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -9,6 +9,8 @@ from sys import stdout
 from rich.table import Table
 from rich.text import Text
 from rich import print as rprint
+from rich import box
+
 
 
 class OutputMode(Enum):
@@ -136,7 +138,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             ),
         )
 
-        tab = Table(*content[0])
+        tab = Table(*content[0], header_style="", box=box.SQUARE)
         for row in content[1:]:
             row = [Text.from_ansi(item) for item in row]
             tab.add_row(*row)

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -7,6 +7,7 @@ from enum import Enum
 from sys import stdout
 
 from rich.table import Table
+from rich.text import Text
 from rich import print as rprint
 
 
@@ -137,6 +138,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
 
         tab = Table(*content[0])
         for row in content[1:]:
+            row = [Text.from_ansi(item) for item in row]
             tab.add_row(*row)
 
         if title is not None:

--- a/linodecli/plugins/firewall-editor.py
+++ b/linodecli/plugins/firewall-editor.py
@@ -10,7 +10,9 @@ import termios
 from ipaddress import IPv4Address, ip_address
 from typing import Callable
 
-from terminaltables import PorcelainTable
+from rich.table import Table
+from rich import box
+from rich import print as rprint
 
 from linodecli.plugins import inherit_plugin_args
 
@@ -272,9 +274,11 @@ def print_rules_table(rules):
             ]
         )
 
-    tab = PorcelainTable([header] + rows)
-    tab.inner_heading_row_border = True
-    print(tab.table)
+    tab = Table(*header, box=box.ASCII, show_edge=False)
+    for row in rows:
+        row = [str(r) for r in row]
+        tab.add_row(*row)
+    rprint(tab)
 
 
 def draw_rules(rules):

--- a/linodecli/plugins/firewall-editor.py
+++ b/linodecli/plugins/firewall-editor.py
@@ -10,9 +10,9 @@ import termios
 from ipaddress import IPv4Address, ip_address
 from typing import Callable
 
-from rich.table import Table
 from rich import box
 from rich import print as rprint
+from rich.table import Table
 
 from linodecli.plugins import inherit_plugin_args
 

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -488,6 +488,8 @@ def print_help(parser: ArgumentParser):
     ]
 
     tab = Table(show_header=False)
+    for row in command_help_map:
+        tab.add_row(*row)
     rprint(tab)
     print()
     print(

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -17,8 +17,8 @@ from math import ceil
 from pathlib import Path
 from typing import List
 
-from rich.table import Table
 from rich import print as rprint
+from rich.table import Table
 
 from linodecli.cli import CLI
 from linodecli.configuration import _do_get_request

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -126,7 +126,7 @@ def list_objects_or_buckets(
 
         if data:
             tab = _borderless_table(data)
-            print(tab.table)
+            rprint(tab)
 
         sys.exit(0)
     else:
@@ -135,7 +135,7 @@ def list_objects_or_buckets(
         data = [[b.get("CreationDate"), b.get("Name")] for b in buckets]
 
         tab = _borderless_table(data)
-        print(tab.table)
+        rprint(tab)
 
         sys.exit(0)
 
@@ -389,7 +389,7 @@ def show_usage(get_client, args):
         tab = _borderless_table(
             [[_pad_to(total, length=7), f"{obj_count} objects", b]]
         )
-        print(tab.table)
+        rprint(tab)
 
     if len(bucket_names) > 1:
         print("--------")

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -488,7 +488,7 @@ def print_help(parser: ArgumentParser):
     ]
 
     tab = Table(show_header=False)
-    rprint(tab.table)
+    rprint(tab)
     print()
     print(
         "Additionally, you can regenerate your Object Storage keys using the "

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -17,7 +17,8 @@ from math import ceil
 from pathlib import Path
 from typing import List
 
-from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 from linodecli.cli import CLI
 from linodecli.configuration import _do_get_request
@@ -486,9 +487,8 @@ def print_help(parser: ArgumentParser):
         for name, func in sorted(COMMAND_MAP.items())
     ]
 
-    tab = SingleTable(command_help_map)
-    tab.inner_heading_row_border = False
-    print(tab.table)
+    tab = Table(show_header=False)
+    rprint(tab.table)
     print()
     print(
         "Additionally, you can regenerate your Object Storage keys using the "

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -5,7 +5,6 @@ from argparse import ArgumentTypeError
 from datetime import datetime
 
 from rich.table import Table
-from rich import print as rprint
 
 from linodecli.plugins.obj.config import DATE_FORMAT
 

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -4,7 +4,8 @@ The helper functions for the object storage plugin.
 from argparse import ArgumentTypeError
 from datetime import datetime
 
-from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 from linodecli.plugins.obj.config import DATE_FORMAT
 
@@ -122,11 +123,6 @@ def _borderless_table(data):
     """
     Returns a terminaltables.SingleTable object with no borders and correct padding
     """
-    tab = SingleTable(data)
-    tab.inner_heading_row_border = False
-    tab.inner_column_border = False
-    tab.outer_border = False
-    tab.padding_left = 0
-    tab.padding_right = 2
+    tab = Table(show_header=False, show_edge=False, padding=(0, 2, 0, 2))
 
     return tab

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -120,7 +120,7 @@ def _denominate(total):
 # helper functions for output
 def _borderless_table(data):
     """
-    Returns a terminaltables.SingleTable object with no borders and correct padding
+    Returns a rich.Table object with no borders and correct padding
     """
     tab = Table(show_header=False, show_edge=False, padding=(0, 2, 0, 2))
 

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -123,7 +123,7 @@ def _borderless_table(data):
     """
     Returns a rich.Table object with no borders and correct padding
     """
-    tab = Table(show_header=False, show_edge=False, padding=(0, 2, 0, 2))
+    tab = Table.grid(padding=(0, 2, 0, 2))
     for row in data:
         row = [Text.from_ansi(str(item)) for item in row]
         tab.add_row(*row)

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -5,6 +5,7 @@ from argparse import ArgumentTypeError
 from datetime import datetime
 
 from rich.table import Table
+from rich.text import Text
 
 from linodecli.plugins.obj.config import DATE_FORMAT
 
@@ -123,5 +124,8 @@ def _borderless_table(data):
     Returns a rich.Table object with no borders and correct padding
     """
     tab = Table(show_header=False, show_edge=False, padding=(0, 2, 0, 2))
+    for row in data:
+        row = [Text.from_ansi(str(item)) for item in row]
+        tab.add_row(*row)
 
     return tab

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ terminaltables
 requests
 PyYAML
 packaging
+rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-terminaltables
 requests
 PyYAML
 packaging

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -3,6 +3,7 @@ import io
 
 from rich.table import Table
 from rich import print as rprint
+from rich import box
 
 from linodecli import ModelAttr, OutputMode, ResponseModel
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,9 +1,9 @@
 import contextlib
 import io
 
-from rich.table import Table
-from rich import print as rprint
 from rich import box
+from rich import print as rprint
+from rich.table import Table
 
 from linodecli import ModelAttr, OutputMode, ResponseModel
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -129,7 +129,7 @@ class TestOutputHandler:
         )
 
         mock_table = io.StringIO()
-        tab = Table("h1", "h2")
+        tab = Table("h1", "h2", header_style="", box=box.SQUARE)
         for row in [["foo", "bar"], ["oof", "rab"]]:
             tab.add_row(*row)
         tab.title = "cool table"
@@ -153,7 +153,7 @@ class TestOutputHandler:
         )
 
         mock_table = io.StringIO()
-        tab = Table("h1")
+        tab = Table("h1", header_style="", box=box.SQUARE)
         for row in [["foo"], ["bar"]]:
             tab.add_row(*row)
         tab.title = "cool table"
@@ -285,7 +285,7 @@ class TestOutputHandler:
         data[0]["cool"] = test_str_truncated
 
         mock_table = io.StringIO()
-        tab = Table("h1")
+        tab = Table("h1", header_style="", box=box.SQUARE)
         tab.add_row(test_str_truncated)
         tab.title = "cool table"
         rprint(tab, file=mock_table)

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,7 +1,8 @@
 import contextlib
 import io
 
-from terminaltables import SingleTable
+from rich.table import Table
+from rich import print as rprint
 
 from linodecli import ModelAttr, OutputMode, ResponseModel
 
@@ -128,9 +129,11 @@ class TestOutputHandler:
         )
 
         mock_table = io.StringIO()
-        tab = SingleTable([["h1", "h2"], ["foo", "bar"], ["oof", "rab"]])
+        tab = Table("h1", "h2")
+        for row in [["foo", "bar"], ["oof", "rab"]]:
+            tab.add_row(*row)
         tab.title = "cool table"
-        print(tab.table, file=mock_table)
+        rprint(tab, file=mock_table)
 
         assert output.getvalue() == mock_table.getvalue()
 
@@ -150,9 +153,11 @@ class TestOutputHandler:
         )
 
         mock_table = io.StringIO()
-        tab = SingleTable([["h1"], ["foo"], ["bar"]])
+        tab = Table("h1")
+        for row in [["foo"], ["bar"]]:
+            tab.add_row(*row)
         tab.title = "cool table"
-        print(tab.table, file=mock_table)
+        rprint(tab, file=mock_table)
 
         assert output.getvalue() == mock_table.getvalue()
 
@@ -280,9 +285,10 @@ class TestOutputHandler:
         data[0]["cool"] = test_str_truncated
 
         mock_table = io.StringIO()
-        tab = SingleTable([["h1"], [test_str_truncated]])
+        tab = Table("h1")
+        tab.add_row(test_str_truncated)
         tab.title = "cool table"
-        print(tab.table, file=mock_table)
+        rprint(tab, file=mock_table)
 
         assert output.getvalue() == mock_table.getvalue()
 


### PR DESCRIPTION
## 📝 Description

Relates to #436 

The version of `terminaltables` used by this project has been archived for a few years now and was recently removed from the Arch community repository (which is what led me to embark on this PR). While the project may remain viable for some time to come, I propose the maintainers of `linode-cli` consider switching to [rich](https://github.com/textualize/rich), which offers much greater versatility when rendering rich text to the terminal in Python (even `pip` uses rich for its progress bar functionality).

I have made the necessary changes to the code in this PR.

### Summary of changes:
- Updated `requirements.txt`
  - Added `rich`
  - Removed `terminaltables`
- Updated all instances of `terminaltables.SingleTable` objects throughout the project with equivalent `rich.Table` objects. The following modules were updated under this effort:
  - `arg_helpers.py`
  - `output.py` - Note for this module I also added the `rich.Text` module to enable proper ANSI sequence rendering. Without converting the table cells to `Text` objects, any cell containing ANSI sequences will result in improper rendering of the columns. This should not be applicable to any other module, but could be implemented for uniformity's sake if desired with no impact to functionality.
  - `__init__.py`
  - `plugins/obj/__init__.py`
  - `plugins/obj/helpers.py`
- Updated the `firewall-editor` plugin to replace `terminaltables.PorcelainTable` object with `rich.Table`. The new `rich.Table` is configured to be equivalent to the corresponding `PorcelainTable` it's replacing.
- Updated the unit test `test_output.py` to use `rich.Table`

## ✔️ How to Test

### Steps
- Run any set of commands associated with generating tables. Among these, make sure to run a command that generates a table with colored text, such as `linode-cli linodes list` to ensure the ANSI escape sequence'd text renders correctly.
- Run `linode-cli` to see the main help message tables
- Run `linode-cli firewall-editor <label>` to see the new firewall editor table.
- Run the `test_output.py` unit test `python -m unittest test_output.py`

### What I tested
- Each of the 4 tests above

### What I **did not** test
- I did  not run the full test suite as I didn't want to destroy my account's configuration nor did I want to make a new account for this purpose. 


## 📷 Preview

### Before/After
- `linode-cli` before
![linode-cli-help-before](https://user-images.githubusercontent.com/7587293/232877125-1fa30359-24bf-4d97-b4a0-c4fc1abf3fe4.png)
- `linode-cli` after
![linode-cli-help-after](https://user-images.githubusercontent.com/7587293/232877477-3ae282b2-387a-4b72-a49a-9ca12b99c962.png)
- `linode-cli linodes list` before
![linode-cli-linodes-list-before](https://user-images.githubusercontent.com/7587293/232877191-e1091e87-77c1-4a0d-b4c4-a636da21d70d.png)
- `linode-cli linodes list` after
![linode-cli-linodes-list-after](https://user-images.githubusercontent.com/7587293/232877536-58b9232a-a88e-4dda-8560-29ab54c6cf2d.png)
- `linode-cli firewall-editor <label>` before
![linode-cli-firewall-editor-before](https://user-images.githubusercontent.com/7587293/232877301-31272971-4319-4bea-89fa-704b265ddf45.png)
- `linode-cli firewall-editor <label>` after
![linode-cli-firewall-editor-after](https://user-images.githubusercontent.com/7587293/232877620-b317ea77-d04c-4ed4-91e8-74400a8d6f4a.png)

## Other Notes

I don't understand exactly how the `Makefile` works for this project, but something prevents me from acquiring the necessary baked data (specifically `bake_version`) using `make` in my fork of the project. If I run `make` from this project and copy the `baked_version` file to my fork, I am able to install with `pip`. I did not make any changes to the `Makefile` (or anything else other than what I listed above for that matter), but I thought this would be worth noting in the PR.

I hope you seriously consider merging this PR and/or implementing `rich` on your own. I can't speak highly enough about its performance and options. Thank you for taking the time to consider these changes.