### PR TITLE
bug: Shorten datetime strings output from `linode-cli obj ls` operation

### DIFF
--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -121,7 +121,7 @@ def list_objects_or_buckets(
             if key == prefix:
                 continue
 
-            data.append((obj.get("LastModified"), obj.get("Size"), key))
+            data.append((_convert_datetime(obj.get("LastModified")), obj.get("Size"), key))
 
         if data:
             tab = _borderless_table(data)
@@ -131,7 +131,7 @@ def list_objects_or_buckets(
     else:
         # list buckets
         buckets = client.list_buckets().get("Buckets", [])
-        data = [[b.get("CreationDate"), b.get("Name")] for b in buckets]
+        data = [[_convert_datetime(b.get("CreationDate")), b.get("Name")] for b in buckets]
 
         tab = _borderless_table(data)
         print(tab.table)

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -121,7 +121,13 @@ def list_objects_or_buckets(
             if key == prefix:
                 continue
 
-            data.append((_convert_datetime(obj.get("LastModified")), obj.get("Size"), key))
+            data.append(
+                (
+                    _convert_datetime(obj.get("LastModified")),
+                    obj.get("Size"),
+                    key,
+                )
+            )
 
         if data:
             tab = _borderless_table(data)
@@ -131,7 +137,10 @@ def list_objects_or_buckets(
     else:
         # list buckets
         buckets = client.list_buckets().get("Buckets", [])
-        data = [[_convert_datetime(b.get("CreationDate")), b.get("Name")] for b in buckets]
+        data = [
+            [_convert_datetime(b.get("CreationDate")), b.get("Name")]
+            for b in buckets
+        ]
 
         tab = _borderless_table(data)
         print(tab.table)


### PR DESCRIPTION
Noticed this while reviewing #440.

I suspect that `boto` used to output dates like this, and the format
changed in the conversion to `boto3`.

Current output:

```
$ linode-cli obj ls
2021-03-10 12:32:10.317000+00:00  example-bucket
```

This branch:

```
$ linode-cli obj ls
2021-03-10 12:32  example-bucket
```

`s3cmd ls` output (for reference - this plugin was originally based on
that):

```
$ s3cmd ls
2021-03-10 12:32  s3://example-bucket
```
