### PR TITLE
Drop Python 3.7 Support and Remove Usage of `pkg_resources`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -307,8 +307,8 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception
 
 
 [FORMAT]

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -6,9 +6,9 @@ Argument parser for the linode CLI
 import argparse
 import os
 import sys
+from importlib.metadata import version
 from sys import argv
 
-from importlib.metadata import version
 from rich import print as rprint
 from rich.table import Table
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -8,7 +8,7 @@ import os
 import sys
 from sys import argv
 
-import pkg_resources
+from importlib.metadata import version
 from rich import print as rprint
 from rich.table import Table
 
@@ -30,7 +30,7 @@ from .output import OutputMode
 
 # this might not be installed at the time of building
 try:
-    VERSION = pkg_resources.require("linode-cli")[0].version
+    VERSION = version("linode-cli")
 except:
     VERSION = "building"
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,6 @@ setup(
         ]
     },
     data_files=get_baked_files(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
 )


### PR DESCRIPTION
## 📝 Description

`pkg_resources` was deprecated and removed in Python 3.12.

## ✔️ How to Test

You can insert a `print(VERSION)` to right after where the `VERSION` is defined. Then run any command with the Linode CLI, and you will be able to see the output.