### PR TITLE
fix: remove dbaas configuration

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -206,9 +206,7 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
 
     # Merge defaults into body if applicable
     if ctx.defaults:
-        parsed_args = ctx.config.update(
-            parsed_args, operation.allowed_defaults, operation.action
-        )
+        parsed_args = ctx.config.update(parsed_args, operation.allowed_defaults)
 
     to_json = {}
 

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -247,17 +247,6 @@ class CLIConfig:
             value = None
             if self.config.has_option(username, key):
                 value = self.config.get(username, key)
-            # different types of database creation use different endpoints,
-            # so we need to set the default engine value based on the type
-            elif key == "engine":
-                if action == "mysql-create" and self.config.has_option(
-                    username, "mysql_engine"
-                ):
-                    value = self.config.get(username, "mysql_engine")
-                elif action == "postgresql-create" and self.config.has_option(
-                    username, "postgresql_engine"
-                ):
-                    value = self.config.get(username, "postgresql_engine")
             else:
                 value = ns_dict[key]
 
@@ -354,15 +343,6 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
         images = [
             i["id"] for i in _do_get_request(self.base_url, "/images")["data"]
         ]
-        engines_list = _do_get_request(self.base_url, "/databases/engines")[
-            "data"
-        ]
-        mysql_engines = [
-            e["id"] for e in engines_list if e["engine"] == "mysql"
-        ]
-        postgresql_engines = [
-            e["id"] for e in engines_list if e["engine"] == "postgresql"
-        ]
 
         is_full_access = _check_full_access(self.base_url, token)
 
@@ -411,26 +391,6 @@ If you prefer to supply a Personal Access Token, use `linode-cli configure --tok
             "Please select a valid Image, or press Enter to skip",
             current_value=_config_get_with_default(
                 self.config, username, "image"
-            ),
-        )
-
-        config["mysql_engine"] = _default_thing_input(
-            "Default Engine to create a Managed MySQL Database.",
-            mysql_engines,
-            "Default Engine (Optional): ",
-            "Please select a valid MySQL Database Engine, or press Enter to skip",
-            current_value=_config_get_with_default(
-                self.config, username, "mysql_engine"
-            ),
-        )
-
-        config["postgresql_engine"] = _default_thing_input(
-            "Default Engine to create a Managed PostgreSQL Database.",
-            postgresql_engines,
-            "Default Engine (Optional): ",
-            "Please select a valid PostgreSQL Database Engine, or press Enter to skip",
-            current_value=_config_get_with_default(
-                self.config, username, "postgresql_engine"
             ),
         )
 

--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -216,7 +216,7 @@ class CLIConfig:
     # might be better to move this to argparsing during refactor and just have
     # configuration return defaults or keys or something
     def update(
-        self, namespace, allowed_defaults, action=None
+        self, namespace, allowed_defaults
     ):  # pylint: disable=too-many-branches
         """
         This updates a Namespace (as returned by ArgumentParser) with config values

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,7 +17,6 @@ region = us-southeast
 image = linode/ubuntu21.10
 token = notafaketoken
 type = g6-nanode-1
-mysql_engine = mysql/8.0.26
 """
 
 LOADED_FILES = {}

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -56,8 +56,7 @@ class TestAPIRequest:
         assert "> " in output
 
     def test_build_request_body(self, mock_cli, create_operation):
-        create_operation.allowed_defaults = ["region", "engine"]
-        create_operation.action = "mysql-create"
+        create_operation.allowed_defaults = ["region", "image"]
 
         result = api_request._build_request_body(
             mock_cli,
@@ -65,7 +64,7 @@ class TestAPIRequest:
             SimpleNamespace(
                 generic_arg="foo",
                 region=None,
-                engine=None,
+                image=None,
             ),
         )
         assert (
@@ -73,22 +72,21 @@ class TestAPIRequest:
                 {
                     "generic_arg": "foo",
                     "region": "us-southeast",
-                    "engine": "mysql/8.0.26",
+                    "image": "linode/ubuntu21.10",
                 }
             )
             == result
         )
 
     def test_build_request_body_null_field(self, mock_cli, create_operation):
-        create_operation.allowed_defaults = ["region", "engine"]
-        create_operation.action = "mysql-create"
+        create_operation.allowed_defaults = ["region", "image"]
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
             SimpleNamespace(
                 generic_arg="foo",
                 region=None,
-                engine=None,
+                image=None,
                 nullable_int=ExplicitNullValue(),
             ),
         )
@@ -97,7 +95,7 @@ class TestAPIRequest:
                 {
                     "generic_arg": "foo",
                     "region": "us-southeast",
-                    "engine": "mysql/8.0.26",
+                    "image": "linode/ubuntu21.10",
                     "nullable_int": None,
                 }
             )
@@ -107,15 +105,14 @@ class TestAPIRequest:
     def test_build_request_body_non_null_field(
         self, mock_cli, create_operation
     ):
-        create_operation.allowed_defaults = ["region", "engine"]
-        create_operation.action = "mysql-create"
+        create_operation.allowed_defaults = ["region", "image"]
         result = api_request._build_request_body(
             mock_cli,
             create_operation,
             SimpleNamespace(
                 generic_arg="foo",
                 region=None,
-                engine=None,
+                image=None,
                 nullable_int=12345,
             ),
         )
@@ -124,7 +121,7 @@ class TestAPIRequest:
                 {
                     "generic_arg": "foo",
                     "region": "us-southeast",
-                    "engine": "mysql/8.0.26",
+                    "image": "linode/ubuntu21.10",
                     "nullable_int": 12345,
                 }
             )

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -234,13 +234,6 @@ mysql_engine = mysql/8.0.26"""
 
         assert "--no-defaults" not in f.getvalue()
 
-        # test that update default engine value correctly when creating database
-        create_db_action = "mysql-create"
-        f = io.StringIO()
-        with contextlib.redirect_stdout(f):
-            result = vars(conf.update(ns, allowed_defaults, create_db_action))
-        assert result.get("engine") == "mysql/new-test-engine"
-
     def test_write_config(self):
         """
         Test CLIConfig.write_config()
@@ -303,18 +296,6 @@ mysql_engine = mysql/8.0.26"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
-                f"{self.base_url}/databases/engines",
-                json={
-                    "data": [
-                        {"id": "mysql/test-engine", "engine": "mysql"},
-                        {
-                            "id": "postgresql/test-engine",
-                            "engine": "postgresql",
-                        },
-                    ]
-                },
-            )
-            m.get(
                 f"{self.base_url}/account/users",
                 json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
@@ -325,9 +306,6 @@ mysql_engine = mysql/8.0.26"""
         assert conf.get_value("image") == "test-image"
         assert conf.get_value("region") == "test-region"
         assert conf.get_value("authorized_users") == "cli-dev"
-        # make sure that we set the default engine value according to type of database
-        assert conf.get_value("mysql_engine") == "mysql/test-engine"
-        assert conf.get_value("postgresql_engine") == "postgresql/test-engine"
         assert conf.get_value("api_host") == "foobar.linode.com"
         assert conf.get_value("api_version") == "v4beta"
         assert conf.get_value("api_scheme") == "https"
@@ -369,18 +347,6 @@ mysql_engine = mysql/8.0.26"""
                 f"{self.base_url}/images", json={"data": [{"id": "test-image"}]}
             )
             m.get(
-                f"{self.base_url}/databases/engines",
-                json={
-                    "data": [
-                        {"id": "mysql/test-engine", "engine": "mysql"},
-                        {
-                            "id": "postgresql/test-engine",
-                            "engine": "postgresql",
-                        },
-                    ]
-                },
-            )
-            m.get(
                 f"{self.base_url}/account/users",
                 json={"data": [{"username": "cli-dev", "ssh_keys": "testkey"}]},
             )
@@ -391,9 +357,6 @@ mysql_engine = mysql/8.0.26"""
         assert conf.get_value("region") == "test-region"
         assert conf.get_value("authorized_users") == "cli-dev"
         assert conf.config.get("DEFAULT", "default-user") == "DEFAULT"
-        # make sure that we set the default engine value according to type of database
-        assert conf.get_value("mysql_engine") == "mysql/test-engine"
-        assert conf.get_value("postgresql_engine") == "postgresql/test-engine"
 
     def test_default_thing_input_no_current(self, monkeypatch):
         stdout_buf = io.StringIO()


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Removing dbaas configuraiton steps as dbaas is now opt-in only.

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

`pytest -v tests/unit/test_configuration.py`
