### PR TITLE
new: Add a `No Default` option when running the `configure` command

### DIFF
--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -424,7 +424,7 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             "Default Engine (Optional): ",
             "Please select a valid PostgreSQL Database Engine, or press Enter to skip",
             current_value=_config_get_with_default(
-                self.config, username, "postgres_engine"
+                self.config, username, "postgresql_engine"
             ),
         )
 

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -15,6 +15,7 @@ from .auth import (
 )
 from .helpers import (
     _check_browsers,
+    _config_get_with_default,
     _default_thing_input,
     _get_config,
     _get_config_path,
@@ -382,6 +383,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             regions,
             "Default Region (Optional): ",
             "Please select a valid Region, or press Enter to skip",
+            current_value=_config_get_with_default(
+                self.config, username, "region"
+            ),
         )
 
         config["type"] = _default_thing_input(
@@ -389,6 +393,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             types,
             "Default Type of Linode (Optional): ",
             "Please select a valid Type, or press Enter to skip",
+            current_value=_config_get_with_default(
+                self.config, username, "type"
+            ),
         )
 
         config["image"] = _default_thing_input(
@@ -396,6 +403,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             images,
             "Default Image (Optional): ",
             "Please select a valid Image, or press Enter to skip",
+            current_value=_config_get_with_default(
+                self.config, username, "image"
+            ),
         )
 
         config["mysql_engine"] = _default_thing_input(
@@ -403,6 +413,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             mysql_engines,
             "Default Engine (Optional): ",
             "Please select a valid MySQL Database Engine, or press Enter to skip",
+            current_value=_config_get_with_default(
+                self.config, username, "mysql_engine"
+            ),
         )
 
         config["postgresql_engine"] = _default_thing_input(
@@ -410,6 +423,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             postgresql_engines,
             "Default Engine (Optional): ",
             "Please select a valid PostgreSQL Database Engine, or press Enter to skip",
+            current_value=_config_get_with_default(
+                self.config, username, "postgres_engine"
+            ),
         )
 
         if auth_users:
@@ -418,6 +434,9 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
                 auth_users,
                 "Default Option (Optional): ",
                 "Please select a valid Option, or press Enter to skip",
+                current_value=_config_get_with_default(
+                    self.config, username, "authorized_users"
+                ),
             )
 
         # save off the new configuration
@@ -446,8 +465,13 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             print(f"Active user is now {username}")
 
         for k, v in config.items():
-            if v:
-                self.config.set(username, k, v)
+            if v is None:
+                if self.config.has_option(username, k):
+                    self.config.remove_option(username, k)
+
+                continue
+
+            self.config.set(username, k, v)
 
         self.write_config()
         os.chmod(_get_config_path(), 0o600)

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -100,7 +100,7 @@ def _default_thing_input(
 
     # If there is a current value, users should have the option to clear it
     if exists:
-        print(f" 1 - No Default")
+        print(" 1 - No Default")
 
     for ind, thing in enumerate(things):
         print(f" {ind + idx_offset} - {thing}")

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -127,13 +127,16 @@ def _default_thing_input(
         if exists and choice_idx == 1:
             return None
 
+        # We need to shift the index to account for the "No Default" option
+        choice_idx -= idx_offset
+
         # Validate index
-        if choice_idx > idx_offset + len(things) or choice_idx < 1:
+        if choice_idx >= len(things) or choice_idx < 0:
             print(error)
             continue
 
         # Choice was valid; return
-        return things[choice_idx - idx_offset]
+        return things[choice_idx]
 
 
 def _config_get_with_default(


### PR DESCRIPTION
## 📝 Description

This change adds a `No Default` option to the `linode-cli configure` command that allows users to optionally clear a default if it is already defined in the existing config. This differs from the skip (enter) functionality in that the skip functionality retains the previous config value and the `No Default` option drops the config value.

## ✔️ How to Test

`make testunit`
