### PR TITLE
new: Improve handling for list structures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,16 @@ you can execute the following::
 
     linode-cli linodes create --region us-east --type g6-nanode-1 --tags tag1 --tags tag2
 
+Lists consisting of nested structures can also be expressed through the command line.
+For example, to create a Linode with a public interface on ``eth0`` and a VLAN interface
+on ``eth1`` you can execute the following::
+
+    linode-cli linodes create \
+        --region us-east --type g6-nanode-1 --image linode/ubuntu22.04 \
+        --root_pass "myr00tp4ss123" \
+        --interfaces.purpose public \
+        --interfaces.purpose vlan --interfaces.label my-vlan
+
 Specifying Nested Arguments
 """""""""""""""""""""""""""
 

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -113,12 +113,19 @@ class ListArgumentAction(argparse.Action):
 
         dest_list = getattr(namespace, self.dest)
         dest_length = len(dest_list)
+        dest_parent = self.dest.split(".")[:-1]
+
+        # If this isn't a nested structure,
+        # append and return early
+        if len(dest_parent) < 1:
+            dest_list.append(values)
+            return
 
         # A list of adjacent fields
         adjacent_keys = [
             k
             for k, v in namespace.__dict__.items()
-            if k.split(".")[:-1] == self.dest.split(".")[:-1]
+            if k.split(".")[:-1] == dest_parent
         ]
 
         # Let's populate adjacent fields ahead of time

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -130,8 +130,7 @@ class ListArgumentAction(argparse.Action):
 
         # Find the deepest field so we can know if
         # we're starting a new object.
-        deepest_field = max(adjacent_items.values(), key=lambda x: len(x))
-        deepest_length = len(deepest_field)
+        deepest_length = max(len(x) for x in adjacent_items.values())
 
         # If we're creating a new list object, append
         # None to every non-populated field.

--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -124,7 +124,7 @@ class ListArgumentAction(argparse.Action):
         # A list of adjacent fields
         adjacent_keys = [
             k
-            for k, v in namespace.__dict__.items()
+            for k in vars(namespace).keys()
             if k.split(".")[:-1] == dest_parent
         ]
 

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -15,7 +15,7 @@ class TestOperation:
 
         for arg_name in ["foo", "bar", "aaa"]:
             parser.add_argument(
-                f"--{arg_name}",
+                f"--foo.{arg_name}",
                 metavar=arg_name,
                 action=operation.ListArgumentAction,
                 type=str,
@@ -23,23 +23,23 @@ class TestOperation:
 
         result = parser.parse_args(
             [
-                "--foo",
+                "--foo.foo",
                 "cool",
-                "--bar",
+                "--foo.bar",
                 "wow",
-                "--aaa",
+                "--foo.aaa",
                 "computer",
-                "--foo",
+                "--foo.foo",
                 "test",
-                "--bar",
+                "--foo.bar",
                 "wow",
-                "--aaa",
+                "--foo.aaa",
                 "akamai",
             ]
         )
-        assert result.foo == ["cool", "test"]
-        assert result.bar == ["wow", "wow"]
-        assert result.aaa == ["computer", "akamai"]
+        assert getattr(result, "foo.foo") == ["cool", "test"]
+        assert getattr(result, "foo.bar") == ["wow", "wow"]
+        assert getattr(result, "foo.aaa") == ["computer", "akamai"]
 
     def test_list_arg_action_missing_attr(self):
         """
@@ -53,7 +53,7 @@ class TestOperation:
 
         for arg_name in ["foo", "bar", "aaa"]:
             parser.add_argument(
-                f"--{arg_name}",
+                f"--foo.{arg_name}",
                 metavar=arg_name,
                 action=operation.ListArgumentAction,
                 type=str,
@@ -61,20 +61,20 @@ class TestOperation:
 
         result = parser.parse_args(
             [
-                "--foo",
+                "--foo.foo",
                 "cool",
-                "--aaa",
+                "--foo.aaa",
                 "computer",
-                "--foo",
+                "--foo.foo",
                 "test",
-                "--bar",
+                "--foo.bar",
                 "wow",
-                "--foo",
+                "--foo.foo",
                 "linode",
-                "--aaa",
+                "--foo.aaa",
                 "akamai",
             ]
         )
-        assert result.foo == ["cool", "test", "linode"]
-        assert result.bar == [None, "wow"]
-        assert result.aaa == ["computer", None, "akamai"]
+        assert getattr(result, "foo.foo") == ["cool", "test", "linode"]
+        assert getattr(result, "foo.bar") == [None, "wow"]
+        assert getattr(result, "foo.aaa") == ["computer", None, "akamai"]

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,0 +1,80 @@
+import argparse
+
+from linodecli import operation
+
+
+class TestOperation:
+    def test_list_arg_action_basic(self):
+        """
+        Tests a basic list argument condition.
+        """
+
+        parser = argparse.ArgumentParser(
+            prog=f"foo",
+        )
+
+        for arg_name in ["foo", "bar", "aaa"]:
+            parser.add_argument(
+                f"--{arg_name}",
+                metavar=arg_name,
+                action=operation.ListArgumentAction,
+                type=str,
+            )
+
+        result = parser.parse_args(
+            [
+                "--foo",
+                "cool",
+                "--bar",
+                "wow",
+                "--aaa",
+                "computer",
+                "--foo",
+                "test",
+                "--bar",
+                "wow",
+                "--aaa",
+                "akamai",
+            ]
+        )
+        assert result.foo == ["cool", "test"]
+        assert result.bar == ["wow", "wow"]
+        assert result.aaa == ["computer", "akamai"]
+
+    def test_list_arg_action_missing_attr(self):
+        """
+        Tests that a missing attribute for the first element will be
+        implicitly populated.
+        """
+
+        parser = argparse.ArgumentParser(
+            prog=f"foo",
+        )
+
+        for arg_name in ["foo", "bar", "aaa"]:
+            parser.add_argument(
+                f"--{arg_name}",
+                metavar=arg_name,
+                action=operation.ListArgumentAction,
+                type=str,
+            )
+
+        result = parser.parse_args(
+            [
+                "--foo",
+                "cool",
+                "--aaa",
+                "computer",
+                "--foo",
+                "test",
+                "--bar",
+                "wow",
+                "--foo",
+                "linode",
+                "--aaa",
+                "akamai",
+            ]
+        )
+        assert result.foo == ["cool", "test", "linode"]
+        assert result.bar == [None, "wow"]
+        assert result.aaa == ["computer", None, "akamai"]


### PR DESCRIPTION
## 📝 Description

This change improves the handling for nested list structures (e.g. Instance Interfaces) by implicitly detecting when the next list entry should be populated. This means that users do not have to explicitly specify empty values for null fields.

For example, see this command:

```bash
linode-cli linodes config-update 1234 5678 \
--interfaces.purpose public \
--interfaces.purpose vlan --interfaces.label my-vlan 
```

A user would intuitively expect this command to set the first interface to public and the second interface to a VLAN with the label `my-vlan`, however executing this command would generate this request body:

```json
{
   "interfaces":[
      {
         "label":"cool",
         "purpose":"public"
      }
   ]
}
```

After this change, the request body is now generated as expected:

```json
{
   "interfaces":[
      {
         "label":null,
         "ipam_address":null,
         "purpose":"public"
      },
      {
         "label":"cool",
         "purpose":"vlan"
      }
   ]
}
```


## ✔️ How to Test

```
make test
```