### PR TITLE
fix: Resolve issue with creating arguments for objects without properties

### DIFF
--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -99,7 +99,7 @@ def _parse_request_model(schema, prefix=None, list_of_objects=False):
 
     if schema.properties is not None:
         for k, v in schema.properties.items():
-            if v.type == "object":
+            if v.type == "object" and not v.readOnly and v.properties:
                 # nested objects receive a prefix and are otherwise parsed normally
                 pref = prefix + "." + k if prefix else k
                 args += _parse_request_model(v, prefix=pref)

--- a/tests/integration/stackscripts/test_stackscripts.py
+++ b/tests/integration/stackscripts/test_stackscripts.py
@@ -45,7 +45,7 @@ def create_stackscript():
         + [
             "create",
             "--script",
-            "#!/bin/bash \n $EXAMPLE_SCRIPT",
+            '#!/bin/bash\n# <UDF name="foo" Label="foo" example="bar" />\n $EXAMPLE_SCRIPT',
             "--image",
             "linode/debian9",
             "--label",
@@ -236,6 +236,8 @@ def test_deploy_linode_from_stackscript(create_stackscript):
             "create",
             "--stackscript_id",
             private_stackscript,
+            "--stackscript_data",
+            '{"foo": "bar"}',
             "--type",
             linode_plan,
             "--image",


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused `object` request fields without properties in the OpenAPI spec to not be handled as JSON arguments. This mirrors the functionality present in the old spec parser implementation 

## ✔️ How to Test

Integration Tests:
```
make INTEGRATION_TEST_PATH="stackscripts" testint
```

Manually:
```
linode-cli linodes create --stackscript_data '{"foo": "bar"}' ...
```