### PR TITLE
fix: Use `+and` for X-Filter header and support filtering on multiple list entries

### DIFF
--- a/linodecli/operation.py
+++ b/linodecli/operation.py
@@ -272,6 +272,7 @@ class CLIOperation:  # pylint: disable=too-many-instance-attributes
                             "--" + attr.name,
                             type=TYPES[attr.item_type],
                             metavar=attr.name,
+                            action="append",
                             nargs="?",
                         )
                     else:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -118,7 +118,18 @@ def list_operation():
         "foo/bar",
         "get info",
         [],
-        ResponseModel([ModelAttr("filterable_result", True, True, "string")]),
+        ResponseModel(
+            [
+                ModelAttr("filterable_result", True, True, "string"),
+                ModelAttr(
+                    "filterable_list_result",
+                    True,
+                    True,
+                    "array",
+                    item_type="string",
+                ),
+            ]
+        ),
         [],
     )
 


### PR DESCRIPTION
## 📝 Description

This change adds support for filtering on multiple entries of the same response list when calling list endpoints. This works by flattening out any parsed list arguments and appending all values to a `+and` filter.

For example:

```bash
linode-cli linodes ls --tags foo --tags bar
```

This command would previously ignore the first specified tag and only filter on the second tag. With this fix, response rows will be required to have both specified tags.

## ✔️ How to Test

```bash
make testunit
```