### PR TITLE
fix: e2e-suite.yml typo in pytest and set file name properly

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -40,7 +40,7 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
           status=0
-          if ! pytest -m tests/integration --disable-warnings --junitxml="${report_filename}"; then
+          if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "Tests failed, but attempting to upload results anyway"
           fi
         env:
@@ -48,7 +48,8 @@ jobs:
 
       - name: Upload test results
         run: |
-          linode-cli obj --cluster us-southeast-1 put "${report_filename}" dx-test-results
+          filename=$(ls | grep -E '^[0-9]{12}_cli_test_report\.xml$')
+          linode-cli obj --cluster us-southeast-1 put "${filename}" dx-test-results
         env:
           LINODE_CLI_TOKEN: ${{ secrets.SHARED_DX_TOKEN }}
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}


### PR DESCRIPTION
## 📝 Description

removed -m argument when running integration test in e2e-suite.yml, this was causing all tests to be skipped.

Added extra step to set the file name correctly after test execution

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**