### PR TITLE
Fix: mark execution as failed when there are failures

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -9,7 +9,8 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
-    continue-on-error: true
+    env:
+      EXIT_STATUS: 0
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3
@@ -40,8 +41,11 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          status=0
-          pytest tests/integration --disable-warnings --junitxml="${report_filename}"
+          if ! pytest tests/integration -k test_help_page_for_non_aliased_actions --disable-warnings --junitxml="${report_filename}"; then
+            echo "EXIT_STATUS=$?" >> $GITHUB_ENV
+          else
+            echo "Tests passed"
+          fi
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
@@ -67,3 +71,9 @@ jobs:
           LINODE_CLI_TOKEN: ${{ secrets.SHARED_DX_TOKEN }}
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+      - name: Handle Exit status
+        run: |
+          if [[ "$EXIT_STATUS" != 0 ]]; then
+            exit $EXIT_STATUS  
+          fi

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -9,6 +9,7 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3
@@ -40,9 +41,7 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
           status=0
-          if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
-            echo "Tests failed, but attempting to upload results anyway"
-          fi
+          pytest tests/integration --disable-warnings --junitxml="${report_filename}"
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -41,10 +41,8 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          if ! pytest tests/integration -k test_help_page_for_non_aliased_actions --disable-warnings --junitxml="${report_filename}"; then
+          if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
-          else
-            echo "Tests passed"
           fi
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
@@ -72,8 +70,11 @@ jobs:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
 
-      - name: Handle Exit status
+      - name: Test Execution Status Handler
         run: |
           if [[ "$EXIT_STATUS" != 0 ]]; then
-            exit $EXIT_STATUS  
+            echo "Test execution contains failure(s)"
+            exit $EXIT_STATUS 
+          else
+            echo "Tests passed!"
           fi

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -42,7 +42,7 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
           if ! pytest tests/integration -k test_help_page_for_non_aliased_actions --disable-warnings --junitxml="${report_filename}"; then
-            echo "EXIT_STATUS=$?" >> $GITHUB_ENV
+            echo "EXIT_STATUS=1" >> $GITHUB_ENV
           else
             echo "Tests passed"
           fi

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -13,7 +13,7 @@ def test_help_page_for_non_aliased_actions():
         "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
         in output
     )
-    assert "wrong assertion" in output
+    assert "You may filter results with:" in output
     assert "--tags" in output
 
 

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -13,7 +13,7 @@ def test_help_page_for_non_aliased_actions():
         "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
         in output
     )
-    assert "You may filter results with:" in output
+    assert "wrong assertion" in output
     assert "--tags" in output
 
 


### PR DESCRIPTION
## 📝 Description

Failing integration tests currently does not mark the run as 'x' (failed). Hence adding logic to mark it as failed when there are failures
 
## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**