### PR TITLE
 Simplified Acctest Command Dispatching Workflow

### DIFF
--- a/.github/workflows/e2e-suite-pr-command.yml
+++ b/.github/workflows/e2e-suite-pr-command.yml
@@ -9,20 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request }}
     steps:
-      - name: Generate App Installation Token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.DX_ACCTEST_APP_ID }}
-          private_key: ${{ secrets.DX_ACCTEST_PRIV_KEY }}
-
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v1
-        env:
-          TOKEN: ${{ steps.generate_token.outputs.token }}
+        uses: peter-evans/slash-command-dispatch@v3
         with:
-          token: ${{ env.TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: acctest
           named-args: true


### PR DESCRIPTION
## 📝 Description

When we created the acctest command workflows, GitHub doesn't support using `GITHUB_TOKEN` to trigger another workflow [but later they added some exception](https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/).

We used a workaround to generate a token as a GitHub App to trigger an `repository_dispatch` event to trigger the integration test. With the newly added exception, now I believe we can trigger the integration test directly by the `repository_dispatch` event triggered by the built-in `GITHUB_TOKEN`, and we can now remove the action that was used to generate GitHub App token.

## ✔️ How to Test

Will only be testable in this repo after merging.

Success on my forked repo:
https://github.com/zliang-akamai/linodego/pull/2#issuecomment-1522019490