### PR TITLE
new: Display region_prices in linode types output

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -9,6 +9,8 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
+    env:
+      EXIT_STATUS: 0
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3
@@ -39,9 +41,8 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          status=0
           if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
-            echo "Tests failed, but attempting to upload results anyway"
+            echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
@@ -68,3 +69,12 @@ jobs:
           LINODE_CLI_TOKEN: ${{ secrets.SHARED_DX_TOKEN }}
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+      - name: Test Execution Status Handler
+        run: |
+          if [[ "$EXIT_STATUS" != 0 ]]; then
+            echo "Test execution contains failure(s)"
+            exit $EXIT_STATUS 
+          else
+            echo "Tests passed!"
+          fi

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -55,7 +55,10 @@ def handle_types_region_prices_list(
         return True
 
     output = Table()
-    headers = sorted(json_data["data"][0].keys() - ["addons"], key=len)
+
+    # To ensure the order of the headers and make sure we have region_prices as the last column
+    headers = sorted(json_data["data"][0].keys() - ["addons", "price", "region_prices"], key=len)
+    headers += ["price.hourly", "price.monthly", "region_prices"]
     region_price_sub_headers = ["id", "hourly", "monthly"]
 
     for header in headers:
@@ -77,17 +80,9 @@ def handle_types_region_prices_list(
                     sub_table.add_row(*region_price_row)
                 row += [sub_table]
 
-            elif h == "price":
-                sub_table = Table()
-                for header in ["hourly", "monthly"]:
-                    sub_table.add_column(header, justify="center")
-                sub_table.add_row(
-                    *[
-                        Align(str(linode[h]["hourly"]), align="left"),
-                        Align(str(linode[h]["monthly"]), align="left"),
-                    ]
-                )
-                row += [sub_table]
+            elif h == "price.hourly" or h == "price.monthly":
+                price_headers = h.split(".")
+                row += [Align(str(linode[price_headers[0]][price_headers[1]]), align="left")]
 
             else:
                 row += [Align(str(linode[h]), align="left")]

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -3,7 +3,6 @@ Contains wrappers for overriding certain pieces of command-handling logic.
 This allows us to easily alter per-command outputs, etc. without making
 large changes to the OpenAPI spec.
 """
-import sys
 
 from rich.align import Align
 from rich.console import Console
@@ -43,8 +42,11 @@ def handle_domains_zone_file(operation, output_handler, json_data) -> bool:
     print("\n".join(json_data["zone_file"]))
     return False
 
+
 @output_override("linodes", "types", OutputMode.table)
-def handle_types_region_prices_list(operation, output_handler, json_data) -> bool:
+def handle_types_region_prices_list(
+    operation, output_handler, json_data
+) -> bool:
     # pylint: disable=unused-argument
     """
     Override the output of 'linode-cli linodes types' to display regional pricing.
@@ -69,7 +71,9 @@ def handle_types_region_prices_list(operation, output_handler, json_data) -> boo
                 for region_price in linode[h]:
                     region_price_row = []
                     for header in region_price_sub_headers:
-                        region_price_row += Align(str(region_price[header]), align="left"),
+                        region_price_row += (
+                            Align(str(region_price[header]), align="left"),
+                        )
                     sub_table.add_row(*region_price_row)
                 row += [sub_table]
 
@@ -77,10 +81,12 @@ def handle_types_region_prices_list(operation, output_handler, json_data) -> boo
                 sub_table = Table()
                 for header in ["hourly", "monthly"]:
                     sub_table.add_column(header, justify="center")
-                sub_table.add_row(*[
-                    Align(str(linode[h]["hourly"]), align="left"),
-                    Align(str(linode[h]["monthly"]), align="left"),
-                ])
+                sub_table.add_row(
+                    *[
+                        Align(str(linode[h]["hourly"]), align="left"),
+                        Align(str(linode[h]["monthly"]), align="left"),
+                    ]
+                )
                 row += [sub_table]
 
             else:
@@ -91,6 +97,9 @@ def handle_types_region_prices_list(operation, output_handler, json_data) -> boo
     console = Console()
     console.print(output)
 
-    print("See our [Pricing Page](https://www.linode.com/pricing/) for Region-specific pricing, which applies after migration is complete.")
+    print(
+        "See our [Pricing Page](https://www.linode.com/pricing/) for Region-specific pricing, "
+        + "which applies after migration is complete."
+    )
 
     return False

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -72,15 +72,14 @@ def handle_types_region_prices_list(
                 for header in region_price_sub_headers:
                     sub_table.add_column(header, justify="center")
                 for region_price in linode[h]:
-                    region_price_row = []
-                    for header in region_price_sub_headers:
-                        region_price_row += (
-                            Align(str(region_price[header]), align="left"),
-                        )
+                    region_price_row = (
+                        Align(str(region_price[header]), align="left")
+                        for header in region_price_sub_headers
+                    )
                     sub_table.add_row(*region_price_row)
                 row += [sub_table]
 
-            elif h == "price.hourly" or h == "price.monthly":
+            elif h in ("price.hourly", "price.monthly"):
                 price_headers = h.split(".")
                 row += [Align(str(linode[price_headers[0]][price_headers[1]]), align="left")]
 

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -80,19 +80,19 @@ def handle_types_region_prices_list(
                         for header in region_price_sub_headers
                     )
                     sub_table.add_row(*region_price_row)
-                row += [sub_table]
+                row.append(sub_table)
 
             elif h in ("price.hourly", "price.monthly"):
                 price_headers = h.split(".")
-                row += [
+                row.append(
                     Align(
                         str(linode[price_headers[0]][price_headers[1]]),
                         align="left",
                     )
-                ]
+                )
 
             else:
-                row += [Align(str(linode[h]), align="left")]
+                row.append(Align(str(linode[h]), align="left"))
 
         output.add_row(*row)
 

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -57,7 +57,10 @@ def handle_types_region_prices_list(
     output = Table()
 
     # To ensure the order of the headers and make sure we have region_prices as the last column
-    headers = sorted(json_data["data"][0].keys() - ["addons", "price", "region_prices"], key=len)
+    headers = sorted(
+        json_data["data"][0].keys() - ["addons", "price", "region_prices"],
+        key=len,
+    )
     headers += ["price.hourly", "price.monthly", "region_prices"]
     region_price_sub_headers = ["id", "hourly", "monthly"]
 
@@ -81,7 +84,12 @@ def handle_types_region_prices_list(
 
             elif h in ("price.hourly", "price.monthly"):
                 price_headers = h.split(".")
-                row += [Align(str(linode[price_headers[0]][price_headers[1]]), align="left")]
+                row += [
+                    Align(
+                        str(linode[price_headers[0]][price_headers[1]]),
+                        align="left",
+                    )
+                ]
 
             else:
                 row += [Align(str(linode[h]), align="left")]

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -3,6 +3,11 @@ Contains wrappers for overriding certain pieces of command-handling logic.
 This allows us to easily alter per-command outputs, etc. without making
 large changes to the OpenAPI spec.
 """
+import sys
+
+from rich.align import Align
+from rich.console import Console
+from rich.table import Table
 
 from linodecli.output import OutputMode
 
@@ -36,4 +41,56 @@ def handle_domains_zone_file(operation, output_handler, json_data) -> bool:
     Fix for output of 'linode-cli domains zone-file --text {id}'.
     """
     print("\n".join(json_data["zone_file"]))
+    return False
+
+@output_override("linodes", "types", OutputMode.table)
+def handle_types_region_prices_list(operation, output_handler, json_data) -> bool:
+    # pylint: disable=unused-argument
+    """
+    Override the output of 'linode-cli linodes types' to display regional pricing.
+    """
+    if len(json_data["data"]) < 1:
+        return True
+
+    output = Table()
+    headers = sorted(json_data["data"][0].keys() - ["addons"], key=len)
+    region_price_sub_headers = ["id", "hourly", "monthly"]
+
+    for header in headers:
+        output.add_column(header, justify="center")
+
+    for linode in json_data["data"]:
+        row = []
+        for h in headers:
+            if h == "region_prices":
+                sub_table = Table()
+                for header in region_price_sub_headers:
+                    sub_table.add_column(header, justify="center")
+                for region_price in linode[h]:
+                    region_price_row = []
+                    for header in region_price_sub_headers:
+                        region_price_row += Align(str(region_price[header]), align="left"),
+                    sub_table.add_row(*region_price_row)
+                row += [sub_table]
+
+            elif h == "price":
+                sub_table = Table()
+                for header in ["hourly", "monthly"]:
+                    sub_table.add_column(header, justify="center")
+                sub_table.add_row(*[
+                    Align(str(linode[h]["hourly"]), align="left"),
+                    Align(str(linode[h]["monthly"]), align="left"),
+                ])
+                row += [sub_table]
+
+            else:
+                row += [Align(str(linode[h]), align="left")]
+
+        output.add_row(*row)
+
+    console = Console()
+    console.print(output)
+
+    print("See our [Pricing Page](https://www.linode.com/pricing/) for Region-specific pricing, which applies after migration is complete.")
+
     return False

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 from linodecli import OutputMode
 from linodecli.overrides import OUTPUT_OVERRIDES
 
+import subprocess
+from typing import List
+
 
 class TestOverrides:
     """
@@ -56,3 +59,70 @@ class TestOverrides:
             )
 
         assert stdout_buf.getvalue() != "line 1\nline 2\n"
+
+    def test_types_region_prices_list(
+        self, mock_cli, list_operation_for_overrides_test
+    ):
+        response_json = {
+          "data": [
+            {
+              "addons": {
+                "backups": {
+                  "price": {
+                    "hourly": 0.008,
+                    "monthly": 5
+                  },
+                  "region_prices": [
+                    {
+                      "hourly": 0.0096,
+                      "id": "us-east",
+                      "monthly": 6
+                    }
+                  ]
+                }
+              },
+              "class": "standard",
+              "disk": 81920,
+              "gpus": 0,
+              "id": "g6-standard-2",
+              "label": "Linode 4GB",
+              "memory": 4096,
+              "network_out": 1000,
+              "price": {
+                "hourly": 0.03,
+                "monthly": 20
+              },
+              "region_prices": [
+                {
+                  "hourly": 0.036,
+                  "id": "us-east",
+                  "monthly": 24
+                }
+              ],
+              "successor": None,
+              "transfer": 4000,
+              "vcpus": 2
+            }
+          ],
+          "page": 1,
+          "pages": 1,
+          "results": 1
+        }
+
+        override_signature = ("linodes", "types", OutputMode.table)
+
+        list_operation_for_overrides_test.command = "linodes"
+        list_operation_for_overrides_test.action = "types"
+        mock_cli.output_handler.mode = OutputMode.table
+
+        stdout_buf = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout_buf):
+            list_operation_for_overrides_test.process_response_json(
+                response_json, mock_cli.output_handler
+            )
+
+        rows = stdout_buf.getvalue().split("\n")
+
+        # assert that the overridden table has the new columns
+        assert len(rows[1].split("┃")) == 14

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -111,4 +111,4 @@ class TestOverrides:
 
         rows = stdout_buf.getvalue().split("\n")
         # assert that the overridden table has the new columns
-        assert len(rows[1].split("┃")) == 15
+        assert len(rows[1].split(rows[1][0])) == 15

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -110,6 +110,5 @@ class TestOverrides:
             )
 
         rows = stdout_buf.getvalue().split("\n")
-
         # assert that the overridden table has the new columns
-        assert len(rows[1].split("┃")) == 14
+        assert len(rows[1].split("┃")) == 15

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -5,9 +5,6 @@ from unittest.mock import patch
 from linodecli import OutputMode
 from linodecli.overrides import OUTPUT_OVERRIDES
 
-import subprocess
-from typing import List
-
 
 class TestOverrides:
     """
@@ -64,49 +61,39 @@ class TestOverrides:
         self, mock_cli, list_operation_for_overrides_test
     ):
         response_json = {
-          "data": [
-            {
-              "addons": {
-                "backups": {
-                  "price": {
-                    "hourly": 0.008,
-                    "monthly": 5
-                  },
-                  "region_prices": [
-                    {
-                      "hourly": 0.0096,
-                      "id": "us-east",
-                      "monthly": 6
-                    }
-                  ]
-                }
-              },
-              "class": "standard",
-              "disk": 81920,
-              "gpus": 0,
-              "id": "g6-standard-2",
-              "label": "Linode 4GB",
-              "memory": 4096,
-              "network_out": 1000,
-              "price": {
-                "hourly": 0.03,
-                "monthly": 20
-              },
-              "region_prices": [
+            "data": [
                 {
-                  "hourly": 0.036,
-                  "id": "us-east",
-                  "monthly": 24
+                    "addons": {
+                        "backups": {
+                            "price": {"hourly": 0.008, "monthly": 5},
+                            "region_prices": [
+                                {
+                                    "hourly": 0.0096,
+                                    "id": "us-east",
+                                    "monthly": 6,
+                                }
+                            ],
+                        }
+                    },
+                    "class": "standard",
+                    "disk": 81920,
+                    "gpus": 0,
+                    "id": "g6-standard-2",
+                    "label": "Linode 4GB",
+                    "memory": 4096,
+                    "network_out": 1000,
+                    "price": {"hourly": 0.03, "monthly": 20},
+                    "region_prices": [
+                        {"hourly": 0.036, "id": "us-east", "monthly": 24}
+                    ],
+                    "successor": None,
+                    "transfer": 4000,
+                    "vcpus": 2,
                 }
-              ],
-              "successor": None,
-              "transfer": 4000,
-              "vcpus": 2
-            }
-          ],
-          "page": 1,
-          "pages": 1,
-          "results": 1
+            ],
+            "page": 1,
+            "pages": 1,
+            "results": 1,
         }
 
         override_signature = ("linodes", "types", OutputMode.table)


### PR DESCRIPTION
## 📝 Description

Add `region_prices` as an extra column in the linode types table to show user DC-specific pricing of each linode type.

## ✔️ How to Test

Unit test: `make testunit`

Manual test: run command `linode-cli linodes types`

## 📷 Preview

Old table:
![image (1)](https://github.com/linode/linode-cli/assets/127243817/2a39beb5-fa12-4e9a-922d-a65408b44917)

New table:
![image](https://github.com/linode/linode-cli/assets/127243817/76a22ffb-27f3-4fb8-8290-20221806cff6)

