### PR TITLE
feat: option to display output in ASCII tables

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -68,6 +68,8 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         cli.output_handler.columns = "*"
     elif parsed.markdown:
         cli.output_handler.mode = OutputMode.markdown
+    elif parsed.ascii_table:
+        cli.output_handler.mode = OutputMode.ascii_table
 
     if parsed.delimiter:
         cli.output_handler.delimiter = parsed.delimiter

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -64,7 +64,7 @@ def register_args(parser):
     parser.add_argument(
         "--ascii-table",
         action="store_true",
-        help="Display output in an ASCII table."
+        help="Display output in an ASCII table.",
     )
     parser.add_argument(
         "--pretty",

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -64,7 +64,7 @@ def register_args(parser):
     parser.add_argument(
         "--ascii-table",
         action="store_true",
-        help="Display output in an ASCII table"
+        help="Display output in an ASCII table."
     )
     parser.add_argument(
         "--pretty",

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -62,6 +62,11 @@ def register_args(parser):
         help="Display output in Markdown format.",
     )
     parser.add_argument(
+        "--ascii-table",
+        action="store_true",
+        help="Display output in an ASCII table"
+    )
+    parser.add_argument(
         "--pretty",
         action="store_true",
         help="If set, pretty-print JSON output.",
@@ -253,7 +258,7 @@ def help_with_ops(ops, config):
         "(e.g. 'https')",
     }
 
-    table = Table(show_header=True, header_style="", box=box.SQUARE)
+    table = Table(show_header=True, header_style="", box=box.SQUARE, safe_box=True)
     table.add_column("Name")
     table.add_column("Description")
 

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -258,7 +258,7 @@ def help_with_ops(ops, config):
         "(e.g. 'https')",
     }
 
-    table = Table(show_header=True, header_style="", box=box.SQUARE, safe_box=True)
+    table = Table(show_header=True, header_style="", box=box.SQUARE)
     table.add_column("Name")
     table.add_column("Description")
 

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -83,7 +83,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             ),
             OutputMode.ascii_table: lambda: self._table_output(
                 header, data, columns, title, to, box.ASCII
-            ),               
+            ),
             OutputMode.delimited: lambda: self._delimited_output(
                 header, data, columns, to
             ),

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -90,7 +90,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             OutputMode.json: lambda: self._json_output(header, data, to),
             OutputMode.markdown: lambda: self._markdown_output(
                 header, data, columns, to
-            )
+            ),
         }
 
         if columns is None:

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -135,7 +135,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         return columns
 
     def _table_output(
-        self, header, data, columns, title, to, box=box.SQUARE
+        self, header, data, columns, title, to, box_style=box.SQUARE
     ):  # pylint: disable=too-many-arguments
         """
         Pretty-prints data in a table
@@ -149,7 +149,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         )
 
         tab = Table(
-            *header, header_style="", box=box, show_header=self.headers
+            *header, header_style="", box=box_style, show_header=self.headers
         )
         for row in content:
             row = [Text.from_ansi(item) for item in row]

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -24,6 +24,7 @@ class OutputMode(Enum):
     delimited = 2
     json = 3
     markdown = 4
+    ascii_table = 5
 
 
 class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -80,13 +81,16 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             OutputMode.table: lambda: self._table_output(
                 header, data, columns, title, to
             ),
+            OutputMode.ascii_table: lambda: self._table_output(
+                header, data, columns, title, to, box.ASCII
+            ),               
             OutputMode.delimited: lambda: self._delimited_output(
                 header, data, columns, to
             ),
             OutputMode.json: lambda: self._json_output(header, data, to),
             OutputMode.markdown: lambda: self._markdown_output(
                 header, data, columns, to
-            ),
+            )
         }
 
         if columns is None:
@@ -131,7 +135,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         return columns
 
     def _table_output(
-        self, header, data, columns, title, to
+        self, header, data, columns, title, to, box=box.SQUARE
     ):  # pylint: disable=too-many-arguments
         """
         Pretty-prints data in a table
@@ -145,7 +149,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         )
 
         tab = Table(
-            *header, header_style="", box=box.SQUARE, show_header=self.headers
+            *header, header_style="", box=box, show_header=self.headers
         )
         for row in content:
             row = [Text.from_ansi(item) for item in row]

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -197,7 +197,7 @@ class TestOutputHandler:
             },
             {"cool": "bar"},
         ]
-        columns = [ModelAttr("cool", True, True, "string")]        
+        columns = [ModelAttr("cool", True, True, "string")]
 
         output_handler = mock_cli.output_handler
         output_handler._table_output(
@@ -208,13 +208,13 @@ class TestOutputHandler:
 
         assert (
             output.getvalue() == " cool  \n"
-                " table \n"
-                "+-----+\n"
-                "| h1  |\n"
-                "|-----|\n"
-                "| foo |\n"
-                "| bar |\n"
-                "+-----+\n"
+            " table \n"
+            "+-----+\n"
+            "| h1  |\n"
+            "|-----|\n"
+            "| foo |\n"
+            "| bar |\n"
+            "+-----+\n"
         )
 
     def test_get_columns_from_model(self, mock_cli):

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -188,6 +188,35 @@ class TestOutputHandler:
 
         assert output.getvalue() == mock_table.getvalue()
 
+    def test_ascii_table_output(self, mock_cli):
+        output = io.StringIO()
+        header = ["h1"]
+        data = [
+            {
+                "cool": "foo",
+            },
+            {"cool": "bar"},
+        ]
+        columns = [ModelAttr("cool", True, True, "string")]        
+
+        output_handler = mock_cli.output_handler
+        output_handler._table_output(
+            header, data, columns, "cool table", output, box.ASCII
+        )
+
+        print(output.getvalue())
+
+        assert (
+            output.getvalue() == " cool  \n"
+                " table \n"
+                "+-----+\n"
+                "| h1  |\n"
+                "|-----|\n"
+                "| foo |\n"
+                "| bar |\n"
+                "+-----+\n"
+        )
+
     def test_get_columns_from_model(self, mock_cli):
         output_handler = mock_cli.output_handler
 


### PR DESCRIPTION
## 📝 Description

This PR adds a new option, `--ascii-table`, to display output like this:

![Screenshot 2023-06-28 at 12 14 54 PM](https://github.com/linode/linode-cli/assets/114753608/f24fccb5-f29c-4fb1-a167-e6f434ea5dbb)

This is better than the default (unicode) tables in some CI runners. It may be more visually appealing to some users as well.

**Questions for consideration:** 
- Should this be an output option, or a global config/setting? 
  - An advantage of a global setting is users may prefer to see ALL tables (including "Available Commands, etc") in this style, as opposed to just output. 
- What do you think of the option name? 
  - `--ascii` is cleaner and more consistent with existing `json` and `markdown` options, but I thought it'd be better to explicitly call out that this applies to the tables only (e.g. not any data coming back from the API).


## ✔️ How to Test
- Try out the new `--ascii-table` option
- Run the new unit test: `pytest tests/unit/test_output.py` 
