### PR TITLE
Add order by and order flag

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -151,16 +151,13 @@ def _build_filter_header(
             del parsed_args_dict[p.name]
 
     # check for order_by and order
-    order_by = None
+    order_by, order = None, None
     if parsed_args_dict['order_by'] is not None:
         order_by = parsed_args_dict['order_by']
         order = 'asc' if parsed_args_dict['order'] == None else parsed_args_dict['order']
     
     del parsed_args_dict['order_by']
     del parsed_args_dict['order']
-
-    print(order_by, order)
-
 
     # The "+and" list to be used in the filter header
     filter_list = []

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -150,6 +150,18 @@ def _build_filter_header(
         if p.name in parsed_args_dict:
             del parsed_args_dict[p.name]
 
+    # check for order_by and order
+    order_by = None
+    if parsed_args_dict['order_by'] is not None:
+        order_by = parsed_args_dict['order_by']
+        order = 'asc' if parsed_args_dict['order'] == None else parsed_args_dict['order']
+    
+    del parsed_args_dict['order_by']
+    del parsed_args_dict['order']
+
+    print(order_by, order)
+
+
     # The "+and" list to be used in the filter header
     filter_list = []
 
@@ -162,7 +174,13 @@ def _build_filter_header(
         filter_list.extend(new_filters)
 
     if len(filter_list) > 0:
-        return json.dumps({"+and": filter_list})
+        if order_by is None:
+            return json.dumps({"+and": filter_list})
+        else:
+            return json.dumps({"+and": filter_list, "+order_by": order_by, "+order": order})
+    else:
+        if order_by is not None:
+            return json.dumps({"+order_by": order_by, "+order": order})
 
     return None
 

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -6,6 +6,7 @@ import glob
 import json
 import platform
 import re
+import sys
 from getpass import getpass
 from os import environ, path
 
@@ -339,11 +340,10 @@ class OpenAPIOperation:
             parser.add_argument(
                 "--order_by", 
                 choices=filterable_args,
-                help="Attribute to order the results by - must be filterable.")
-
-            order_group = parser.add_mutually_exclusive_group()
-    
-            order_group.add_argument(
+                help="Attribute to order the results by - must be filterable.",
+                required='--order' in sys.argv)    
+            
+            parser.add_argument(
                 "--order", 
                 choices=['asc', 'desc'], 
                 default='asc',

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -315,8 +315,10 @@ class OpenAPIOperation:
 
         if self.method == "get":
             # build args for filtering
+            filterable_args = []
             for attr in self.response_model.attrs:
                 if attr.filterable:
+                    filterable_args.append(attr.name)
                     expected_type = TYPES[attr.datatype]
                     if expected_type == list:
                         parser.add_argument(
@@ -332,6 +334,21 @@ class OpenAPIOperation:
                             type=expected_type,
                             metavar=attr.name,
                         )
+            
+            # Add --order_by and --order argument
+            parser.add_argument(
+                "--order_by", 
+                choices=filterable_args,
+                help="Attribute to order the results by - must be filterable.")
+
+            order_group = parser.add_mutually_exclusive_group()
+    
+            order_group.add_argument(
+                "--order", 
+                choices=['asc', 'desc'], 
+                default='asc',
+                help="Either “asc” or “desc”. Defaults to “asc”. Requires +order_by")
+
 
         elif self.method in ("post", "put"):
             # build args for body JSON


### PR DESCRIPTION
## 📝 Description

Adds --order_by and --order to filtering operations.

## ✔️ How to Test

Tested using command line. 

Ex.
`linode-cli linodes list --order_by label --order desc`
`linode-cli linodes list --order_by label`