### PR TITLE
fix: obj plugin error with invalid cluster

### DIFF
--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -451,11 +451,19 @@ def print_help(parser: ArgumentParser):
     print("See --help for individual commands for more information")
 
 
-def get_obj_args_parser():
+def get_obj_args_parser(client: CLI):
     """
     Initialize and return the argument parser for the obj plug-in.
     """
     parser = inherit_plugin_args(ArgumentParser(PLUGIN_BASE, add_help=False))
+    clusters = [
+        c["id"]
+        for c in _do_get_request(  # pylint: disable=protected-access
+            client.config.base_url,
+            "/object-storage/clusters",
+            token=client.config.get_value("token"),
+        )["data"]
+    ]
 
     parser.add_argument(
         "command",
@@ -468,6 +476,7 @@ def get_obj_args_parser():
         "--cluster",
         metavar="CLUSTER",
         type=str,
+        choices=clusters,
         help="The cluster to use for the operation",
     )
 
@@ -527,7 +536,7 @@ def call(
 
         sys.exit(2)  # requirements not met - we can't go on
 
-    parser = get_obj_args_parser()
+    parser = get_obj_args_parser(context.client)
     parsed, args = parser.parse_known_args(args)
 
     # don't mind --no-defaults if it's there; the top-level parser already took care of it

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -451,7 +451,7 @@ def print_help(parser: ArgumentParser):
     print("See --help for individual commands for more information")
 
 
-def get_obj_args_parser(clusters: list[str]):
+def get_obj_args_parser(clusters: List[str]):
     """
     Initialize and return the argument parser for the obj plug-in.
     """

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -451,19 +451,11 @@ def print_help(parser: ArgumentParser):
     print("See --help for individual commands for more information")
 
 
-def get_obj_args_parser(client: CLI):
+def get_obj_args_parser(clusters: list[str]):
     """
     Initialize and return the argument parser for the obj plug-in.
     """
     parser = inherit_plugin_args(ArgumentParser(PLUGIN_BASE, add_help=False))
-    clusters = [
-        c["id"]
-        for c in _do_get_request(  # pylint: disable=protected-access
-            client.config.base_url,
-            "/object-storage/clusters",
-            token=client.config.get_value("token"),
-        )["data"]
-    ]
 
     parser.add_argument(
         "command",
@@ -536,7 +528,15 @@ def call(
 
         sys.exit(2)  # requirements not met - we can't go on
 
-    parser = get_obj_args_parser(context.client)
+    clusters = [
+        c["id"]
+        for c in _do_get_request(  # pylint: disable=protected-access
+            context.client.config.base_url,
+            "/object-storage/clusters",
+            token=context.client.config.get_value("token"),
+        )["data"]
+    ]
+    parser = get_obj_args_parser(clusters)
     parsed, args = parser.parse_known_args(args)
 
     # don't mind --no-defaults if it's there; the top-level parser already took care of it

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -79,6 +79,7 @@ INVALID_PAGE_MSG = "No result to show in this page."
 
 
 def get_available_cluster(cli: CLI):
+    """Get list of possible clusters for the account"""
     return [
         c["id"]
         for c in _do_get_request(  # pylint: disable=protected-access

--- a/tests/unit/test_plugin_obj.py
+++ b/tests/unit/test_plugin_obj.py
@@ -5,7 +5,7 @@ from linodecli.plugins.obj import get_obj_args_parser, helpers, print_help
 
 
 def test_print_help(mock_cli: CLI, capsys: CaptureFixture):
-    parser = get_obj_args_parser(mock_cli)
+    parser = get_obj_args_parser(["us-mia-1"])
     print_help(parser)
     captured_text = capsys.readouterr()
     assert parser.format_help() in captured_text.out

--- a/tests/unit/test_plugin_obj.py
+++ b/tests/unit/test_plugin_obj.py
@@ -1,10 +1,11 @@
 from pytest import CaptureFixture
 
+from linodecli import CLI
 from linodecli.plugins.obj import get_obj_args_parser, helpers, print_help
 
 
-def test_print_help(capsys: CaptureFixture):
-    parser = get_obj_args_parser()
+def test_print_help(mock_cli: CLI, capsys: CaptureFixture):
+    parser = get_obj_args_parser(mock_cli)
     print_help(parser)
     captured_text = capsys.readouterr()
     assert parser.format_help() in captured_text.out


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

When using the command with a invalid region it would print out a large stack trace error, to fix this I added a list of valid clusters generated from the API.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

Use the command with a invalid cluster ID
```bash
lin obj --cluster us-west
```
