### PR TITLE
fix: Resolve issue when not specifying all keys for object list entries

### DIFF
--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -455,20 +455,31 @@ class OpenAPIOperation:
         parsed,
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         lists = {}
+
         # group list items as expected
         for arg_name, list_name in list_items:
             item_name = arg_name.split(list_name)[1][1:]
+
             if hasattr(parsed, arg_name):
                 val = getattr(parsed, arg_name) or []
                 if not val:
                     continue
+
                 if list_name not in lists:
-                    new_list = [{item_name: c} for c in val]
-                    lists[list_name] = new_list
-                else:
-                    update_list = lists[list_name]
-                    for obj, item in zip(update_list, val):
-                        obj[item_name] = item
+                    lists[list_name] = []
+
+                target_list = lists[list_name]
+
+                # If there are any additional indices not accounted for
+                # in the target list, add new objects accordingly.
+                if len(target_list) < len(val):
+                    for _ in range(len(val) - len(target_list)):
+                        target_list.append({})
+
+                # Populate each entry in the target list
+                # with each corresponding entry in val.
+                for obj, item in zip(target_list, val):
+                    obj[item_name] = item
 
         # break out list items with periods in their name into objects.  This
         # allows supporting nested lists

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -97,3 +97,16 @@ components:
           type: number
           nullable: true
           description: An arbitrary nullable float
+        object_list:
+          type: array
+          description: An arbitrary list of objects.
+          items:
+            type: object
+            description: An arbitrary object.
+            properties:
+              field_string:
+                type: string
+                description: An arbitrary field.
+              field_int:
+                type: number
+                description: An arbitrary field.

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -159,6 +159,23 @@ class TestOperation:
         result = create_operation.parse_args(["--nullable_float", "456.123"])
         assert result.nullable_float == 456.123
 
+    def test_parse_args_object_list(self, create_operation):
+        result = create_operation.parse_args(
+            [
+                "--object_list.field_string", "test1", "--object_list.field_int", "123",
+                "--object_list.field_int", "456"
+            ]
+        )
+        assert result.object_list == [
+            {
+                "field_string": "test1",
+                "field_int": 123,
+            },
+            {
+                "field_int": 456,
+            }
+        ]
+
     def test_array_arg_action_basic(self):
         """
         Tests a basic array argument condition..

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -162,8 +162,12 @@ class TestOperation:
     def test_parse_args_object_list(self, create_operation):
         result = create_operation.parse_args(
             [
-                "--object_list.field_string", "test1", "--object_list.field_int", "123",
-                "--object_list.field_int", "456"
+                "--object_list.field_string",
+                "test1",
+                "--object_list.field_int",
+                "123",
+                "--object_list.field_int",
+                "456",
             ]
         )
         assert result.object_list == [
@@ -173,7 +177,7 @@ class TestOperation:
             },
             {
                 "field_int": 456,
-            }
+            },
         ]
 
     def test_array_arg_action_basic(self):


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused some object list entries to not be processed when some keys are excluded. 

## ✔️ How to Test

### Running Unit Tests

```bash
make testunit
```

### Manual Testing

1. Pull down this change.
2. Install the Linode CLI:

```bash
make install
```

3. Create an arbitrary VPC and subnet:

```bash
export VPC_ID=$(linode-cli vpcs create --label test-vpc --region us-mia --json | jq '.[0].id')
export SUBNET_ID=$(linode-cli vpcs subnet-create --label test-subnet --ipv4 '10.0.1.0/24' ${VPC_ID} --json | jq '.[0].id')
```

4. Attempt to create a Linode with a VPC and public interface using debug mode:

```bash
linode-cli linodes create \
  --label test-instance \
  --region us-mia \
  --image linode/alpine3.19 \
  --root_pass 'testp4ssw0rd!!!!!!23123' \
  --type g6-nanode-1 \
  --interfaces.primary true --interfaces.purpose vpc --interfaces.subnet_id ${SUBNET_ID} \
  --interfaces.purpose=public \
  --debug
```

5. Observe two interfaces are defined in the logged API request:

```bash
{
  ...
  "interfaces": [
    {
      "label": null,
      "ipam_address": null,
      "purpose": "vpc",
      "active": null,
      "primary": true,
      "subnet_id": 19585
    },
    {
      "purpose": "public"
    }
  ]
}
```
