### PR TITLE
new: hyperlinks for help URLs

### DIFF
--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -355,7 +355,7 @@ def action_help(cli, command, action):
     print()
     print(op.summary)
     if op.docs_url:
-        print(f"API Documentation: {op.docs_url}")
+        rprint(f"API Documentation: [link={op.docs_url}]{op.docs_url}[/link]")
     print()
     if op.method == "get" and op.action == "list":
         filterable_attrs = [


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Creates a clickable (if supported) hyperlink for `--help` output.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

Run a help command and click the link or observe its style change.

```bash
make install
lin linodes ls --help
```
