### PR TITLE
Replace `distutils` with `packaging` for Py 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "packaging"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ requests-mock==1.11.0
 boto3-stubs[s3]
 build>=0.10.0
 twine>=4.0.2
+packaging>=23.2

--- a/version
+++ b/version
@@ -4,7 +4,8 @@
 #       Prints the current version
 
 import os
-from distutils.version import LooseVersion
+
+from packaging.version import parse
 
 ENV_LINODE_CLI_VERSION = "LINODE_CLI_VERSION"
 
@@ -22,8 +23,7 @@ def get_version(ref="HEAD"):
     if version_str.startswith("v"):
         version_str = version_str[1:]
 
-    parts = LooseVersion(version_str).version[:3]
-    return tuple(parts)
+    return parse(version_str).release
 
 
 major, minor, patch = get_version()


### PR DESCRIPTION
## 📝 Description

`distutils` has been removed in Python 3.12, and we need to replace it with `packaging` in order to get the release workflow works again.

This is targeting `dev` branch intentionally because other code in `dev` branch is needed to get everything working with Python 3.12.

## ✔️ How to Test

1. Install both Python 3.11 and 3.12.
2. `export LINODE_CLI_VERSION=v1.2.3.dev` 
OR
`export LINODE_CLI_VERSION=v1.2.3`
4. Then these three ways should output the same result of version. 
`python3.12 version`
`python3.11 version`
`python3.11 version` (in main branch before merging this PR)
