### PR TITLE
Fix: changing `--order_by` to `--order-by` to match CLI flag conventions

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -151,7 +151,7 @@ def _build_filter_header(
             del parsed_args_dict[p.name]
 
     # check for order-by and order
-    order_by = parsed_args_dict.pop("order-by")
+    order_by = parsed_args_dict.pop("order_by")
     order = parsed_args_dict.pop("order") or "asc"
 
     # The "+and" list to be used in the filter header

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -150,8 +150,8 @@ def _build_filter_header(
         if p.name in parsed_args_dict:
             del parsed_args_dict[p.name]
 
-    # check for order_by and order
-    order_by = parsed_args_dict.pop("order_by")
+    # check for order-by and order
+    order_by = parsed_args_dict.pop("order-by")
     order = parsed_args_dict.pop("order") or "asc"
 
     # The "+and" list to be used in the filter header

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -364,6 +364,7 @@ def action_help(cli, command, action):
             print("You may filter results with:")
             for attr in filterable_attrs:
                 print(f"  --{attr.name}")
+            print("Additionally, you may order results using --order-by and --order.")
         return
     if op.args:
         print("Arguments:")

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -364,7 +364,9 @@ def action_help(cli, command, action):
             print("You may filter results with:")
             for attr in filterable_attrs:
                 print(f"  --{attr.name}")
-            print("Additionally, you may order results using --order-by and --order.")
+            print(
+                "Additionally, you may order results using --order-by and --order."
+            )
         return
     if op.args:
         print("Arguments:")

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -344,9 +344,9 @@ class OpenAPIOperation:
                     type=expected_type,
                     metavar=attr.name,
                 )
-        # Add --order_by and --order argument
+        # Add --order-by and --order argument
         parser.add_argument(
-            "--order_by",
+            "--order-by",
             choices=filterable_args,
             help="Attribute to order the results by - must be filterable.",
             required="--order" in sys.argv,


### PR DESCRIPTION
## 📝 Description

Changes `--order_by`flag to `--order-by` to match CLI conventions. Also added a print statements for `--help` for list actions.

## ✔️ How to Test

`linode-cli linodes list --order-by label`
`linode-cli linodes list --help`