### PR TITLE
test: Update outdated backup test and address test warnings messages 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for more convenient building of the Linode CLI and its baked content
 #
-INTEGRATION_TEST_PATH :=
+MODULE :=
 TEST_CASE_COMMAND :=
 
 ifdef TEST_CASE
@@ -62,7 +62,7 @@ testunit:
 
 .PHONY: testint
 testint:
-	pytest tests/integration/${INTEGRATION_TEST_PATH} ${TEST_CASE_COMMAND} --disable-warnings
+	pytest tests/integration/${MODULE} ${TEST_CASE_COMMAND}
 
 .PHONY: testall
 testall:
@@ -89,4 +89,4 @@ format: black isort autoflake
 
 @PHONEY: smoketest
 smoketest:
-	pytest -m smoke tests/integration --disable-warnings
+	pytest -m smoke tests/integration

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -443,3 +443,10 @@ def create_vpc_w_subnet():
     )[0]
 
     return vpc_json
+
+
+@pytest.mark.smoke
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "smoke: mark test as part of smoke test suite"
+    )

--- a/tests/integration/linodes/helpers_linodes.py
+++ b/tests/integration/linodes/helpers_linodes.py
@@ -245,7 +245,7 @@ def create_linode_and_wait(
     return linode_id
 
 
-def set_backups_enabled_in_account_settings(toggle: "bool"):
+def set_backups_enabled_in_account_settings(toggle: bool):
     command = [
         "linode-cli",
         "account",


### PR DESCRIPTION
## 📝 Description

In this pull request, several improvements are made:
- outdated backup test is updated to reflect the requirement of setting `backups_enabled` in account settings before executing the backup test
-  usage of INTEGRATION_TEST_PATH is replaced with MODULE for better clarity when running tests against specific modules
- All warning messages in int/smoke tests are addressed

## ✔️ How to Test

`make TEST_CASE="test_create_linode_with_backup_disabled" testint`
`make smoketest`
`make MODULE=account testint`