### PR TITLE
fix: Resolve bug that prevented nested dict fields in object lists from being included in request body

### DIFF
--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -420,7 +420,7 @@ class OpenAPIOperation:
                     action=ListArgumentAction,
                     type=arg_type_handler,
                 )
-                list_items.append((arg.path, arg.prefix))
+                list_items.append((arg.path, arg.list_parent))
             else:
                 if arg.datatype == "string" and arg.format == "password":
                     # special case - password input

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -104,6 +104,16 @@ components:
             type: object
             description: An arbitrary object.
             properties:
+              field_dict:
+                type: object
+                description: An arbitrary nested dict.
+                properties:
+                  nested_string:
+                    type: string
+                    description: A deeply nested string.
+                  nested_int:
+                    type: number
+                    description: A deeply nested integer.
               field_string:
                 type: string
                 description: An arbitrary field.

--- a/tests/integration/linodes/test_interfaces.py
+++ b/tests/integration/linodes/test_interfaces.py
@@ -3,9 +3,7 @@ import time
 
 import pytest
 
-from tests.integration.conftest import (
-    create_vpc_w_subnet,
-)
+from tests.integration.conftest import create_vpc_w_subnet
 from tests.integration.helpers import delete_target_id, exec_test_command
 from tests.integration.linodes.helpers_linodes import (
     BASE_CMD,

--- a/tests/integration/linodes/test_interfaces.py
+++ b/tests/integration/linodes/test_interfaces.py
@@ -1,0 +1,96 @@
+import json
+import time
+
+import pytest
+
+from tests.integration.conftest import (
+    create_vpc_w_subnet,
+)
+from tests.integration.helpers import delete_target_id, exec_test_command
+from tests.integration.linodes.helpers_linodes import (
+    BASE_CMD,
+    DEFAULT_LABEL,
+    DEFAULT_RANDOM_PASS,
+    DEFAULT_TEST_IMAGE,
+)
+
+timestamp = str(time.time_ns())
+linode_label = DEFAULT_LABEL + timestamp
+
+
+@pytest.fixture
+def linode_with_vpc_interface():
+    vpc_json = create_vpc_w_subnet()
+
+    vpc_region = vpc_json["region"]
+    vpc_id = str(vpc_json["id"])
+    subnet_id = str(vpc_json["subnets"][0]["id"])
+
+    linode_json = json.loads(
+        exec_test_command(
+            BASE_CMD
+            + [
+                "create",
+                "--type",
+                "g6-nanode-1",
+                "--region",
+                vpc_region,
+                "--image",
+                DEFAULT_TEST_IMAGE,
+                "--root_pass",
+                DEFAULT_RANDOM_PASS,
+                "--interfaces.purpose",
+                "vpc",
+                "--interfaces.primary",
+                "true",
+                "--interfaces.subnet_id",
+                subnet_id,
+                "--interfaces.ipv4.nat_1_1",
+                "any",
+                "--interfaces.ipv4.vpc",
+                "10.0.0.5",
+                "--interfaces.purpose",
+                "public",
+                "--json",
+                "--suppress-warnings",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )[0]
+
+    yield linode_json, vpc_json
+
+    delete_target_id(target="linodes", id=str(linode_json["id"]))
+    delete_target_id(target="vpcs", id=vpc_id)
+
+
+def test_with_vpc_interface(linode_with_vpc_interface):
+    linode_json, vpc_json = linode_with_vpc_interface
+
+    config_json = json.loads(
+        exec_test_command(
+            BASE_CMD
+            + [
+                "configs-list",
+                str(linode_json["id"]),
+                "--json",
+                "--suppress-warnings",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )[0]
+
+    vpc_interface = config_json["interfaces"][0]
+    public_interface = config_json["interfaces"][1]
+
+    assert vpc_interface["primary"]
+    assert vpc_interface["purpose"] == "vpc"
+    assert vpc_interface["subnet_id"] == vpc_json["subnets"][0]["id"]
+    assert vpc_interface["vpc_id"] == vpc_json["id"]
+    assert vpc_interface["ipv4"]["vpc"] == "10.0.0.5"
+    assert vpc_interface["ipv4"]["nat_1_1"] == linode_json["ipv4"][0]
+
+    assert not public_interface["primary"]
+    assert public_interface["purpose"] == "public"

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -2,40 +2,17 @@ import time
 
 import pytest
 
-from tests.integration.conftest import get_regions_with_capabilities
+from tests.integration.conftest import (
+    create_vpc_w_subnet,
+    get_regions_with_capabilities,
+)
 from tests.integration.helpers import delete_target_id, exec_test_command
 
 
 @pytest.fixture
 def test_vpc_w_subnet():
-    region = get_regions_with_capabilities(["VPCs"])[0]
-
-    vpc_label = str(time.time_ns()) + "label"
-
-    subnet_label = str(time.time_ns()) + "label"
-
-    vpc_id = (
-        exec_test_command(
-            [
-                "linode-cli",
-                "vpcs",
-                "create",
-                "--label",
-                vpc_label,
-                "--region",
-                region,
-                "--subnets.ipv4",
-                "10.0.0.0/24",
-                "--subnets.label",
-                subnet_label,
-                "--no-headers",
-                "--text",
-                "--format=id",
-            ]
-        )
-        .stdout.decode()
-        .rstrip()
-    )
+    vpc_json = create_vpc_w_subnet()
+    vpc_id = str(vpc_json["id"])
 
     yield vpc_id
 

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -162,22 +162,29 @@ class TestOperation:
     def test_parse_args_object_list(self, create_operation):
         result = create_operation.parse_args(
             [
+                # First object
                 "--object_list.field_string",
                 "test1",
                 "--object_list.field_int",
                 "123",
+                "--object_list.field_dict.nested_string",
+                "test2",
+                "--object_list.field_dict.nested_int",
+                "789",
+                # Second object
                 "--object_list.field_int",
                 "456",
+                "--object_list.field_dict.nested_string",
+                "test3",
             ]
         )
         assert result.object_list == [
             {
                 "field_string": "test1",
                 "field_int": 123,
+                "field_dict": {"nested_string": "test2", "nested_int": 789},
             },
-            {
-                "field_int": 456,
-            },
+            {"field_int": 456, "field_dict": {"nested_string": "test3"}},
         ]
 
     def test_array_arg_action_basic(self):


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused nested dict fields in object lists (e.g. `--interfaces.ipv4.nat_1_1`) to be excluded from request bodies.

This issue occurred because the logic to traverse API spec request arguments did not preserve whether a nested dict field was under a list. Additionally, the name of the list for a field was resolved using the prefix of a field rather than its top-level list name causing mismatches for deeply nested fields.

## ✔️ How to Test

The following test steps assume you have pulled down this change locally and run `make install`.

### Integration Testing

```bash
make INTEGRATION_TEST_PATH=linodes/test_interfaces.py testint
```

### Unit Testing

```bash
make testunit
```

### Manual Testing

1. Create an arbitrary VPC and VPC subnet:

```bash
export VPC_ID=$(linode-cli vpcs create --label test-vpc --region us-mia --json | jq '.[0].id')
export SUBNET_ID=$(linode-cli vpcs subnet-create --label test-subnet --ipv4 '10.0.1.0/24' ${VPC_ID} --json | jq '.[0].id')
```

2. Create an instance with an interface referencing the new VPC and defining the nested `interfaces.ipv4.nat_1_1` and `interfaces.ipv4.vpc` fields. This command should be run with debug mode enabled (`--debug`).

```bash
linode-cli linodes create \
  --label test-instance \
  --region us-mia \
  --image linode/alpine3.19 \
  --root_pass 'testp4ssw0rd!!!!!!23123' \
  --type g6-nanode-1 \
  --interfaces.primary true --interfaces.purpose vpc --interfaces.subnet_id ${SUBNET_ID} \
  --interfaces.ipv4.nat_1_1 any --interfaces.ipv4.vpc "10.0.1.5" \
  --debug
```

3. Observe that the API request contains the following structure for the interfaces field:

```bash
"interfaces": [{"purpose": "vpc", "primary": true, "subnet_id": 12345, "ipv4": {"vpc": "10.0.1.5", "nat_1_1": "any"}}]
```
