### PR TITLE
fix: Display empty lists when using `--json`

### DIFF
--- a/linodecli/output.py
+++ b/linodecli/output.py
@@ -372,8 +372,7 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
 
                     results.append(selected)
 
-                if len(results) > 0:
-                    ret[k] = results
+                ret[k] = results
 
         return ret
 


### PR DESCRIPTION
## 📝 Description

This change updates the JSON `--format` logic to support outputting empty lists that meet the format criteria.

## ✔️ How to Test

```
make testunit
```
