### PR TITLE
new: Overhaul truncation system; move markdown output to Rich

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -100,6 +100,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
     cli.output_handler.suppress_warnings = parsed.suppress_warnings
     cli.output_handler.disable_truncation = parsed.no_truncation
+    cli.output_handler.column_width = parsed.column_width
 
     if parsed.as_user and not skip_config:
         cli.config.set_user(parsed.as_user)

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -127,6 +127,13 @@ def register_args(parser):
         help="Prevent the truncation of long values in command outputs.",
     )
     parser.add_argument(
+        "--column-width",
+        type=int,
+        default=None,
+        help="Sets the maximum width of each column in outputted tables. "
+        "By default, columns are dynamically sized to fit the terminal.",
+    )
+    parser.add_argument(
         "--version",
         "-v",
         action="store_true",

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -41,6 +41,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         columns=None,
         disable_truncation=False,
         suppress_warnings=False,
+        column_width=None,
     ):
         self.mode = mode
         self.delimiter = delimiter
@@ -50,9 +51,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         self.suppress_warnings = suppress_warnings
 
         self.disable_truncation = disable_truncation
-        self.overflow_mode = cast(
-            OverflowMethod, "fold" if disable_truncation else "ellipsis"
-        )
+        self.column_width = column_width
 
         # Used to track whether a warning has already been printed
         self.has_warned = False
@@ -148,10 +147,17 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             value_transform=lambda attr, v: str(attr.render_value(v)),
         )
 
+        # Determine the rich overflow mode to use
+        # for each column.
+        overflow_mode = cast(
+            OverflowMethod, "fold" if self.disable_truncation else "ellipsis"
+        )
+
         # Convert the headers into column objects
         # so we can override the overflow method.
         header_columns = [
-            Column(v, overflow=self.overflow_mode) for v in header
+            Column(v, overflow=overflow_mode, max_width=self.column_width)
+            for v in header
         ]
 
         tab = Table(


### PR DESCRIPTION
## 📝 Description

This PR makes a number of changes to the CLI's output system, including:
- The removal of the legacy truncation system in favor of dynamic truncation through Rich
- The removal of the legacy markdown output method in favor of Rich's markdown box style
- The addition of a new `--column-width` field to specify the maximum width of each column in an output table 

NOTE: This PR will be repointed to `dev` once the `openspec` branch has been merged.

## ✔️ How to Test

```
make testunit
```
