### PR TITLE
Support VPC Interfaces Changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ endif
 install: check-prerequisites requirements build
 	pip3 install --force dist/*.whl
 
-.PHONY: build
-build: clean
+.PHONY: bake
+bake: clean
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-3 linodecli/
+
+.PHONY: build
+build: clean bake
 	python3 -m build --wheel --sdist
 
 .PHONY: requirements

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -10,7 +10,9 @@ import sys
 from getpass import getpass
 from os import environ, path
 from typing import List, Tuple
+
 from openapi3.paths import Operation
+
 from linodecli.baked.request import OpenAPIFilteringRequest, OpenAPIRequest
 from linodecli.baked.response import OpenAPIResponse
 from linodecli.overrides import OUTPUT_OVERRIDES

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -10,7 +10,7 @@ import sys
 from getpass import getpass
 from os import environ, path
 from typing import List, Tuple
-
+from openapi3.paths import Operation
 from linodecli.baked.request import OpenAPIFilteringRequest, OpenAPIRequest
 from linodecli.baked.response import OpenAPIResponse
 from linodecli.overrides import OUTPUT_OVERRIDES
@@ -212,7 +212,7 @@ class OpenAPIOperation:
     This is the class that should be pickled when building the CLI.
     """
 
-    def __init__(self, command, operation, method, params):
+    def __init__(self, command, operation: Operation, method, params):
         """
         Wraps an openapi3.Operation object and handles pulling out values relevant
         to the Linode CLI.

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -1,8 +1,10 @@
 """
 Converting the processed OpenAPI Responses into something the CLI can work with
 """
-from .colors import colorize_string
 from openapi3.paths import MediaType
+
+from .colors import colorize_string
+
 
 def _is_paginated(response):
     """

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -2,7 +2,7 @@
 Converting the processed OpenAPI Responses into something the CLI can work with
 """
 from .colors import colorize_string
-
+from openapi3.paths import MediaType
 
 def _is_paginated(response):
     """
@@ -159,26 +159,35 @@ def _parse_response_model(schema, prefix=None, nested_list_depth=0):
     :returns: The list of parsed OpenAPIResponseAttr objects representing this schema
     :rtype: List[OpenAPIResponseAttr]
     """
+
+    if schema.type == "array":
+        return _parse_response_model(
+            schema.items,
+            prefix=prefix,
+            nested_list_depth=nested_list_depth,
+        )
+
     attrs = []
+    if schema.properties is None:
+        return attrs
 
-    if schema.properties is not None:
-        for k, v in schema.properties.items():
-            pref = prefix + "." + k if prefix else k
+    for k, v in schema.properties.items():
+        pref = prefix + "." + k if prefix else k
 
-            if v.type == "object":
-                attrs += _parse_response_model(v, prefix=pref)
-            elif v.type == "array" and v.items.type == "object":
-                attrs += _parse_response_model(
-                    v.items,
-                    prefix=pref,
-                    nested_list_depth=nested_list_depth + 1,
+        if v.type == "object":
+            attrs += _parse_response_model(v, prefix=pref)
+        elif v.type == "array" and v.items.type == "object":
+            attrs += _parse_response_model(
+                v.items,
+                prefix=pref,
+                nested_list_depth=nested_list_depth + 1,
+            )
+        else:
+            attrs.append(
+                OpenAPIResponseAttr(
+                    k, v, prefix=prefix, nested_list_depth=nested_list_depth
                 )
-            else:
-                attrs.append(
-                    OpenAPIResponseAttr(
-                        k, v, prefix=prefix, nested_list_depth=nested_list_depth
-                    )
-                )
+            )
 
     return attrs
 
@@ -189,7 +198,7 @@ class OpenAPIResponse:
     responses section of an OpenAPI Operation
     """
 
-    def __init__(self, response):
+    def __init__(self, response: MediaType):
         """
         :param response: The response's MediaType object in the OpenAPI spec,
                           corresponding to the application/json response type
@@ -228,7 +237,9 @@ class OpenAPIResponse:
         # Needs to go last to handle custom schemas
         if "pages" in json:
             return json["data"]
-        return [json]
+        if not isinstance(json, list):
+            json = [json]
+        return json
 
     def _fix_json_rows(self, json):
         """


### PR DESCRIPTION
## 📝 Description

The existing CLI code doesn't work with network interface listing API from the VPC OpenAPI spec draft.

## ✔️ How to Test

1. Install CLI with VPC OpenAPI spec draft, 

```bash
SPEC=https://raw.githubusercontent.com/bbiggerr/linode-api-docs/add/vpc/openapi.yaml make install
```

2. [Config the CLI](https://github.com/linode/linode-cli/wiki/Configuration#configurable-api-url) to target alpha API server. (Ping me if you would like to know how to do it in details)
3. Create a Linode on alpha and try to list the network interfaces in its config with the CLI:
```bash
linode linodes config-interfaces-list [LINODEID] [CONFIGID]
```

Expected result looks like:
```
┌───────┬───────┬─────────┬──────────────┐
│ id    │ label │ purpose │ ipam_address │
├───────┼───────┼─────────┼──────────────┤
│ 12345 │       │ public  │              │
│ 67890 │       │ vpc     │              │
└───────┴───────┴─────────┴──────────────┘
```