### PR TITLE
fix: Only use `+and` when filtering on multiple attributes

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -161,10 +161,15 @@ def _build_filter_header(
         new_filters = [{k: j} for j in v] if isinstance(v, list) else [{k: v}]
         filter_list.extend(new_filters)
 
-    if len(filter_list) > 0:
-        return json.dumps({"+and": filter_list})
+    if len(filter_list) < 1:
+        return None
 
-    return None
+    return json.dumps(
+        # Only use +and if there are multiple attributes to filter on
+        {"+and": filter_list}
+        if len(filter_list) > 1
+        else filter_list[0]
+    )
 
 
 def _build_request_url(ctx, operation, parsed_args) -> str:

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -125,6 +125,21 @@ class TestAPIRequest:
             == result
         )
 
+    def test_build_filter_header_single(self, list_operation):
+        result = api_request._build_filter_header(
+            list_operation,
+            SimpleNamespace(
+                filterable_result="bar",
+            ),
+        )
+
+        assert (
+            json.dumps(
+                {"filterable_result": "bar"},
+            )
+            == result
+        )
+
     def test_do_request_get(self, mock_cli, list_operation):
         mock_response = Mock(status_code=200, reason="OK")
 

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -140,6 +140,26 @@ class TestAPIRequest:
             == result
         )
 
+    def test_build_filter_header_single_list(self, list_operation):
+        result = api_request._build_filter_header(
+            list_operation,
+            SimpleNamespace(
+                filterable_list_result=["foo", "bar"],
+            ),
+        )
+
+        assert (
+            json.dumps(
+                {
+                    "+and": [
+                        {"filterable_list_result": "foo"},
+                        {"filterable_list_result": "bar"},
+                    ]
+                }
+            )
+            == result
+        )
+
     def test_do_request_get(self, mock_cli, list_operation):
         mock_response = Mock(status_code=200, reason="OK")
 


### PR DESCRIPTION
## 📝 Description

This change alters the filter header generation logic to only use `+and` when multiple attributes are being filtered on. This is a workaround to limit the impact of inconsistencies between top-level and nested filters.

Related to #500 

## ✔️ How to Test

```
make testunit
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**