### PR TITLE
ci: update labels and release drafter

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,4 @@
+# PR Labels
 - name: new-feature
   description: for new features in the changelog.
   color: 225fee
@@ -13,6 +14,9 @@
 - name: documentation
   description: for updates to the documentation in the changelog.
   color: d3e1e6
+- name: dependencies
+  description: dependency updates usually from dependabot
+  color: 5c9dff
 - name: testing
   description: for updates to the testing suite in the changelog.
   color: 933ac9
@@ -22,3 +26,13 @@
 - name: ignore-for-release
   description: PRs you do not want to render in the changelog
   color: 7b8eac
+- name: do-not-merge
+  description: PRs that should not be merged until the commented issue is resolved
+  color: eb1515
+# Issue Labels
+- name: enhancement
+  description: issues that request a enhancement
+  color: 22ee47
+- name: bug
+  description: issues that report a bug
+  color: ed8e21

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,31 @@
+name: labeler
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labeler.yml'
+  pull_request:
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labeler.yml'
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Run Labeler
+        uses: crazy-max/ghaction-github-labeler@de749cf181958193cb7debf1a9c5bb28922f3e1b
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          dry-run: ${{ github.event_name == 'pull_request' }}
+          exclude: |
+            help*
+            *issue


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Updates to use githubs built in release notes and using the following labels.

`**NOTE**: The labeler job is dry running on the PR to show what it will do, doesn't execute until we merge.`

### ⚠️  Breaking Change
breaking-change: any changes that break end users or downstream workflows
### 🐛 Bug Fixes
bugfix: changes that fix a existing bug
### 🚀 New Features
new-feature: changes that add new features such as endpoints or tools
### 💡 Improvements
improvement: changes that improve existing features or reflect small API changes
### 🧪 Testing Improvements
testing: improvements to the testing workflows
### ⚙️  Repo/CI Improvements
repo-ci-improvement: improvements to the CI workflow, like this PR!
### 📖 Documentation
documentation: updates to the package/repo documentation or wiki
### 📦 Dependency Updates
dependencies: Used by dependabot mostly
### Ignore For Release
ignore-for-release: for PRs you dont want rendered in the changelog, usually the release merge to main