### PR TITLE
new: Add API spec version to User-Agent; add User-Agent to metadata plugin requests

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -6,7 +6,6 @@ import itertools
 import json
 import sys
 import time
-from sys import version_info
 from typing import Any, Iterable, List, Optional
 
 import requests
@@ -69,10 +68,7 @@ def do_request(
     headers = {
         "Authorization": f"Bearer {ctx.config.get_token()}",
         "Content-Type": "application/json",
-        "User-Agent": (
-            f"linode-cli:{ctx.version} "
-            f"python/{version_info[0]}.{version_info[1]}.{version_info[2]}"
-        ),
+        "User-Agent": ctx.user_agent,
     }
 
     parsed_args = operation.parse_args(args)

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -193,3 +193,10 @@ class CLI:  # pylint: disable=too-many-instance-attributes
 
         # Fail if no matching alias was found
         raise ValueError(f"No action {action} for command {command}")
+
+    @property
+    def user_agent(self) -> str:
+        """
+        Returns the User-Agent to use when making API requests.
+        """
+        return f"linode-cli/{self.version} linode-api-docs/{self.spec_version} python/{version_info[0]}.{version_info[1]}.{version_info[2]}"

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -199,4 +199,8 @@ class CLI:  # pylint: disable=too-many-instance-attributes
         """
         Returns the User-Agent to use when making API requests.
         """
-        return f"linode-cli/{self.version} linode-api-docs/{self.spec_version} python/{version_info[0]}.{version_info[1]}.{version_info[2]}"
+        return (
+            f"linode-cli/{self.version} "
+            f"linode-api-docs/{self.spec_version} "
+            f"python/{version_info[0]}.{version_info[1]}.{version_info[2]}"
+        )

--- a/linodecli/plugins/metadata.py
+++ b/linodecli/plugins/metadata.py
@@ -194,7 +194,7 @@ def get_metadata_parser():
     return parser
 
 
-def call(args, _):
+def call(args, context):
     """
     The entrypoint for this plugin
     """
@@ -209,7 +209,7 @@ def call(args, _):
     # make a client, but only if we weren't printing help and endpoint is valid
     if "--help" not in args:
         try:
-            client = MetadataClient()
+            client = MetadataClient(user_agent=context.client.user_agent)
         except ConnectTimeout as exc:
             raise ConnectionError(
                 "Can't access Metadata service. Please verify that you are inside a Linode."

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,7 +61,7 @@ def _get_parsed_spec(filename):
 
 @pytest.fixture
 def mock_cli(
-    version="DEVELOPMENT",
+    version="0.0.0",
     url="http://localhost",
     defaults=True,
 ):

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -337,6 +337,7 @@ class TestAPIRequest:
                     ]
                 }
             )
+            assert headers["User-Agent"] == mock_cli.user_agent
             assert "Authorization" in headers
             assert data is None
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -73,6 +73,11 @@ class TestCLI:
             mock_cli.find_operation("foo", "cool")
             mock_cli.find_operation("cool", "cool")
 
+    def test_user_agent(self, mock_cli: CLI):
+        assert re.compile(
+            r"linode-cli/[0-9]+\.[0-9]+\.[0-9]+ linode-api-docs/[0-9]+\.[0-9]+\.[0-9]+ python/[0-9]+\.[0-9]+\.[0-9]+"
+        ).match(mock_cli.user_agent)
+
 
 def test_get_all_pages(
     mock_cli: CLI, list_operation: OpenAPIOperation, monkeypatch: MonkeyPatch


### PR DESCRIPTION
## 📝 Description

This change updates the API request User-Agent to include the version of the API spec and updates the `metadata` plugin to include the CLI User-Agent in its requests.

Expected UA for generated CLI commands:

```
linode-cli/0.0.0 linode-api-docs/4.173.0 python/3.12.1
```

Expected UA for `metadata` plugin commands:

```
 linode-cli/0.0.0 linode-api-docs/4.173.0 python/3.12.1 linode-py-metadata/0.2.0
```

## ✔️ How to Test

The following test steps assume you have pulled this PR locally and run `make install`.

### Unit Testing

```
make testunit
```

### Manual Testing

**NOTE: These instructions do not include steps for testing the metadata plugin UA because the metadata SDK does not yet support debug outputs (see https://github.com/linode/py-metadata/pull/29).**

1. Run the following command:

```bash
linode-cli linodes ls --debug
```

2. Ensure the command runs as expected.
3. Ensure the User-Agent field in the debug output looks similar to the following:

```
> User-Agent: linode-cli/0.0.0 linode-api-docs/4.173.0 python/3.12.1
```

####
