### PR TITLE
new: Add support for output overrides and add `domains zone-file` override

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -9,7 +9,8 @@ import platform
 from getpass import getpass
 from os import environ, path
 
-from linodecli import output_overrides
+from .overrides import OUTPUT_OVERRIDES
+
 from linodecli.helpers import handle_url_overrides
 
 
@@ -347,7 +348,7 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
         if self.response_model is None:
             return
 
-        override = output_overrides.OVERRIDES.get((self.command, self.action, handler.mode))
+        override = OUTPUT_OVERRIDES.get((self.command, self.action, handler.mode))
         if override is not None and not override(self, handler, json):
             return
 

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -9,9 +9,9 @@ import platform
 from getpass import getpass
 from os import environ, path
 
-from .overrides import OUTPUT_OVERRIDES
-
 from linodecli.helpers import handle_url_overrides
+
+from .overrides import OUTPUT_OVERRIDES
 
 
 def parse_boolean(value):
@@ -348,7 +348,9 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
         if self.response_model is None:
             return
 
-        override = OUTPUT_OVERRIDES.get((self.command, self.action, handler.mode))
+        override = OUTPUT_OVERRIDES.get(
+            (self.command, self.action, handler.mode)
+        )
         if override is not None and not override(self, handler, json):
             return
 

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -9,6 +9,7 @@ import platform
 from getpass import getpass
 from os import environ, path
 
+from linodecli import output_overrides
 from linodecli.helpers import handle_url_overrides
 
 
@@ -344,6 +345,10 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
         Processes the response as JSON and prints
         """
         if self.response_model is None:
+            return
+
+        override = output_overrides.OVERRIDES.get((self.command, self.action, handler.mode))
+        if override is not None and not override(self, handler, json):
             return
 
         json = self.response_model.fix_json(json)

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -22,8 +22,8 @@ def output_override(command: str, action: str, output_mode: OutputMode):
     If the returned bool is False, the original output functionality will be skipped.
     Otherwise, the original output functionality will continue as normal.
     """
+
     def inner(func):
-        global OUTPUT_OVERRIDES
         OUTPUT_OVERRIDES[(command, action, output_mode)] = func
 
     return inner
@@ -31,6 +31,7 @@ def output_override(command: str, action: str, output_mode: OutputMode):
 
 @output_override("domains", "zone-file", OutputMode.delimited)
 def handle_domains_zone_file(operation, output_handler, json_data) -> bool:
+    # pylint: disable=unused-argument
     """
     Fix for output of 'linode-cli domains zone-file --text {id}'.
     """

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -1,0 +1,38 @@
+"""
+Contains wrappers for overriding certain pieces of command-handling logic.
+This allows us to easily alter per-command outputs, etc. without making
+large changes to the OpenAPI spec.
+"""
+
+from linodecli.output import OutputMode
+
+OUTPUT_OVERRIDES = {}
+
+
+def output_override(command: str, action: str, output_mode: OutputMode):
+    """
+    A decorator function for adding a new output override handler.
+
+    Output override functions should have the following signature::
+
+        @output_override("command", "action", OutputMode.{output_mode})
+        def my_override(operation, output_handler, json_data) -> bool:
+            ...
+
+    If the returned bool is False, the original output functionality will be skipped.
+    Otherwise, the original output functionality will continue as normal.
+    """
+    def inner(func):
+        global OUTPUT_OVERRIDES
+        OUTPUT_OVERRIDES[(command, action, output_mode)] = func
+
+    return inner
+
+
+@output_override("domains", "zone-file", OutputMode.delimited)
+def handle_domains_zone_file(operation, output_handler, json_data) -> bool:
+    """
+    Fix for output of 'linode-cli domains zone-file --text {id}'.
+    """
+    print("\n".join(json_data["zone_file"]))
+    return False

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -1,12 +1,7 @@
 import contextlib
 import io
-import json
-from types import SimpleNamespace
-from unittest.mock import Mock, patch
 
-import requests
-
-from linodecli import api_request, OutputMode
+from linodecli import OutputMode
 
 
 class TestOverrides:
@@ -23,13 +18,11 @@ class TestOverrides:
 
         with contextlib.redirect_stdout(stdout_buf):
             list_operation.process_response_json(
-                {
-                    "zone_file": [
-                        "line 1",
-                        "line 2"
-                    ]
-                },
-                mock_cli.output_handler
+                {"zone_file": ["line 1", "line 2"]}, mock_cli.output_handler
             )
 
         assert stdout_buf.getvalue() == "line 1\nline 2\n"
+
+        # Change the action to bypass the override
+        list_operation.action = "zone-notfile"
+        mock_cli.output_handler.mode = OutputMode.delimited

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -2,7 +2,6 @@ import contextlib
 import io
 from unittest.mock import patch
 
-
 from linodecli import ModelAttr, OutputMode, ResponseModel
 from linodecli.overrides import OUTPUT_OVERRIDES
 

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -1,0 +1,35 @@
+import contextlib
+import io
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import requests
+
+from linodecli import api_request, OutputMode
+
+
+class TestOverrides:
+    """
+    Unit tests for linodecli.overrides
+    """
+
+    def test_domains_zone_file(self, mock_cli, list_operation):
+        stdout_buf = io.StringIO()
+
+        list_operation.command = "domains"
+        list_operation.action = "zone-file"
+        mock_cli.output_handler.mode = OutputMode.delimited
+
+        with contextlib.redirect_stdout(stdout_buf):
+            list_operation.process_response_json(
+                {
+                    "zone_file": [
+                        "line 1",
+                        "line 2"
+                    ]
+                },
+                mock_cli.output_handler
+            )
+
+        assert stdout_buf.getvalue() == "line 1\nline 2\n"


### PR DESCRIPTION
## 📝 Description

This change introduces a new output override system that allows us to modularly add custom output logic for specific generated commands. This is useful for cleaning up outputs for endpoints with responses that may be too complicated to account for in the spec parser.
