### PR TITLE
Fix run e2e workflow

### DIFF
--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       test_path:
-        description: "The path from 'test/integration' to target to be tested, e.g. 'cli'"
+        description: "The path from 'test/integration' to the target to be tested, e.g. 'cli'"
         required: false
       sha:
         description: 'The hash value of the commit.'

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -56,6 +56,8 @@ jobs:
           owner: ${{ github.event.repository.owner.login }}
           repo: ${{ github.event.repository.name }}
           pr_num: ${{ fromJSON(inputs.pull_request_number) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update system packages
         run: sudo apt-get update -y

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Update system packages
         run: sudo apt-get update -y
 
-      - name: Install system deps
-        run: sudo apt-get install -y build-essential
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       test_path:
-        description: 'Test path to be tested: e.g. integration/cli'
+        description: "The path from 'test/integration' to target to be tested, e.g. 'cli'"
         required: false
       sha:
         description: 'The hash value of the commit.'

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Check out merge commit
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
 
@@ -124,7 +124,7 @@ jobs:
 
       # Check out merge commit
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha }}
 


### PR DESCRIPTION
## 📝 Description
- Correct the example in the description `test_path` parameter of the [run e2e test workflow](https://github.com/linode/linode-cli/actions/workflows/e2e-suite-pr.yml).
- Add GitHub Token to the graphql API call (for checking the commit has of a PR).
- Bump repo checkout action version.
- Cleanup unnecessary step, `Install system deps`