### PR TITLE
new: Address breaking change in MDS plugin `sshkeys` command

### DIFF
--- a/linodecli/plugins/metadata.py
+++ b/linodecli/plugins/metadata.py
@@ -57,11 +57,16 @@ def print_ssh_keys_table(data):
     """
     table = Table(show_lines=True)
 
-    table.add_column("ssh keys")
+    table.add_column("user")
+    table.add_column("ssh key")
 
-    if data.users.root is not None:
-        for key in data.users.root:
-            table.add_row(key)
+    for name, keys in data.users.items():
+        # Keys will be None if no keys are configured for the user
+        if keys is None:
+            continue
+
+        for key in keys:
+            table.add_row(name, key)
 
     rprint(table)
 

--- a/tests/unit/test_plugin_metadata.py
+++ b/tests/unit/test_plugin_metadata.py
@@ -116,7 +116,9 @@ def test_ssh_key_table(capsys: CaptureFixture):
     print_ssh_keys_table(SSH_KEYS)
     captured_text = capsys.readouterr()
 
-    assert "ssh keys" in captured_text.out
+    assert "user" in captured_text.out
+    assert "ssh key" in captured_text.out
+    assert "root" in captured_text.out
     assert "ssh-key-1" in captured_text.out
     assert "ssh-key-2" in captured_text.out
 
@@ -125,4 +127,5 @@ def test_empty_ssh_key_table(capsys: CaptureFixture):
     print_ssh_keys_table(SSH_KEYS_EMPTY)
     captured_text = capsys.readouterr()
 
-    assert "ssh keys" in captured_text.out
+    assert "user" in captured_text.out
+    assert "ssh key" in captured_text.out


### PR DESCRIPTION
## 📝 Description

This change addresses a breaking change in the `metadata` plugin that caused the `sshkeys` command to raise an error. This breaking change was made in the Metadata SDK because the MDS can resolve the SSH keys of users configured using cloud-config and we are no longer limited to the root user.

To simply the formatting a bit, each row in the command output now represents a single key/user relationship.

## ✔️ How to Test

The following test steps assume you are on a development Linode, have pulled down this change, and have run `make install`.

### Unit Testing

```
make testunit
```

### Manual Testing

1. Run the following:

```
linode-cli metadata sshkeys
```

2. Ensure the output is similar to the preview below.

## 📷 Preview

<img width="1697" alt="linode-cli_–_metadata_py" src="https://github.com/linode/linode-cli/assets/114949949/be2b756a-9531-4f1c-8f41-7b92dd0ebe6b">
