### PR TITLE
Add `SKIP_BAKE` Argument to `bake` Target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ install: check-prerequisites requirements build
 
 .PHONY: bake
 bake: clean
+ifeq ($(SKIP_BAKE), 1)
+	@echo Skipping bake stage
+else
 	python3 -m linodecli bake ${SPEC} --skip-config
 	cp data-3 linodecli/
+endif
 
 .PHONY: build
 build: clean bake


### PR DESCRIPTION
## 📝 Description

This is to allow baking being skipped during `make build` or `make install`

## ✔️ How to Test

- Run `make build` to verified `bake` runs (`python3 -m linodecli bake` in the standard output)
- Run `SKIP_BAKE=1 make build` to verify `bake` doesn't run (`Skipping bake stage` in the standard output)