### PR TITLE
Fix `boto3` missing error message in obj extension

### DIFF
--- a/linodecli/plugins/obj/objects.py
+++ b/linodecli/plugins/obj/objects.py
@@ -7,8 +7,13 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import List
 
-from boto3.exceptions import S3UploadFailedError
-from boto3.s3.transfer import MB, TransferConfig
+try:
+    from boto3.exceptions import S3UploadFailedError
+    from boto3.s3.transfer import MB, TransferConfig
+except:
+    # this has been handled in `call` function
+    # by print an error message
+    pass
 
 from linodecli.helpers import expand_globs
 from linodecli.plugins import inherit_plugin_args


### PR DESCRIPTION
## 📝 Description

We imported boto3 in `objects.py` which skips the boto3 check logic `__init__.py`. Added `try ... except ...` block to ignore the exception and let the `call` function in `__init__.py` to print the error message.

## ✔️ How to Test
`make install`
`python3 -m pip uninstall boto3 -y`
`linode obj ls`

GHA run passed: https://github.com/linode/linode-cli/actions/runs/6750190271