### PR TITLE
new: Display example usage in command help pages

### DIFF
--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -5,6 +5,7 @@ Argument parser for the linode CLI
 
 import os
 import sys
+import textwrap
 from importlib import import_module
 
 import requests
@@ -349,13 +350,30 @@ def action_help(cli, command, action):
     except ValueError:
         return
     print(f"linode-cli {command} {action}", end="")
+
     for param in op.params:
         pname = param.name.upper()
         print(f" [{pname}]", end="")
+
     print()
     print(op.summary)
+
     if op.docs_url:
         rprint(f"API Documentation: [link={op.docs_url}]{op.docs_url}[/link]")
+
+    if len(op.samples) > 0:
+        print()
+        print(f"Example Usage{'s' if len(op.samples) > 1 else ''}: ")
+
+        rprint(
+            *[
+                # Indent all samples for readability; strip and trailing newlines
+                textwrap.indent(v.get("source").rstrip(), "  ")
+                for v in op.samples
+            ],
+            sep="\n\n",
+        )
+
     print()
     if op.method == "get" and op.action == "list":
         filterable_attrs = [

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -311,6 +311,13 @@ class OpenAPIOperation:
             )
         self.docs_url = docs_url
 
+        code_samples_ext = operation.extensions.get("code-samples")
+        self.samples = (
+            [v for v in code_samples_ext if v.get("lang").lower() == "cli"]
+            if code_samples_ext is not None
+            else []
+        )
+
     @property
     def args(self):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,3 @@ requests-mock==1.11.0
 boto3-stubs[s3]
 build>=0.10.0
 twine>=4.0.2
-packaging>=23.2

--- a/tests/unit/test_arg_helpers.py
+++ b/tests/unit/test_arg_helpers.py
@@ -179,6 +179,10 @@ class TestArgParsing:
         mocked_ops.summary = "test summary"
         mocked_ops.docs_url = "https://website.com/endpoint"
         mocked_ops.method = "post"
+        mocked_ops.samples = [
+            {"lang": "CLI", "source": "linode-cli command action\n  --foo=bar"},
+            {"lang": "CLI", "source": "linode-cli command action\n  --bar=foo"},
+        ]
 
         mocked_args = mocker.MagicMock()
         mocked_args.read_only = False
@@ -196,6 +200,13 @@ class TestArgParsing:
         assert "test summary" in captured.out
         assert "API Documentation" in captured.out
         assert "https://website.com/endpoint" in captured.out
+        assert (
+            "Example Usages: \n"
+            "  linode-cli command action\n"
+            "    --foo=bar\n\n"
+            "  linode-cli command action\n"
+            "    --bar=foo\n\n"
+        ) in captured.out
         assert "Arguments" in captured.out
         assert "test description" in captured.out
         assert "(required)" in captured.out
@@ -208,6 +219,9 @@ class TestArgParsing:
         mocked_ops.method = "get"
         mocked_ops.action = "list"
         mocked_ops.args = None
+        mocked_ops.samples = [
+            {"lang": "CLI", "source": "linode-cli command action"}
+        ]
 
         mock_attr = mocker.MagicMock()
         mock_attr.filterable = True
@@ -221,6 +235,7 @@ class TestArgParsing:
         assert "test summary" in captured.out
         assert "API Documentation" in captured.out
         assert "https://website.com/endpoint" in captured.out
+        assert "Example Usage: \n  linode-cli command action" in captured.out
         assert "Arguments" not in captured.out
         assert "filter results" in captured.out
         assert "filtername" in captured.out


### PR DESCRIPTION
## 📝 Description

This pull request adds a new `Example Usage` section to generated command help pages. These examples are pulled from the `x-code-samples` OpenAPI spec extension.

This functionality was previously implemented before the spec parser rework (#299, #303) but was never merged. Thanks @bavedarnow and @Dorthu for the original idea and implementations!

Closes #299, #303 

## 📷 Preview

<img width="1015" alt="linode-cli_–_operation_py" src="https://github.com/linode/linode-cli/assets/114949949/97e7f7d8-93cb-49ca-bfd2-a866e25a3e26">

## ✔️ How to Test

The following testing instructions assume you have pulled down this change and run `make install`.

### Running unit tests:

```bash
make testunit
```

### Manual testing:

1. View the help page for the `linodes create` (POST) command:

```bash
linode-cli linodes create --help
```

2. Observe the `Example Usage` section displays as expected.
3. View the help page for the `linodes view` (GET) command:

```bash
linode-cli linodes view --help
```

4. Observe the `Example Usage` section displays as expected.
5. View the help page for the `linodes update` (PUT) section.

```bash
linode-cli linodes update --help
```

6. Observe the `Example Usage` section displays as expected.
7. View the help page for the `linodes delete` (DELETE) section.

```bash
linode-cli linodes delete --help
```

8. Observe the `Example Usage` section displays as expected.
