### PR TITLE
fix: Resolve type error when using `--no-truncation` on non-string values

### DIFF
--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -256,11 +256,11 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         return content
 
     def _attempt_truncate_value(self, value):
-        if self.disable_truncation:
-            return value
-
         if not isinstance(value, str):
             value = str(value)
+
+        if self.disable_truncation:
+            return value
 
         if len(value) < self.truncation_length:
             return value

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -291,6 +291,12 @@ class TestOutputHandler:
 
         assert result == test_str
 
+        # Ensure integers are properly converted
+        result = mock_cli.output_handler._attempt_truncate_value(12345)
+
+        assert result == "12345"
+        assert isinstance(result, str)
+
     def test_truncated_table(self, mock_cli):
         output = io.StringIO()
 


### PR DESCRIPTION
## 📝 Description

This change fixes a bug that would cause an error to be raised when attempting to disable truncation on certain commands.

## ✔️ How to Test

```bash
make testunit
```

```bash
make install
linode-cli linodes ls --no-truncation
```