### PR TITLE
fix: Resolve `--no-headers` flag for tabular output

### DIFF
--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -139,22 +139,20 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         content = self._build_output_content(
             data,
             columns,
-            header=header,
             value_transform=lambda attr, v: self._attempt_truncate_value(
                 attr.render_value(v)
             ),
         )
 
-        tab = Table(*content[0], header_style="", box=box.SQUARE)
-        for row in content[1:]:
+        tab = Table(
+            *header, header_style="", box=box.SQUARE, show_header=self.headers
+        )
+        for row in content:
             row = [Text.from_ansi(item) for item in row]
             tab.add_row(*row)
 
         if title is not None:
             tab.title = title
-
-        if not self.headers:
-            tab.show_header = False
 
         rprint(tab, file=to)
 

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -162,6 +162,32 @@ class TestOutputHandler:
 
         assert output.getvalue() == mock_table.getvalue()
 
+    def test_table_output_models_no_headers(self, mock_cli):
+        mock_cli.output_handler.headers = False
+
+        output = io.StringIO()
+        header = ["h1"]
+        data = [
+            {
+                "cool": "foo",
+            },
+            {"cool": "bar"},
+        ]
+        columns = [ModelAttr("cool", True, True, "string")]
+
+        mock_cli.output_handler._table_output(
+            header, data, columns, "cool table", output
+        )
+
+        mock_table = io.StringIO()
+        tab = Table(header_style="", show_header=False, box=box.SQUARE)
+        for row in [["foo"], ["bar"]]:
+            tab.add_row(*row)
+        tab.title = "cool table"
+        rprint(tab, file=mock_table)
+
+        assert output.getvalue() == mock_table.getvalue()
+
     def test_get_columns_from_model(self, mock_cli):
         output_handler = mock_cli.output_handler
 


### PR DESCRIPTION
## 📝 Description

This change resolves an issue with the `--no-headers` flag in table output mode which would cause the first row of content to be dropped.

## ✔️ How to Test

```
make testunit
```
