### PR TITLE
added test for linode_type and account_transfer 

### DIFF
--- a/tests/integration/account/test_account_transfer.py
+++ b/tests/integration/account/test_account_transfer.py
@@ -1,0 +1,24 @@
+import os
+import subprocess
+from typing import List
+
+env = os.environ.copy()
+env["COLUMNS"] = "200"
+
+
+def exec_test_command(args: List[str]):
+    process = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    return process
+
+
+def test_account_transfer():
+    process = exec_test_command(["linode-cli", "account", "transfer"])
+    output = process.stdout.decode()
+    print(output)
+    assert "billable" in output
+    assert "quota" in output
+    assert "used" in output

--- a/tests/integration/account/test_account_transfer.py
+++ b/tests/integration/account/test_account_transfer.py
@@ -18,7 +18,6 @@ def exec_test_command(args: List[str]):
 def test_account_transfer():
     process = exec_test_command(["linode-cli", "account", "transfer"])
     output = process.stdout.decode()
-    print(output)
     assert "billable" in output
     assert "quota" in output
     assert "used" in output

--- a/tests/integration/linodes/test_types.py
+++ b/tests/integration/linodes/test_types.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+from typing import List
+
+env = os.environ.copy()
+env["COLUMNS"] = "200"
+
+
+def exec_test_command(args: List[str]):
+    process = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    return process
+
+
+# verifying the DC pricing changes along with types
+def test_linode_type():
+    process = exec_test_command(["linode-cli", "linodes", "types"])
+    output = process.stdout.decode()
+    print(output)
+    assert " price.hourly " in output
+    assert " price.monthly " in output
+    assert " region_prices " in output
+    assert " hourly " in output
+    assert " monthly " in output

--- a/tests/integration/linodes/test_types.py
+++ b/tests/integration/linodes/test_types.py
@@ -19,7 +19,6 @@ def exec_test_command(args: List[str]):
 def test_linode_type():
     process = exec_test_command(["linode-cli", "linodes", "types"])
     output = process.stdout.decode()
-    print(output)
     assert " price.hourly " in output
     assert " price.monthly " in output
     assert " region_prices " in output


### PR DESCRIPTION
Added the test for
linode-cli linodes types
linode-cli account transfer

What does this PR do and why is this change necessary?
covers the integration test

✔️ How to Test
Run test individually
make INTEGRATION_TEST_PATH=/linodes/test_types.py testint
make INTEGRATION_TEST_PATH=account testint
Run all test
make testint

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**