### PR TITLE
fix: Install Python dependencies in OCI publish workflow

### DIFF
--- a/.github/workflows/oci-build.yml
+++ b/.github/workflows/oci-build.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install deps
+        run: make requirements
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # pin@v2.2.0
 

--- a/version
+++ b/version
@@ -10,21 +10,12 @@ from packaging.version import parse
 ENV_LINODE_CLI_VERSION = "LINODE_CLI_VERSION"
 
 
-def get_version_env():
-    return os.getenv(ENV_LINODE_CLI_VERSION)
-
-
-def get_version(ref="HEAD"):
+def get_version():
     # We want to override the version if an environment variable is specified.
     # This is useful for certain release and testing pipelines.
-    version_str = get_version_env() or "0.0.0"
-
-    # Strip the `v` prefix if specified
-    if version_str.startswith("v"):
-        version_str = version_str[1:]
+    version_str = os.getenv(ENV_LINODE_CLI_VERSION, "0.0.0")
 
     return parse(version_str).release
 
 
-major, minor, patch = get_version()
-print("{}.{}.{}".format(major, minor, patch))
+print("{}.{}.{}".format(*get_version()))


### PR DESCRIPTION
## 📝 Description

This change updates the OCI publish workflow to install the Linode CLI Python dependencies on the GHA runner. This is necessary because this workflow determines the desired CLI version before building the image using the `version` script.


Example run: https://github.com/lgarber-akamai/linode-cli/actions/runs/6906139859/job/18790538357