### PR TITLE
fix: Resolve issues with nested explicit list and null value serialization

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -7,7 +7,7 @@ import json
 import sys
 import time
 from sys import version_info
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
 import requests
 from packaging import version
@@ -15,7 +15,11 @@ from requests import Response
 
 from linodecli.helpers import API_CA_PATH
 
-from .baked.operation import ExplicitNullValue, OpenAPIOperation
+from .baked.operation import (
+    ExplicitEmptyListValue,
+    ExplicitNullValue,
+    OpenAPIOperation,
+)
 from .helpers import handle_url_overrides
 
 
@@ -199,6 +203,47 @@ def _build_request_url(ctx, operation, parsed_args) -> str:
     return result
 
 
+def _traverse_request_body(o: Any) -> Any:
+    """
+    This function traverses is intended to be called immediately before
+    request body serialization and contains special handling for dropping
+    keys with null values and translating ExplicitNullValue instances into
+    serializable null values.
+    """
+    if isinstance(o, dict):
+        result = {}
+        for k, v in o.items():
+            # Implicit null values should be dropped from the request
+            if v is None:
+                continue
+
+            # Values that are expected to be serialized as empty lists
+            # and explicit None values are converted here.
+            # See: operation.py
+            # NOTE: These aren't handled at the top-level of this function
+            # because we don't want them filtered out in the step above.
+            if isinstance(v, ExplicitEmptyListValue):
+                result[k] = []
+                continue
+
+            if isinstance(v, ExplicitNullValue):
+                result[k] = None
+                continue
+
+            value = _traverse_request_body(v)
+
+            # We should exclude implicit empty lists
+            if not (hasattr(value, "__len__") and len(value) < 1):
+                result[k] = value
+
+        return result
+
+    if isinstance(o, list):
+        return [_traverse_request_body(v) for v in o]
+
+    return o
+
+
 def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
     if operation.method == "get":
         # Get operations don't have a body
@@ -208,24 +253,10 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
     if ctx.defaults:
         parsed_args = ctx.config.update(parsed_args, operation.allowed_defaults)
 
-    to_json = {}
-
-    for k, v in vars(parsed_args).items():
-        # Skip null values
-        if v is None:
-            continue
-
-        # Explicitly include ExplicitNullValues
-        if isinstance(v, ExplicitNullValue):
-            to_json[k] = None
-            continue
-
-        to_json[k] = v
-
     expanded_json = {}
 
     # expand paths
-    for k, v in to_json.items():
+    for k, v in vars(parsed_args).items():
         cur = expanded_json
         for part in k.split(".")[:-1]:
             if part not in cur:
@@ -233,7 +264,7 @@ def _build_request_body(ctx, operation, parsed_args) -> Optional[str]:
             cur = cur[part]
         cur[k.split(".")[-1]] = v
 
-    return json.dumps(expanded_json)
+    return json.dumps(_traverse_request_body(expanded_json))
 
 
 def _print_request_debug_info(method, url, headers, body):

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -233,7 +233,7 @@ def _traverse_request_body(o: Any) -> Any:
             value = _traverse_request_body(v)
 
             # We should exclude implicit empty lists
-            if not (hasattr(value, "__len__") and len(value) < 1):
+            if not (isinstance(value, (dict, list)) and len(value) < 1):
                 result[k] = value
 
         return result

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -221,7 +221,7 @@ def _traverse_request_body(o: Any) -> Any:
             # and explicit None values are converted here.
             # See: operation.py
             # NOTE: These aren't handled at the top-level of this function
-            # because we don't want them filtered out in the step above.
+            # because we don't want them filtered out in the step below.
             if isinstance(v, ExplicitEmptyListValue):
                 result[k] = []
                 continue

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -60,6 +60,12 @@ class ExplicitNullValue:
     """
 
 
+class ExplicitEmptyListValue:
+    """
+    A special type used to explicitly pass empty lists to the API.
+    """
+
+
 def wrap_parse_nullable_value(arg_type):
     """
     A helper function to parse `null` as None for nullable CLI args.
@@ -91,9 +97,16 @@ class ArrayAction(argparse.Action):
 
         output_list = getattr(namespace, self.dest)
 
+        # If a user has already specified an [] but is specifying
+        # another value, assume "[]" was intended to be a literal.
+        if isinstance(output_list, ExplicitEmptyListValue):
+            setattr(namespace, self.dest, ["[]", values])
+            return
+
         # If the output list is empty and the user specifies a []
-        # argument, keep the list empty
+        # argument, set the list to an explicitly empty list.
         if values == "[]" and len(output_list) < 1:
+            setattr(namespace, self.dest, ExplicitEmptyListValue())
             return
 
         output_list.append(values)

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -120,3 +120,7 @@ components:
               field_int:
                 type: number
                 description: An arbitrary field.
+              nullable_string:
+                type: string
+                description: An arbitrary nullable string.
+                nullable: true

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,7 +1,7 @@
 import argparse
 
 from linodecli.baked import operation
-from linodecli.baked.operation import ExplicitNullValue
+from linodecli.baked.operation import ExplicitEmptyListValue, ExplicitNullValue
 
 
 class TestOperation:
@@ -178,11 +178,13 @@ class TestOperation:
                 "test3",
             ]
         )
+
         assert result.object_list == [
             {
                 "field_string": "test1",
                 "field_int": 123,
                 "field_dict": {"nested_string": "test2", "nested_int": 789},
+                "nullable_string": None,  # We expect this to be filtered out later
             },
             {"field_int": 456, "field_dict": {"nested_string": "test3"}},
         ]
@@ -209,7 +211,7 @@ class TestOperation:
 
         # User wants an explicitly empty list
         result = parser.parse_args(["--foo", "[]"])
-        assert getattr(result, "foo") == []
+        assert isinstance(getattr(result, "foo"), ExplicitEmptyListValue)
 
         # User doesn't specify the list
         result = parser.parse_args([])


### PR DESCRIPTION
## 📝 Description

This change resolves a few minor bugs related to how explicit list values (`[]`) and explicit null values (`null`) are serialized in request bodies when nested in a list.

The resolved issues are as follows:
- Explicit null values nested in object lists raised an `Object of type ExplicitNullValue is not JSON serializable` error
- Implicit null values were not automatically excluded from list objects

This PR specifically adds a new `_traverse_request_body` function that drops implicit null values and replaces ExplicitNullValue and ExplicitEmptyListValue with `None` and `[]` respectively.

## ✔️ How to Test

The following test steps all assume you have pulled down this code locally and run `make install`.

### Unit Testing

```bash
make testunit
```

### Integration Testing

```bash
make testint
```

### Manual Testing

1. Run the following CLI command to create an instance in debug mode with explicit null values for the `--interfaces.label` and `--interfaces.ipam_address` fields:

```bash
linode-cli linodes create \
  --backups_enabled false \
  --booted true \
  --image 'linode/alpine3.19' \
  --label test-instance \
  --private_ip false \
  --region us-ord \
  --root_pass 'f00b@r!!!!!00!0!!2135435439' \
  --type g6-nanode-1 \
  --interfaces.ipam_address null --interfaces.label null --interfaces.primary true --interfaces.purpose "public"
```

2. Ensure the API request body is as follows:

```json
{"image": "linode/alpine3.19", "root_pass": "f00b@r!!!!!00!0!!2135435439", "booted": true, "backups_enabled": false, "type": "g6-nanode-1", "region": "us-ord", "label": "test-instance", "private_ip": false, "interfaces": [{"label": null, "ipam_address": null, "purpose": "public", "primary": true}]}
```

3. Ensure the instance operation succeeds and the CLI exits with status 0.
