### PR TITLE
test: Add skip for backup test for managed test accounts

### DIFF
--- a/tests/integration/cli/test_host_overrides.py
+++ b/tests/integration/cli/test_host_overrides.py
@@ -11,7 +11,10 @@ def test_cli_command_fails_to_access_invalid_host(monkeypatch: MonkeyPatch):
     process = exec_failing_test_command(["linode-cli", "linodes", "ls"])
     output = process.stderr.decode()
 
-    assert "Max retries exceeded with url: //wrongapi.linode.com" in output
+    expected_output = ["Max retries exceeded with url:", "wrongapi.linode.com"]
+
+    for eo in expected_output:
+        assert eo in output
 
 
 def test_cli_uses_v4beta_when_override_is_set(monkeypatch: MonkeyPatch):

--- a/tests/integration/linodes/test_backups.py
+++ b/tests/integration/linodes/test_backups.py
@@ -61,7 +61,7 @@ def check_account_settings():
 
 
 @pytest.mark.skipif(
-    check_account_settings(), reason="Condition is true, skipping the test."
+    check_account_settings(), reason="Account is managed, skipping the test.."
 )
 def test_create_linode_with_backup_disabled(
     create_linode_backup_disabled_setup,

--- a/tests/integration/linodes/test_backups.py
+++ b/tests/integration/linodes/test_backups.py
@@ -44,6 +44,25 @@ def create_linode_backup_disabled_setup():
     delete_target_id("linodes", linode_id)
 
 
+def check_account_settings():
+    result = exec_test_command(
+        [
+            "linode-cli",
+            "account",
+            "settings",
+            "--text",
+            "--format",
+            "managed",
+            "--no-headers",
+        ]
+    ).stdout.decode()
+
+    return result
+
+
+@pytest.mark.skipif(
+    check_account_settings(), reason="Condition is true, skipping the test."
+)
 def test_create_linode_with_backup_disabled(
     create_linode_backup_disabled_setup,
 ):


### PR DESCRIPTION
## 📝 Description

Adding skip to backup tests as `backups_enabled` setting does not apply to accounts that are managed

TOD Link - http://198.19.5.79:1212/tests?team=DX&buildName=linode-cli&bld_id=664babc93caad400014ecda6&testcaseName=test_create_linode_with_backup_disabled

## ✔️ How to Test

1. Log into account that is managed (e.g. cli testing account)

2. ` make TEST_CASE="test_create_linode_with_backup_disabled" testint -s `

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**