### PR TITLE
proposal: Display full path in the header for nested columns

### DIFF
--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -240,7 +240,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
                 for attr in attrs:
                     # Display this column if the format string
                     # matches the column_name or path of this column
-                    if attr.column_name == col or attr.name == col:
+                    if col in (attr.column_name, attr.name):
                         attrs.remove(attr)
                         columns.append(attr)
 

--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -103,7 +103,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             )
 
         if isinstance(columns[0], OpenAPIResponseAttr):
-            header = [c.column_name for c in columns]
+            header = [c.name for c in columns]
         else:
             header = columns
 
@@ -238,7 +238,9 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             columns = []
             for col in self.columns.split(","):
                 for attr in attrs:
-                    if attr.column_name == col:
+                    # Display this column if the format string
+                    # matches the column_name or path of this column
+                    if attr.column_name == col or attr.name == col:
                         attrs.remove(attr)
                         columns.append(attr)
 
@@ -314,6 +316,10 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         """
         Prints data in JSON format
         """
+        # Special handling for JSON headers.
+        # We're only interested in the last part of the column name.
+        header = [v.split(".")[-1] for v in header]
+
         content = []
         if len(data) and isinstance(data[0], dict):  # we got delimited json in
             # parse down to the value we display

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -504,7 +504,10 @@ class TestOutputHandler:
 
         output = output.getvalue().splitlines()
 
-        lines = ["foo\tbar\tfoobar", "cool\tcool2\twow"]
+        lines = [
+            "foo.single_nested.foo\tfoo.single_nested.bar\tfoobar",
+            "cool\tcool2\twow",
+        ]
 
         for i, line in enumerate(lines):
             assert line in output[i]
@@ -547,6 +550,40 @@ class TestOutputHandler:
             "├───────┼───────┤",
             "│ cool  │ cool2 │",
             "└───────┴───────┘",
+        ]
+
+        for i, line in enumerate(lines):
+            assert line in output[i]
+
+    def test_format_nested_field(
+        self, mock_cli, get_operation_for_subtable_test
+    ):
+        output = io.StringIO()
+
+        mock_cli.output_handler.mode = OutputMode.delimited
+        mock_cli.output_handler.single_table = True
+        mock_cli.output_handler.columns = "foo.single_nested.bar"
+
+        mock_data = {
+            "table": [{"foo": "cool", "bar": 12345}],
+            "foo": {
+                "single_nested": {"foo": "cool", "bar": "cool2"},
+                "table": [{"foobar": ["127.0.0.1", "127.0.0.2"]}],
+            },
+            "foobar": "wow",
+        }
+
+        mock_cli.output_handler.print_response(
+            get_operation_for_subtable_test.response_model,
+            data=[mock_data],
+            to=output,
+        )
+
+        output = output.getvalue().splitlines()
+
+        lines = [
+            "foo.single_nested.bar",
+            "cool2",
         ]
 
         for i, line in enumerate(lines):


### PR DESCRIPTION
## 📝 Description

This PR updates the table output logic to display the full path of nested fields in their column headers. Additionally, this change allows users to format on nested fields using their full paths (e.g. `linode-cli events ls --format entity.id`).

## ✔️ How to Test

```
make testunit
```
