### PR TITLE
fix: `region-table` Firewall column

### DIFF
--- a/linodecli/plugins/region-table.py
+++ b/linodecli/plugins/region-table.py
@@ -26,8 +26,7 @@ def call(_, ctx):
         ("Vlans", "Vlan"),
         ("Premium Plans", "Premium"),
         ("Metadata", "Meta"),
-        ("Block Storage", "Blocks"),
-        ("Block Storage Migrations", "& Migration"),
+        ("Block Storage", "Block"),
     ]
 
     if status != 200:

--- a/linodecli/plugins/region-table.py
+++ b/linodecli/plugins/region-table.py
@@ -20,7 +20,7 @@ def call(_, ctx):
         ("GPU Linodes", "GPU"),
         ("NodeBalancers", "NB"),
         ("Kubernetes", "K8s"),
-        ("Firewalls", "FW"),
+        ("Cloud Firewall", "FW"),
         ("Managed Databases", "DB"),
         ("Object Storage", "OBJ"),
         ("Vlans", "Vlan"),


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Change `Firewalls` to `Cloud Firewall` which is the correct term used in the API.
Remove `Block Storage Migration` from the table.
Rename `Blocks` to `Block`

Resolves #532 
