### PR TITLE
new: Add `--cloud-init` flag to image upload plugin

### DIFF
--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -95,6 +95,12 @@ def call(args, context):
         help="A description for this Image.  Blank if omitted.",
     )
     parser.add_argument(
+        "--cloud-init",
+        metavar="CLOUD_INIT",
+        action="store_true",
+        help="If given, the new image will be flagged as cloud-init compatible.",
+    )
+    parser.add_argument(
         "file",
         metavar="FILE",
         help="The image file to upload.  Should be a raw disk image "
@@ -148,6 +154,9 @@ def call(args, context):
     call_args = ["--region", parsed.region, "--label", label]
     if parsed.description:
         call_args += ["--description", parsed.description]
+
+    if parsed.cloud_init:
+        call_args += ["--cloud_init", "true"]
 
     status, resp = context.client.call_operation("images", "upload", call_args)
 

--- a/linodecli/plugins/image-upload.py
+++ b/linodecli/plugins/image-upload.py
@@ -96,7 +96,6 @@ def call(args, context):
     )
     parser.add_argument(
         "--cloud-init",
-        metavar="CLOUD_INIT",
         action="store_true",
         help="If given, the new image will be flagged as cloud-init compatible.",
     )

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -108,7 +108,15 @@ def test_file_upload_cloud_init(
 
     # Upload the test image
     process = exec_test_command(
-        BASE_CMD + ["--label", label, "--description", description, "--cloud-init", file_path]
+        BASE_CMD
+        + [
+            "--label",
+            label,
+            "--description",
+            description,
+            "--cloud-init",
+            file_path,
+        ]
     )
 
     assert process.returncode == 0

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -10,7 +10,7 @@ import pytest
 
 from tests.integration.helpers import get_random_text
 
-REGION = "us-southeast"
+REGION = "us-iad"
 BASE_CMD = ["linode-cli", "image-upload", "--region", REGION]
 
 # A minimal gzipped image that will be accepted by the API
@@ -92,6 +92,37 @@ def test_file_upload(
     image = json.loads(process.stdout.decode())
 
     assert image[0]["label"] == label
+
+    # Delete the image
+    process = exec_test_command(["linode-cli", "images", "rm", image[0]["id"]])
+    assert process.returncode == 0
+
+
+@pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
+def test_file_upload_cloud_init(
+    fake_image_file,
+):
+    file_path = fake_image_file
+    label = f"cli-test-{get_random_text()}"
+    description = "test description"
+
+    # Upload the test image
+    process = exec_test_command(
+        BASE_CMD + ["--label", label, "--description", description, "--cloud-init", file_path]
+    )
+
+    assert process.returncode == 0
+
+    # Get the new image from the API
+    process = exec_test_command(
+        ["linode-cli", "images", "ls", "--json", "--label", label]
+    )
+    assert process.returncode == 0
+
+    image = json.loads(process.stdout.decode())
+
+    assert image[0]["label"] == label
+    assert "cloud-init" in image[0]["capabilities"]
 
     # Delete the image
     process = exec_test_command(["linode-cli", "images", "rm", image[0]["id"]])


### PR DESCRIPTION
## 📝 Description

This change adds a `--cloud-init` flag to the `image-upload` plugin, indicating that an image is cloud-init compatible.

Depends on: https://github.com/linode/linode-api-docs/pull/893
Resolves #556 

## ✔️ How to Test

The following test steps assume you have pulled down this change and ran the following:
```bash
make SPEC="https://raw.githubusercontent.com/linode/linode-api-docs/93b217f629d821ddb6bd8c52c341104e793c9885/openapi.yaml" install
```

### E2E Testing

```bash
make INTEGRATION_TEST_PATH=image testint
```

### Manual Testing

1. Create an arbitrary gzipped image.

```bash
touch test_image && gzip test_image
```

2. Upload the image to Linode with the cloud-init flag specified. Take note of the returned image ID.

```bash
linode-cli image-upload --label test-image --region us-iad --cloud-init test_image.gz
```

3. Once the image has been uploaded, view the image's capabilities using the CLI.

```bash
linode-cli images view private/MYIMAGEID --format capabilities
```

4. Observe that the `cloud-init` is listed under the capabilities column.