### PR TITLE
fix incorrect `linode-cli obj du` number formatting

### DIFF
--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -106,16 +106,11 @@ def _denominate(total):
     """
     Coverts bucket size to human readable bytes.
     """
-    total = float(total)
-    denomination = ["KB", "MB", "GB", "TB"]
-    for x in denomination:
-        if total > 1024:
-            total = total / 1024
+    for unit in ("KB", "MB", "GB", "TB"):
+        total = total / 1024
         if total < 1024:
-            total = round(total, 2)
-            total = str(total) + " " + x
             break
-    return total
+    return f'{round(total, 2)} {unit}'
 
 
 # helper functions for output

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -110,7 +110,7 @@ def _denominate(total):
         total = total / 1024
         if total < 1024:
             break
-    return f'{round(total, 2)} {unit}'
+    return f"{round(total, 2)} {unit}"
 
 
 # helper functions for output

--- a/tests/unit/test_plugin_obj.py
+++ b/tests/unit/test_plugin_obj.py
@@ -1,6 +1,6 @@
 from pytest import CaptureFixture
 
-from linodecli.plugins.obj import get_obj_args_parser, print_help
+from linodecli.plugins.obj import get_obj_args_parser, helpers, print_help
 
 
 def test_print_help(capsys: CaptureFixture):
@@ -12,3 +12,24 @@ def test_print_help(capsys: CaptureFixture):
         "See --help for individual commands for more information"
         in captured_text.out
     )
+
+
+def test_helpers_denominate():
+    assert helpers._denominate(0) == '0.0 KB'
+    assert helpers._denominate(1) == '0.0 KB'
+    assert helpers._denominate(12) == '0.01 KB'
+    assert helpers._denominate(123) == '0.12 KB'
+    assert helpers._denominate(1000) == '0.98 KB'
+
+    assert helpers._denominate(1024) == '1.0 KB'
+    assert helpers._denominate(1024 ** 2) == '1.0 MB'
+    assert helpers._denominate(1024 ** 3) == '1.0 GB'
+    assert helpers._denominate(1024 ** 4) == '1.0 TB'
+    assert helpers._denominate(1024 ** 5) == '1024.0 TB'
+
+    assert helpers._denominate(102400) == '100.0 KB'
+    assert helpers._denominate(1024000) == '1000.0 KB'
+    assert helpers._denominate((1024 ** 2) // 10) == '102.4 KB'
+
+    assert helpers._denominate(123456789) == '117.74 MB'
+    assert helpers._denominate(1e23) == '90949470177.29 TB'

--- a/tests/unit/test_plugin_obj.py
+++ b/tests/unit/test_plugin_obj.py
@@ -15,21 +15,21 @@ def test_print_help(capsys: CaptureFixture):
 
 
 def test_helpers_denominate():
-    assert helpers._denominate(0) == '0.0 KB'
-    assert helpers._denominate(1) == '0.0 KB'
-    assert helpers._denominate(12) == '0.01 KB'
-    assert helpers._denominate(123) == '0.12 KB'
-    assert helpers._denominate(1000) == '0.98 KB'
+    assert helpers._denominate(0) == "0.0 KB"
+    assert helpers._denominate(1) == "0.0 KB"
+    assert helpers._denominate(12) == "0.01 KB"
+    assert helpers._denominate(123) == "0.12 KB"
+    assert helpers._denominate(1000) == "0.98 KB"
 
-    assert helpers._denominate(1024) == '1.0 KB'
-    assert helpers._denominate(1024 ** 2) == '1.0 MB'
-    assert helpers._denominate(1024 ** 3) == '1.0 GB'
-    assert helpers._denominate(1024 ** 4) == '1.0 TB'
-    assert helpers._denominate(1024 ** 5) == '1024.0 TB'
+    assert helpers._denominate(1024) == "1.0 KB"
+    assert helpers._denominate(1024**2) == "1.0 MB"
+    assert helpers._denominate(1024**3) == "1.0 GB"
+    assert helpers._denominate(1024**4) == "1.0 TB"
+    assert helpers._denominate(1024**5) == "1024.0 TB"
 
-    assert helpers._denominate(102400) == '100.0 KB'
-    assert helpers._denominate(1024000) == '1000.0 KB'
-    assert helpers._denominate((1024 ** 2) // 10) == '102.4 KB'
+    assert helpers._denominate(102400) == "100.0 KB"
+    assert helpers._denominate(1024000) == "1000.0 KB"
+    assert helpers._denominate((1024**2) // 10) == "102.4 KB"
 
-    assert helpers._denominate(123456789) == '117.74 MB'
-    assert helpers._denominate(1e23) == '90949470177.29 TB'
+    assert helpers._denominate(123456789) == "117.74 MB"
+    assert helpers._denominate(1e23) == "90949470177.29 TB"


### PR DESCRIPTION
## 📝 Description

`linode obj du` produces correct output in almost all real-world cases, but it's off by a few orders of magnitude when 0 < size < 1024 (claims KB when should be bytes), and does stranger things whenever size happens to be a power of 1024, or whenever it is greater than 1 PiB.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

One way to reproduce the bug is to create a bucket containing a single file whose size meets any of the above criteria, then run `linode obj du` against it. For example, the bucket below contains a single 415 byte file. `obj ls` reports the correct size, but `obj du` incorrectly claims a total of 415 KB:

```
$ linode-cli obj du
415.0 KB    1 objects  jafreche
$ linode-cli obj ls jafreche
2023-06-13 23:22  415  index.html
$ curl --silent https://jafreche.us-east-1.linodeobjects.com/index.html | wc -c
     415
```

**How do I run the relevant unit/integration tests?**

```
pytest tests/unit/test_plugin_obj.py
```

## 📷 Preview

Here's a table comparing old and new output for various inputs, with code copied from before and after this change, and inputs copied from the new unit test. Note that cases that were already being handled correctly are completely untouched by this fix.

```
$ ./denominate.py 

input                before               .. after               
-----------------------------------------------------------------
0                    '0.0 KB'             == '0.0 KB'            
1                    '1.0 KB'             != '0.0 KB'            
12                   '12.0 KB'            != '0.01 KB'           
123                  '123.0 KB'           != '0.12 KB'           
1000                 '1000.0 KB'          != '0.98 KB'           
1024                 1024.0               != '1.0 KB'            
1048576              1024.0               != '1.0 MB'            
1073741824           1024.0               != '1.0 GB'            
1099511627776        1024.0               != '1.0 TB'            
1125899906842624     1024.0               != '1024.0 TB'         
102400               '100.0 KB'           == '100.0 KB'          
1024000              '1000.0 KB'          == '1000.0 KB'         
104857               '102.4 KB'           == '102.4 KB'          
123456789            '117.74 MB'          == '117.74 MB'         
1e+23                90949470177.29282    != '90949470177.29 TB' 

$ cat ./denominate.py 
#!/usr/bin/env python3

def _denominate_before(total):
    total = float(total)
    denomination = ["KB", "MB", "GB", "TB"]
    for x in denomination:
        if total > 1024:
            total = total / 1024
        if total < 1024:
            total = round(total, 2)
            total = str(total) + " " + x
            break
    return total

def _denominate_after(total):
    for unit in ("KB", "MB", "GB", "TB"):
        total = total / 1024
        if total < 1024:
            break
    return f'{round(total, 2)} {unit}'

def main():
    print()
    print(f'{"input":20} {"before":20} .. {"after":20}')
    print('-' * 65)
    for total in (0, 1, 12, 123, 1000, 1024, 1024**2, 1024**3, 1024**4, 1024**5, 102400, 1024000, 1024**2//10, 123456789, 1e23):
        before = _denominate_before(total)
        after = _denominate_after(total)
        cmp = '==' if before == after else '!='
        print(f'{total!r:20} {before!r:20} {cmp} {after!r:20}')
    print()

main()
```