### PR TITLE
new: update pyenv to use environment name

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+linode-cli


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Updates `pyenv` to point to local environment setup by devenv.
