### PR TITLE
fix: Resolve issues with absolute paths in OBJ plugin and fix warning suppression logic

### DIFF
--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -105,12 +105,6 @@ def register_args(parser):
         "are configured on initial setup or with linode-cli configure",
     )
     parser.add_argument(
-        "--suppress-warnings",
-        action="store_true",
-        help="Suppress warnings that are intended for human users. "
-        "This is useful for scripting the CLI's behavior.",
-    )
-    parser.add_argument(
         "--no-truncation",
         action="store_true",
         default=False,

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -72,6 +72,13 @@ def register_args_shared(parser):
         "be configured.",
     )
 
+    parser.add_argument(
+        "--suppress-warnings",
+        action="store_true",
+        help="Suppress warnings that are intended for human users. "
+        "This is useful for scripting the CLI's behavior.",
+    )
+
     return parser
 
 

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -73,7 +73,7 @@ except ImportError:
 
 def list_objects_or_buckets(
     get_client, args, **kwargs
-):  # pylint: disable=too-many-locals
+):  # pylint: disable=too-many-locals,unused-argument
     """
     Lists buckets or objects
     """
@@ -154,7 +154,7 @@ def list_objects_or_buckets(
         sys.exit(0)
 
 
-def generate_url(get_client, args, **kwargs):
+def generate_url(get_client, args, **kwargs):  # pylint: disable=unused-argument
     """
     Generates a URL to an object
     """
@@ -205,7 +205,7 @@ def generate_url(get_client, args, **kwargs):
     print(url)
 
 
-def set_acl(get_client, args, **kwargs):
+def set_acl(get_client, args, **kwargs):  # pylint: disable=unused-argument
     """
     Modify Access Control List for a Bucket or Objects
     """
@@ -265,7 +265,7 @@ def set_acl(get_client, args, **kwargs):
     print("ACL updated")
 
 
-def show_usage(get_client, args, **kwargs):
+def show_usage(get_client, args, **kwargs):  # pylint: disable=unused-argument
     """
     Shows space used by all buckets in this cluster, and total space
     """
@@ -321,7 +321,9 @@ def show_usage(get_client, args, **kwargs):
     sys.exit(0)
 
 
-def list_all_objects(get_client, args, **kwargs):
+def list_all_objects(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Lists all objects in all buckets
     """

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -445,18 +445,20 @@ def get_credentials(cli: CLI):
     return access_key, secret_key
 
 
-def regenerate_s3_credentials(cli: CLI):
+def regenerate_s3_credentials(cli: CLI, suppress_warnings=False):
     """
     Force regenerate object storage access key and secret key.
     """
     print("Regenerating Object Storage keys..")
     _get_s3_creds(cli, force=True)
     print("Done.")
-    print(
-        "Warning: Your old Object Storage keys _were not_ automatically expired!  If you want "
-        "to expire them, see `linode-cli object-storage keys-list` and "
-        "`linode-cli object-storage keys-delete [KEYID]`."
-    )
+
+    if not suppress_warnings:
+        print(
+            "WARNING: Your old Object Storage keys _were not_ automatically expired!  If you want "
+            "to expire them, see `linode-cli object-storage keys-list` and "
+            "`linode-cli object-storage keys-delete [KEYID]`."
+        )
 
 
 def call(
@@ -530,7 +532,9 @@ def call(
         except ClientError as e:
             sys.exit(f"Error: {e}")
     elif parsed.command == "regenerate-keys":
-        regenerate_s3_credentials(context.client)
+        regenerate_s3_credentials(
+            context.client, suppress_warnings=parsed.suppress_warnings
+        )
     elif parsed.command == "configure":
         _configure_plugin(context.client)
     else:

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -72,7 +72,7 @@ except ImportError:
 
 
 def list_objects_or_buckets(
-    get_client, args
+    get_client, args, **kwargs
 ):  # pylint: disable=too-many-locals
     """
     Lists buckets or objects
@@ -154,7 +154,7 @@ def list_objects_or_buckets(
         sys.exit(0)
 
 
-def generate_url(get_client, args):
+def generate_url(get_client, args, **kwargs):
     """
     Generates a URL to an object
     """
@@ -205,7 +205,7 @@ def generate_url(get_client, args):
     print(url)
 
 
-def set_acl(get_client, args):
+def set_acl(get_client, args, **kwargs):
     """
     Modify Access Control List for a Bucket or Objects
     """
@@ -265,7 +265,7 @@ def set_acl(get_client, args):
     print("ACL updated")
 
 
-def show_usage(get_client, args):
+def show_usage(get_client, args, **kwargs):
     """
     Shows space used by all buckets in this cluster, and total space
     """
@@ -321,7 +321,7 @@ def show_usage(get_client, args):
     sys.exit(0)
 
 
-def list_all_objects(get_client, args):
+def list_all_objects(get_client, args, **kwargs):
     """
     Lists all objects in all buckets
     """
@@ -524,7 +524,9 @@ def call(
 
     if parsed.command in COMMAND_MAP:
         try:
-            COMMAND_MAP[parsed.command](get_client, args)
+            COMMAND_MAP[parsed.command](
+                get_client, args, suppress_warnings=parsed.suppress_warnings
+            )
         except ClientError as e:
             sys.exit(f"Error: {e}")
     elif parsed.command == "regenerate-keys":

--- a/linodecli/plugins/obj/buckets.py
+++ b/linodecli/plugins/obj/buckets.py
@@ -8,7 +8,9 @@ from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import PLUGIN_BASE
 
 
-def create_bucket(get_client, args, **kwargs):
+def create_bucket(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Creates a new bucket
     """
@@ -30,7 +32,9 @@ def create_bucket(get_client, args, **kwargs):
     sys.exit(0)
 
 
-def delete_bucket(get_client, args, **kwargs):
+def delete_bucket(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Deletes a bucket
     """

--- a/linodecli/plugins/obj/buckets.py
+++ b/linodecli/plugins/obj/buckets.py
@@ -8,7 +8,7 @@ from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import PLUGIN_BASE
 
 
-def create_bucket(get_client, args):
+def create_bucket(get_client, args, **kwargs):
     """
     Creates a new bucket
     """
@@ -30,7 +30,7 @@ def create_bucket(get_client, args):
     sys.exit(0)
 
 
-def delete_bucket(get_client, args):
+def delete_bucket(get_client, args, **kwargs):
     """
     Deletes a bucket
     """

--- a/linodecli/plugins/obj/objects.py
+++ b/linodecli/plugins/obj/objects.py
@@ -25,7 +25,7 @@ from linodecli.plugins.obj.helpers import (
 
 def upload_object(
     get_client, args, **kwargs
-):  # pylint: disable=too-many-locals
+):  # pylint: disable=too-many-locals,unused-argument
     """
     Uploads an object to object storage
     """
@@ -105,7 +105,9 @@ def upload_object(
 
 # We can't parse suppress_warnings from the parser
 # because it is handled at the top-level of this plugin.
-def get_object(get_client, args, suppress_warnings=False, **kwargs):
+def get_object(
+    get_client, args, suppress_warnings=False, **kwargs
+):  # pylint: disable=unused-argument
     """
     Retrieves an uploaded object and writes it to a file
     """
@@ -178,7 +180,9 @@ def get_object(get_client, args, suppress_warnings=False, **kwargs):
     print("Done.")
 
 
-def delete_object(get_client, args, **kwargs):
+def delete_object(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Removes a file from a bucket
     """

--- a/linodecli/plugins/obj/website.py
+++ b/linodecli/plugins/obj/website.py
@@ -8,7 +8,7 @@ from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import BASE_WEBSITE_TEMPLATE, PLUGIN_BASE
 
 
-def enable_static_site(get_client, args):
+def enable_static_site(get_client, args, **kwargs):
     """
     Turns a bucket into a static website
     """
@@ -66,7 +66,7 @@ def enable_static_site(get_client, args):
     )
 
 
-def static_site_info(get_client, args):
+def static_site_info(get_client, args, **kwargs):
     """
     Returns info about a configured static site
     """
@@ -99,7 +99,7 @@ def static_site_info(get_client, args):
     print(f"Error document: {error}")
 
 
-def disable_static_site(get_client, args):
+def disable_static_site(get_client, args, **kwargs):
     """
     Disables static site for a bucket
     """

--- a/linodecli/plugins/obj/website.py
+++ b/linodecli/plugins/obj/website.py
@@ -8,7 +8,9 @@ from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import BASE_WEBSITE_TEMPLATE, PLUGIN_BASE
 
 
-def enable_static_site(get_client, args, **kwargs):
+def enable_static_site(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Turns a bucket into a static website
     """
@@ -66,7 +68,9 @@ def enable_static_site(get_client, args, **kwargs):
     )
 
 
-def static_site_info(get_client, args, **kwargs):
+def static_site_info(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Returns info about a configured static site
     """
@@ -99,7 +103,9 @@ def static_site_info(get_client, args, **kwargs):
     print(f"Error document: {error}")
 
 
-def disable_static_site(get_client, args, **kwargs):
+def disable_static_site(
+    get_client, args, **kwargs
+):  # pylint: disable=unused-argument
     """
     Disables static site for a bucket
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 PyYAML
 packaging
 rich
+urllib3<2


### PR DESCRIPTION
## 📝 Description

This pull request resolves an issue that would cause the CLI to crash (or 403) if an absolute path was provided when getting an object. Additionally, this change adds support for the `--suppress-warnings` argument in the OBJ plugin.

Resolves #451 

## ✔️ How to Test

```bash
make test
pytest tests/integration/test_obj_plugin.py
```
