### PR TITLE
Migrate build frontend to `pypa/build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ install: check-prerequisites requirements build
 build: clean
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-3 linodecli/
-	python3 setup.py bdist_wheel
-	python3 setup.py sdist
+	python3 -m build --wheel --sdist --no-isolation
 
 .PHONY: requirements
 requirements:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ autoflake>=2.0.1
 pytest-mock>=3.10.0
 requests-mock==1.11.0
 boto3-stubs[s3]
+build>=0.10.0


### PR DESCRIPTION
## 📝 Description

Calling `setup.py` directly is now deprecated.
