### PR TITLE
fix: Resolve issue with `x-linode-cli-rows` extension

### DIFF
--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -187,13 +187,14 @@ class OpenAPIResponse:
             )
         else:
             self.attrs = _parse_response_model(response.schema)
-        self.rows = response.schema.extensions.get("linode-cli-rows")
+        self.rows = response.extensions.get("linode-cli-rows")
         self.nested_list = response.extensions.get("linode-cli-nested-list")
 
     def fix_json(self, json):
         """
         Formats JSON from the API into a list of rows
         """
+
         if self.rows:
             return self._fix_json_rows(json)
         if self.nested_list:

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -225,11 +225,6 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
                 v = OutputHandler._select_json_elements(keys, v)
                 if v:
                     ret[k] = v
-            elif isinstance(v, list):
-                for elem in v:
-                    v = OutputHandler._select_json_elements(keys, elem)
-                    if v:
-                        ret[k] = v
         return ret
 
     def _build_output_content(

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -225,6 +225,11 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
                 v = OutputHandler._select_json_elements(keys, v)
                 if v:
                     ret[k] = v
+            elif isinstance(v, list):
+                for elem in v:
+                    v = OutputHandler._select_json_elements(keys, elem)
+                    if v:
+                        ret[k] = v
         return ret
 
     def _build_output_content(


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused the `x-linode-cli-rows` spec extension to not work as expected, which caused the `linodes backups-list {instanceId}` to be unusable.

## ✔️ How to Test

Fixed command:
```bash
linode-cli linodes backups-list 12345
```

Integration tests:
```bash
make RUN_LONG_TESTS=TRUE testint
```
