### PR TITLE
fix: Use HEAD SHA from main branch rather than default branch

### DIFF
--- a/.github/workflows/remote-release-trigger.yml
+++ b/.github/workflows/remote-release-trigger.yml
@@ -56,9 +56,14 @@ jobs:
             
             return "v" + cli_version_segments.join(".")
 
+      - name: Calculate the SHA of HEAD on the main branch
+        id: calculate_head_sha
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: rickstaa/action-create-tag@84c90e6ba79b47b5147dcb11ff25d6a0e06238ba # pin@v1
         with:
           tag: ${{ steps.calculate_version.outputs.result }}
+          commit_sha: ${{ steps.calculate_head_sha.outputs.commit_sha }}
 
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1


### PR DESCRIPTION
## 📝 Description

This change updates the automated release workflow to create release tags on the main branch rather than the default (dev) branch. This is necessary because we only want to release code that has been merged to the main branch.

Example run: https://github.com/lgarber-akamai/linode-cli/actions/runs/6814710635