### PR TITLE
test: add release info to xml file before uploading to obj storage

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
+          echo "${{ github.event.release.tag_name }}"
           if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
@@ -52,13 +53,13 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          echo $RELEASE_VERSION
-          echo ${{ env.RELEASE_VERSION }}
+          echo "${{ github.event.release.tag_name }}"
           filename=$(ls | grep -E '^[0-9]{12}_cli_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
+          --release_tag "${{ github.event.release.tag_name }}" \
           --xmlfile "${filename}"
 
       - name: Upload test results

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          echo "${{ github.event.release.tag_name }}"
+          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
+          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
           if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
@@ -59,7 +60,7 @@ jobs:
           --branch_name "${{ env.RELEASE_VERSION }}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
-          --release_tag "${{ github.event.release.tag_name }}" \
+          --release_tag "$GITHUB_REF_NAME" \
           --xmlfile "${filename}"
 
       - name: Upload test results

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -47,18 +47,13 @@ jobs:
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
-      - name: Set release version env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
       - name: Add additional information to XML report
         run: |
-          release_tag=$(git describe --tags --abbrev=0)
           filename=$(ls | grep -E '^[0-9]{12}_cli_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
-          --branch_name "${{ env.RELEASE_VERSION }}" \
+          --branch_name "${GITHUB_REF#refs/*/}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
-          --release_tag "$release_tag" \
           --xmlfile "${filename}"
 
       - name: Upload test results

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -42,7 +42,7 @@ jobs:
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
           echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+          echo "tag": ${GITHUB_REF#refs/*/}
           if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -41,8 +41,6 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          echo "Tag name from GITHUB_REF_NAME: $GITHUB_REF_NAME"
-          echo "tag": ${GITHUB_REF#refs/*/}
           if ! pytest tests/integration --disable-warnings --junitxml="${report_filename}"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
@@ -54,13 +52,13 @@ jobs:
 
       - name: Add additional information to XML report
         run: |
-          echo "${{ github.event.release.tag_name }}"
+          release_tag=$(git describe --tags --abbrev=0)
           filename=$(ls | grep -E '^[0-9]{12}_cli_test_report\.xml$') 
           python scripts/add_to_xml_test_report.py \
           --branch_name "${{ env.RELEASE_VERSION }}" \
           --gha_run_id "$GITHUB_RUN_ID" \
           --gha_run_number "$GITHUB_RUN_NUMBER" \
-          --release_tag "$GITHUB_REF_NAME" \
+          --release_tag "$release_tag" \
           --xmlfile "${filename}"
 
       - name: Upload test results

--- a/scripts/add_to_xml_test_report.py
+++ b/scripts/add_to_xml_test_report.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser(description='Modify XML with workflow informati
 parser.add_argument('--branch_name', required=True)
 parser.add_argument('--gha_run_id', required=True)
 parser.add_argument('--gha_run_number', required=True)
+parser.add_argument('--release_tag', required=True)
 parser.add_argument('--xmlfile', required=True)  # Added argument for XML file path
 
 args = parser.parse_args()

--- a/scripts/add_to_xml_test_report.py
+++ b/scripts/add_to_xml_test_report.py
@@ -26,6 +26,9 @@ gha_run_id_element.text = args.gha_run_id
 gha_run_number_element = ET.Element('gha_run_number')
 gha_run_number_element.text = args.gha_run_number
 
+gha_run_number_element = ET.Element('release_tag')
+gha_run_number_element.text = args.gha_run_number
+
 # Add the new elements to the root of the XML
 root.append(branch_name_element)
 root.append(gha_run_id_element)

--- a/scripts/add_to_xml_test_report.py
+++ b/scripts/add_to_xml_test_report.py
@@ -26,13 +26,14 @@ gha_run_id_element.text = args.gha_run_id
 gha_run_number_element = ET.Element('gha_run_number')
 gha_run_number_element.text = args.gha_run_number
 
-gha_run_number_element = ET.Element('release_tag')
-gha_run_number_element.text = args.gha_run_number
+gha_release_tag_element = ET.Element('release_tag')
+gha_release_tag_element.text = args.gha_run_number
 
 # Add the new elements to the root of the XML
 root.append(branch_name_element)
 root.append(gha_run_id_element)
 root.append(gha_run_number_element)
+root.append(gha_release_tag_element)
 
 # Save the modified XML
 modified_xml_file_path = xml_file_path  # Overwrite it

--- a/scripts/add_to_xml_test_report.py
+++ b/scripts/add_to_xml_test_report.py
@@ -1,12 +1,38 @@
 import argparse
 import xml.etree.ElementTree as ET
+import requests
+
+latest_release_url = "https://api.github.com/repos/linode/linode-cli/releases/latest"
+
+
+def get_release_version():
+    url = latest_release_url
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Check for HTTP errors
+
+        release_info = response.json()
+        version = release_info["tag_name"]
+
+        # Remove 'v' prefix if it exists
+        if version.startswith("v"):
+            version = version[1:]
+
+        return str(version)
+
+    except requests.exceptions.RequestException as e:
+        print("Error:", e)
+    except KeyError:
+        print("Error: Unable to fetch release information from GitHub API.")
+
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description='Modify XML with workflow information')
 parser.add_argument('--branch_name', required=True)
 parser.add_argument('--gha_run_id', required=True)
 parser.add_argument('--gha_run_number', required=True)
-parser.add_argument('--release_tag', required=True)
+parser.add_argument('--release_tag', required=False)
 parser.add_argument('--xmlfile', required=True)  # Added argument for XML file path
 
 args = parser.parse_args()
@@ -27,7 +53,7 @@ gha_run_number_element = ET.Element('gha_run_number')
 gha_run_number_element.text = args.gha_run_number
 
 gha_release_tag_element = ET.Element('release_tag')
-gha_release_tag_element.text = args.gha_run_number
+gha_release_tag_element.text = get_release_version()
 
 # Add the new elements to the root of the XML
 root.append(branch_name_element)

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -13,7 +13,7 @@ def test_help_page_for_non_aliased_actions():
         "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
         in output
     )
-    assert "wrong assertion" in output
+    assert "You may filter results with:" in output
     assert "--tags" in output
 
 

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -13,7 +13,7 @@ def test_help_page_for_non_aliased_actions():
         "API Documentation: https://www.linode.com/docs/api/linode-instances/#linodes-list"
         in output
     )
-    assert "You may filter results with:" in output
+    assert "wrong assertion" in output
     assert "--tags" in output
 
 


### PR DESCRIPTION
## 📝 Description

Problem: For some context, the script that is used to upload test report from OBJ storage to TOD is currently calling GitHub API endpoints from ECP Test VM to get the release info for corresponding repository. However recently there has been a rate limiting issue that is causing an error calling endpoint from that particular VM. E.g.
`Error: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/linode/terraform-provider-linode/releases/latest
linode-terraform None`

Fix: Use existing add_to_xml_report.py script to add the release information to the xml report before uploading it to Object Storage so we don't have to rely on calling any endpoints from the Test VM


## ✔️ How to Test

Build - 

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**