### PR TITLE
fix: Support specifying arrays nested in complex lists as JSON

### DIFF
--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -398,10 +398,20 @@ def action_help(cli, command, action):
                 if op.method in {"post", "put"} and arg.required
                 else ""
             )
-            nullable_fmt = " (nullable)" if arg.nullable else ""
-            print(
-                f"  --{arg.path}: {is_required}{arg.description}{nullable_fmt}"
+
+            extensions = []
+
+            if arg.format == "json":
+                extensions.append("JSON")
+
+            if arg.nullable:
+                extensions.append("nullable")
+
+            suffix = (
+                f" ({', '.join(extensions)})" if len(extensions) > 0 else ""
             )
+
+            print(f"  --{arg.path}: {is_required}{arg.description}{suffix}")
 
 
 def bake_command(cli, spec_loc):

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -50,6 +50,11 @@ class OpenAPIRequestArg:
             schema.extensions.get("linode-cli-format") or schema.format or None
         )
 
+        # If this is a deeply nested array we should treat it as JSON.
+        # This allows users to specify fields like --interfaces.ip_ranges.
+        if schema.type == "array" and list_parent is not None:
+            self.format = "json"
+
         #: The type accepted for this argument. This will ultimately determine what
         #: we accept in the ArgumentParser
         self.datatype = (

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -114,6 +114,11 @@ components:
                   nested_int:
                     type: number
                     description: A deeply nested integer.
+              field_array:
+                type: array
+                description: An arbitrary deeply nested array.
+                items:
+                  type: string
               field_string:
                 type: string
                 description: An arbitrary field.

--- a/tests/integration/linodes/test_interfaces.py
+++ b/tests/integration/linodes/test_interfaces.py
@@ -47,6 +47,8 @@ def linode_with_vpc_interface():
                 "any",
                 "--interfaces.ipv4.vpc",
                 "10.0.0.5",
+                "--interfaces.ip_ranges",
+                json.dumps(["10.0.0.6/32"]),
                 "--interfaces.purpose",
                 "public",
                 "--json",
@@ -89,6 +91,7 @@ def test_with_vpc_interface(linode_with_vpc_interface):
     assert vpc_interface["vpc_id"] == vpc_json["id"]
     assert vpc_interface["ipv4"]["vpc"] == "10.0.0.5"
     assert vpc_interface["ipv4"]["nat_1_1"] == linode_json["ipv4"][0]
+    assert vpc_interface["ip_ranges"][0] == "10.0.0.6/32"
 
     assert not public_interface["primary"]
     assert public_interface["purpose"] == "public"

--- a/tests/unit/test_arg_helpers.py
+++ b/tests/unit/test_arg_helpers.py
@@ -184,13 +184,22 @@ class TestArgParsing:
             {"lang": "CLI", "source": "linode-cli command action\n  --bar=foo"},
         ]
 
-        mocked_args = mocker.MagicMock()
-        mocked_args.read_only = False
-        mocked_args.required = True
-        mocked_args.path = "path"
-        mocked_args.description = "test description"
-
-        mocked_ops.args = [mocked_args]
+        mocked_ops.args = [
+            mocker.MagicMock(
+                read_only=False,
+                required=True,
+                path="path",
+                description="test description",
+            ),
+            mocker.MagicMock(
+                read_only=False,
+                required=False,
+                path="path2",
+                description="test description 2",
+                format="json",
+                nullable=True,
+            ),
+        ]
 
         mock_cli.find_operation = mocker.Mock(return_value=mocked_ops)
 
@@ -209,7 +218,9 @@ class TestArgParsing:
         ) in captured.out
         assert "Arguments" in captured.out
         assert "test description" in captured.out
+        assert "test description 2" in captured.out
         assert "(required)" in captured.out
+        assert "(JSON, nullable)" in captured.out
         assert "filter results" not in captured.out
 
     def test_action_help_get_method(self, capsys, mocker, mock_cli):

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 from linodecli.baked import operation
 from linodecli.baked.operation import ExplicitEmptyListValue, ExplicitNullValue
@@ -171,6 +172,8 @@ class TestOperation:
                 "test2",
                 "--object_list.field_dict.nested_int",
                 "789",
+                "--object_list.field_array",
+                json.dumps(["foo", "bar"]),
                 # Second object
                 "--object_list.field_int",
                 "456",
@@ -184,6 +187,7 @@ class TestOperation:
                 "field_string": "test1",
                 "field_int": 123,
                 "field_dict": {"nested_string": "test2", "nested_int": 789},
+                "field_array": ["foo", "bar"],
                 "nullable_string": None,  # We expect this to be filtered out later
             },
             {"field_int": 456, "field_dict": {"nested_string": "test3"}},


### PR DESCRIPTION
## 📝 Description

This change allows users to specify deeply nested array fields (e.g. `--interfaces.ip_ranges`) as JSON. These fields previously could not be specified at all due to limitations with how the CLI differentiates between objects in complex lists.

This PR also adds a new suffix for fields on command help pages that identifies whether an argument expects JSON.

**NOTE: The failing metadata plugin unit tests are not relevant to this PR and can be ignored, see TPT-2691.**

## ✔️ How to Test

The following test steps assume you have pulled down this change locally and run `make install`.

### E2E Testing

```bash
make INTEGRATION_TEST_PATH=linodes/test_interfaces.py testint
```

### Unit Testing

```bash
make testunit
```

### Manual Testing

1. Create a VPC and VPC subnet:

```bash
export VPC_ID=$(linode-cli vpcs create --label test-vpc --region us-mia --json | jq '.[0].id')
export SUBNET_ID=$(linode-cli vpcs subnet-create --label test-subnet --ipv4 '10.0.0.0/24' ${VPC_ID} --json | jq '.[0].id')
```

2. Attempt to create a Linode with an interface with an explicit `ip_ranges` field:

```bash
linode-cli linodes create \
  --label test-instance \
  --region us-mia \
  --image linode/alpine3.19 \
  --root_pass 'testp4ssw0rd!!!!!!23123' \
  --type g6-nanode-1 \
  --interfaces.primary true --interfaces.purpose vpc --interfaces.subnet_id ${SUBNET_ID} --interfaces.ip_ranges '["10.0.0.5/32"]' \
  --interfaces.purpose=public \
  --debug
```

3. Ensure the `ip_ranges` field has been properly included in the debug output request body.
4. Navigate to the instance in Cloud Manager and ensure all fields match the creation command.

## 📷 Preview

### Command Help Page

<img width="1696" alt="linode-cli_–_arg_helpers_py" src="https://github.com/linode/linode-cli/assets/114949949/d7ffcb0f-9846-4a67-8495-e352642c1493">
