### PR TITLE
Add twine check in lint workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install: check-prerequisites requirements build
 build: clean
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-3 linodecli/
-	python3 -m build --wheel --sdist --no-isolation
+	python3 -m build --wheel --sdist
 
 .PHONY: requirements
 requirements:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ifndef SPEC
 override SPEC = $(shell ./resolve_spec_url ${SPEC_VERSION})
 endif
 
+.PHONY: install
 install: check-prerequisites requirements build
 	pip3 install --force dist/*.whl
 
@@ -27,7 +28,7 @@ build: clean
 requirements:
 	pip3 install -r requirements.txt
 
-.PHONY: requirements
+.PHONY: lint
 lint:
 	pylint linodecli
 	isort --check-only linodecli tests
@@ -63,13 +64,17 @@ testall:
 .PHONY: test
 test: testunit
 
+.PHONY: black
 black:
 	black linodecli tests
 
+.PHONY: isort
 isort:
 	isort linodecli tests
 
+.PHONY: autoflake
 autoflake:
 	autoflake linodecli tests
 
+.PHONY: format
 format: black isort autoflake

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,12 @@ requirements:
 	pip3 install -r requirements.txt
 
 .PHONY: lint
-lint:
+lint: build
 	pylint linodecli
 	isort --check-only linodecli tests
 	autoflake --check linodecli tests
 	black --check --verbose linodecli tests
+	twine check dist/*
 
 .PHONY: check-prerequisites
 check-prerequisites:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-mock>=3.10.0
 requests-mock==1.11.0
 boto3-stubs[s3]
 build>=0.10.0
+twine>=4.0.2

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     version=version,
     description="CLI for the Linode API",
     long_description=long_description,
+    long_description_content_type="text/x-rst",
     author="Linode",
     author_email="developers@linode.com",
     url="https://www.linode.com/docs/api/",


### PR DESCRIPTION
## 📝 Description

`twine check` is necessary to ensure the package can be built and validated for publishing on PyPI.

## ✔️ How to Test
`make lint` or see the GHA run result.