### PR TITLE
Fix error assertions and cleanup dependencies

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python wheel
-        run: pip install wheel boto3 mock
+        run: pip install wheel boto3
 
       - name: Update cert
         run: pip install certifi -U

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -6,9 +6,9 @@ import contextlib
 import io
 import json
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import requests
-from mock import Mock, patch
 
 from linodecli import api_request
 

--- a/tests/unit/test_completion.py
+++ b/tests/unit/test_completion.py
@@ -3,7 +3,7 @@
 Unit tests for linodecli.completion
 """
 
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 
 from linodecli import completion
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -73,10 +73,11 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as err:
             with contextlib.redirect_stdout(f):
                 conf.set_user("bad_user")
 
+        assert err.value.code == 1
         assert "not configured" in f.getvalue()
 
         conf.set_user("cli-dev2")
@@ -90,11 +91,12 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as err:
             with contextlib.redirect_stdout(f):
                 conf.remove_user("cli-dev")
 
         assert "default user!" in f.getvalue()
+        assert err.value.code == 1
 
         with patch("linodecli.configuration.open", mock_open()):
             conf.remove_user("cli-dev2")
@@ -108,10 +110,11 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as err:
             with contextlib.redirect_stdout(f):
                 conf.print_users()
 
+        assert err.value.code == 0
         assert "*  cli-dev" in f.getvalue()
 
     def test_set_default_user(self):
@@ -121,10 +124,11 @@ mysql_engine = mysql/8.0.26"""
         conf = self._build_test_config()
 
         f = io.StringIO()
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as err:
             with contextlib.redirect_stdout(f):
                 conf.set_default_user("bad_user")
 
+        assert err.value.code == 1
         assert "not configured" in f.getvalue()
 
         with patch("linodecli.configuration.open", mock_open()):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -7,10 +7,10 @@ import contextlib
 import io
 import os
 import sys
+from unittest.mock import call, mock_open, patch
 
 import pytest
 import requests_mock
-from mock import call, mock_open, patch
 
 from linodecli import configuration
 
@@ -73,12 +73,11 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        try:
+        with pytest.raises(SystemExit):
             with contextlib.redirect_stdout(f):
                 conf.set_user("bad_user")
-        except SystemExit as err:
-            assert err.code == 1
-            assert "not configured" in f.getvalue()
+
+        assert "not configured" in f.getvalue()
 
         conf.set_user("cli-dev2")
         assert conf.username == "cli-dev2"
@@ -91,12 +90,11 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        try:
+        with pytest.raises(SystemExit):
             with contextlib.redirect_stdout(f):
                 conf.remove_user("cli-dev")
-        except SystemExit as err:
-            assert err.code == 1
-            assert "default user!" in f.getvalue()
+
+        assert "default user!" in f.getvalue()
 
         with patch("linodecli.configuration.open", mock_open()):
             conf.remove_user("cli-dev2")
@@ -110,12 +108,11 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
 
-        try:
+        with pytest.raises(SystemExit):
             with contextlib.redirect_stdout(f):
                 conf.print_users()
-        except SystemExit as err:
-            assert err.code == 0
-            assert "*  cli-dev" in f.getvalue()
+
+        assert "*  cli-dev" in f.getvalue()
 
     def test_set_default_user(self):
         """
@@ -124,12 +121,11 @@ mysql_engine = mysql/8.0.26"""
         conf = self._build_test_config()
 
         f = io.StringIO()
-        try:
+        with pytest.raises(SystemExit):
             with contextlib.redirect_stdout(f):
                 conf.set_default_user("bad_user")
-        except SystemExit as err:
-            assert err.code == 1
-            assert "not configured" in f.getvalue()
+
+        assert "not configured" in f.getvalue()
 
         with patch("linodecli.configuration.open", mock_open()):
             conf.set_default_user("cli-dev2")

--- a/tests/unit/test_plugin_image_upload.py
+++ b/tests/unit/test_plugin_image_upload.py
@@ -1,6 +1,7 @@
 import importlib
 from unittest.mock import patch
 
+import pytest
 from pytest import CaptureFixture
 
 from linodecli.plugins import PluginContext
@@ -10,26 +11,26 @@ plugin = importlib.import_module("linodecli.plugins.image-upload")
 
 
 def test_print_help(capsys: CaptureFixture):
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(["--help"], None)
-    except SystemExit as err:
-        assert err.code == 0
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 0
     assert "The image file to upload" in captured_text
     assert "The region to upload the image to" in captured_text
 
 
 def test_no_file(mock_cli, capsys: CaptureFixture):
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(
             ["--label", "cool", "blah.txt"],
             PluginContext("REALTOKEN", mock_cli),
         )
-    except SystemExit as err:
-        assert err.code == 2
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 2
     assert "No file at blah.txt" in captured_text
 
 
@@ -39,12 +40,12 @@ def test_file_too_large(mock_cli, capsys: CaptureFixture):
     args = ["--label", "cool", "blah.txt"]
     ctx = PluginContext("REALTOKEN", mock_cli)
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
-    except SystemExit as err:
-        assert err.code == 2
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 2
     assert "File blah.txt is too large" in captured_text
 
 
@@ -57,12 +58,12 @@ def test_unauthorized(mock_cli, capsys: CaptureFixture):
 
     ctx = PluginContext("REALTOKEN", mock_cli)
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
-    except SystemExit as err:
-        assert err.code == 3
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 3
     assert "Your token was not authorized to use this endpoint" in captured_text
 
 
@@ -75,12 +76,12 @@ def test_non_beta(mock_cli, capsys: CaptureFixture):
 
     ctx = PluginContext("REALTOKEN", mock_cli)
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
-    except SystemExit as err:
-        assert err.code == 4
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 4
     assert (
         "It looks like you are not in the Machine Images Beta" in captured_text
     )
@@ -95,12 +96,12 @@ def test_non_beta(mock_cli, capsys: CaptureFixture):
 
     ctx = PluginContext("REALTOKEN", mock_cli)
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
-    except SystemExit as err:
-        assert err.code == 4
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 4
     assert (
         "It looks like you are not in the Machine Images Beta" in captured_text
     )
@@ -114,12 +115,12 @@ def test_failed_upload(mock_cli, capsys: CaptureFixture):
 
     ctx = PluginContext("REALTOKEN", mock_cli)
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
-    except SystemExit as err:
-        assert err.code == 3
 
     captured_text = capsys.readouterr().out
+
+    assert err.value.code == 3
     assert (
         "Upload failed with status 500; response was it borked :("
         in captured_text

--- a/tests/unit/test_plugin_kubeconfig.py
+++ b/tests/unit/test_plugin_kubeconfig.py
@@ -56,11 +56,11 @@ dictionary: {"foo": "bar"}
 def test_print_help():
     stdout_buf = io.StringIO()
 
-    try:
+    with pytest.raises(SystemExit) as err:
         with contextlib.redirect_stdout(stdout_buf):
             plugin.call(["--help"], None)
-    except SystemExit as err:
-        assert err.code == 0
+
+    assert err.value.code == 0
 
     assert "Path to kubeconfig file." in stdout_buf.getvalue()
     assert "Label for desired cluster." in stdout_buf.getvalue()
@@ -70,14 +70,14 @@ def test_print_help():
 def test_no_label_no_id(mock_cli):
     stderr_buf = io.StringIO()
 
-    try:
+    with pytest.raises(SystemExit) as err:
         with contextlib.redirect_stderr(stderr_buf):
             plugin.call(
                 [],
                 PluginContext("REALTOKEN", mock_cli),
             )
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     assert "Either --label or --id must be used." in stderr_buf.getvalue()
 
@@ -87,14 +87,14 @@ def test_nonexisting_label(mock_cli):
     stderr_buf = io.StringIO()
     mock_cli.call_operation = mock_call_operation
 
-    try:
+    with pytest.raises(SystemExit) as err:
         with contextlib.redirect_stderr(stderr_buf):
             plugin.call(
                 ["--label", "empty_data"],
                 PluginContext("REALTOKEN", mock_cli),
             )
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     assert (
         "Cluster with label empty_data does not exist." in stderr_buf.getvalue()
@@ -105,14 +105,14 @@ def test_nonexisting_label(mock_cli):
 def test_nonexisting_id(mock_cli):
     stderr_buf = io.StringIO()
 
-    try:
+    with pytest.raises(SystemExit) as err:
         with contextlib.redirect_stderr(stderr_buf):
             plugin.call(
                 ["--id", "12345"],
                 PluginContext("REALTOKEN", mock_cli),
             )
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     assert "Error retrieving kubeconfig:" in stderr_buf.getvalue()
 
@@ -124,7 +124,7 @@ def test_improper_file(mock_cli, fake_empty_file):
 
     file_path = fake_empty_file
 
-    try:
+    with pytest.raises(SystemExit) as err:
         with contextlib.redirect_stderr(stderr_buf):
             plugin.call(
                 [
@@ -135,8 +135,8 @@ def test_improper_file(mock_cli, fake_empty_file):
                 ],
                 PluginContext("REALTOKEN", mock_cli),
             )
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     assert "Could not load file at" in stderr_buf.getvalue()
 

--- a/tests/unit/test_plugin_ssh.py
+++ b/tests/unit/test_plugin_ssh.py
@@ -1,6 +1,7 @@
 import argparse
 from unittest.mock import patch
 
+import pytest
 from pytest import CaptureFixture
 
 import linodecli.plugins.ssh as plugin
@@ -8,10 +9,10 @@ from linodecli.plugins import PluginContext
 
 
 def test_print_help(capsys: CaptureFixture):
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(["--help"], None)
-    except SystemExit as err:
-        assert err.code == 0
+
+    assert err.value.code == 0
 
     captured_text = capsys.readouterr().out
     assert "[USERNAME@]LABEL" in captured_text
@@ -20,10 +21,10 @@ def test_print_help(capsys: CaptureFixture):
 
 @patch("linodecli.plugins.ssh.platform", "win32")
 def test_windows_error(capsys: CaptureFixture):
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(["test@test"], None)
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     captured_text = capsys.readouterr().out
     assert "This plugin is not currently supported in Windows." in captured_text
@@ -39,12 +40,12 @@ def test_target_not_running(mock_cli, capsys: CaptureFixture):
 
     mock_cli.call_operation = mock_call_operation
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.call(
             [f"test@{test_label}"], PluginContext("FAKETOKEN", mock_cli)
         )
-    except SystemExit as err:
-        assert err.code == 2
+
+    assert err.value.code == 2
 
     captured_text = capsys.readouterr().out
     assert (
@@ -121,12 +122,12 @@ def test_find_with_bad_label(mock_cli, capsys: CaptureFixture):
 
     mock_cli.call_operation = mock_call_operation
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.find_linode_with_label(
             PluginContext("FAKETOKEN", mock_cli), test_label
         )
-    except SystemExit as err:
-        assert err.code == 1
+
+    assert err.value.code == 1
 
     captured_text = capsys.readouterr().out
 
@@ -145,12 +146,12 @@ def test_find_api_error(mock_cli, capsys: CaptureFixture):
 
     mock_cli.call_operation = mock_call_operation
 
-    try:
+    with pytest.raises(SystemExit) as err:
         plugin.find_linode_with_label(
             PluginContext("FAKETOKEN", mock_cli), test_label
         )
-    except SystemExit as err:
-        assert err.code == 2
+
+    assert err.value.code == 2
 
     captured_text = capsys.readouterr().out
 


### PR DESCRIPTION
## 📝 Description

replaced all try and except blocks with pytest.raises for cleaner and proper assertion
since mock is part of python std lib, we can import it directly from unittest

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**