### PR TITLE
Wrap output args helpers and create `output` module

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -13,6 +13,7 @@ from rich import print as rprint
 from rich.table import Column, Table
 
 from linodecli import plugins
+from linodecli.output.helpers import configure_output_handler
 
 from .arg_helpers import (
     bake_command,
@@ -32,7 +33,7 @@ from .help_pages import (
     print_help_plugins,
 )
 from .helpers import handle_url_overrides
-from .output import OutputMode
+from .output.output_handler import OutputMode
 from .version import __version__
 
 VERSION = __version__
@@ -64,53 +65,18 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     )
     parsed, args = register_args(parser).parse_known_args()
 
-    # output/formatting settings
-    if parsed.text:
-        cli.output_handler.mode = OutputMode.delimited
-    elif parsed.json:
-        cli.output_handler.mode = OutputMode.json
-        cli.output_handler.columns = "*"
-    elif parsed.markdown:
-        cli.output_handler.mode = OutputMode.markdown
-    elif parsed.ascii_table:
-        cli.output_handler.mode = OutputMode.ascii_table
+    configure_output_handler(parsed, cli.output_handler, cli.suppress_warnings)
 
-    if parsed.delimiter:
-        cli.output_handler.delimiter = parsed.delimiter
-    if parsed.pretty:
-        cli.output_handler.mode = OutputMode.json
-        cli.output_handler.pretty_json = True
-        cli.output_handler.columns = "*"
-    if parsed.no_headers:
-        cli.output_handler.headers = False
     if parsed.all_rows:
         cli.pagination = False
-    elif parsed.format:
-        cli.output_handler.columns = parsed.format
 
     cli.defaults = not parsed.no_defaults
     cli.retry_count = 0
     cli.no_retry = parsed.no_retry
     cli.suppress_warnings = parsed.suppress_warnings
-
-    if parsed.all_columns or parsed.all:
-        if parsed.all and not cli.suppress_warnings:
-            print(
-                "WARNING: '--all' is a deprecated flag, "
-                "and will be removed in a future version. "
-                "Please consider use '--all-columns' instead."
-            )
-        cli.output_handler.columns = "*"
-
     cli.page = parsed.page
     cli.page_size = parsed.page_size
     cli.debug_request = parsed.debug
-
-    cli.output_handler.suppress_warnings = parsed.suppress_warnings
-    cli.output_handler.disable_truncation = parsed.no_truncation
-    cli.output_handler.column_width = parsed.column_width
-    cli.output_handler.single_table = parsed.single_table
-    cli.output_handler.tables = parsed.table
 
     if parsed.as_user and not skip_config:
         cli.config.set_user(parsed.as_user)

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -12,10 +12,11 @@ import yaml
 
 from linodecli import plugins
 from linodecli.helpers import (
-    pagination_args_shared,
     register_args_shared,
     register_debug_arg,
+    register_pagination_args_shared,
 )
+from linodecli.output.helpers import register_output_args_shared
 
 
 def register_args(parser):
@@ -41,98 +42,20 @@ def register_args(parser):
         action="store_true",
         help="Display information about a command, action, or the CLI overall.",
     )
-    parser.add_argument(
-        "--text",
-        action="store_true",
-        help="Display text output with a delimiter (defaults to tabs).",
-    )
-    parser.add_argument(
-        "--delimiter",
-        metavar="DELIMITER",
-        type=str,
-        help="The delimiter when displaying raw output.",
-    )
-    parser.add_argument(
-        "--json", action="store_true", help="Display output as JSON."
-    )
-    parser.add_argument(
-        "--markdown",
-        action="store_true",
-        help="Display output in Markdown format.",
-    )
-    parser.add_argument(
-        "--ascii-table",
-        action="store_true",
-        help="Display output in an ASCII table.",
-    )
-    parser.add_argument(
-        "--pretty",
-        action="store_true",
-        help="If set, pretty-print JSON output.",
-    )
-    parser.add_argument(
-        "--no-headers",
-        action="store_true",
-        help="If set, does not display headers in output.",
-    )
-    parser.add_argument(
-        "--all",
-        action="store_true",
-        help=(
-            "Deprecated flag. An alias of '--all-columns', "
-            "scheduled to be removed in a future version."
-        ),
-    )
-    parser.add_argument(
-        "--all-columns",
-        action="store_true",
-        help=(
-            "If set, displays all possible columns instead of "
-            "the default columns. This may not work well on some terminals."
-        ),
-    )
-    parser.add_argument(
-        "--format",
-        metavar="FORMAT",
-        type=str,
-        help="The columns to display in output. Provide a comma-"
-        "separated list of column names.",
-    )
+
     parser.add_argument(
         "--no-defaults",
         action="store_true",
         help="Suppress default values for arguments.  Default values "
         "are configured on initial setup or with linode-cli configure",
     )
-    parser.add_argument(
-        "--no-truncation",
-        action="store_true",
-        default=False,
-        help="Prevent the truncation of long values in command outputs.",
-    )
+
     parser.add_argument(
         "--no-retry",
         action="store_true",
         help="Skip retrying on common errors like timeouts.",
     )
-    parser.add_argument(
-        "--single-table",
-        action="store_true",
-        help="Disable printing multiple tables for complex API responses.",
-    )
-    parser.add_argument(
-        "--table",
-        type=str,
-        action="append",
-        help="The specific table(s) to print in output of a command.",
-    )
-    parser.add_argument(
-        "--column-width",
-        type=int,
-        default=None,
-        help="Sets the maximum width of each column in outputted tables. "
-        "By default, columns are dynamically sized to fit the terminal.",
-    )
+
     parser.add_argument(
         "--version",
         "-v",
@@ -140,7 +63,8 @@ def register_args(parser):
         help="Prints version information and exits.",
     )
 
-    pagination_args_shared(parser)
+    register_output_args_shared(parser)
+    register_pagination_args_shared(parser)
     register_args_shared(parser)
     register_debug_arg(parser)
 

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -18,7 +18,7 @@ from openapi3.paths import Operation
 
 from linodecli.baked.request import OpenAPIFilteringRequest, OpenAPIRequest
 from linodecli.baked.response import OpenAPIResponse
-from linodecli.output import OutputHandler
+from linodecli.output.output_handler import OutputHandler
 from linodecli.overrides import OUTPUT_OVERRIDES
 
 

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -9,10 +9,10 @@ from sys import version_info
 
 from openapi3 import OpenAPI
 
-from .api_request import do_request, get_all_pages
-from .baked import OpenAPIOperation
-from .configuration import CLIConfig
-from .output import OutputHandler, OutputMode
+from linodecli.api_request import do_request, get_all_pages
+from linodecli.baked import OpenAPIOperation
+from linodecli.configuration import CLIConfig
+from linodecli.output.output_handler import OutputHandler, OutputMode
 
 METHODS = ("get", "post", "put", "delete")
 

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -39,7 +39,7 @@ def handle_url_overrides(
     ).geturl()
 
 
-def pagination_args_shared(parser: ArgumentParser):
+def register_pagination_args_shared(parser: ArgumentParser):
     """
     Add pagination related arguments to the given
     ArgumentParser that may be shared across the CLI and plugins.

--- a/linodecli/output/helpers.py
+++ b/linodecli/output/helpers.py
@@ -1,0 +1,135 @@
+from argparse import ArgumentParser, Namespace
+
+from linodecli.output.output_handler import OutputHandler, OutputMode
+
+
+def register_output_args_shared(parser: ArgumentParser):
+    parser.add_argument(
+        "--text",
+        action="store_true",
+        help="Display text output with a delimiter (defaults to tabs).",
+    )
+    parser.add_argument(
+        "--delimiter",
+        metavar="DELIMITER",
+        type=str,
+        help="The delimiter when displaying raw output.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Display output as JSON."
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Display output in Markdown format.",
+    )
+
+    parser.add_argument(
+        "--ascii-table",
+        action="store_true",
+        help="Display output in an ASCII table.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="If set, pretty-print JSON output.",
+    )
+    parser.add_argument(
+        "--no-headers",
+        action="store_true",
+        help="If set, does not display headers in output.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "Deprecated flag. An alias of '--all-columns', "
+            "scheduled to be removed in a future version."
+        ),
+    )
+    parser.add_argument(
+        "--all-columns",
+        action="store_true",
+        help=(
+            "If set, displays all possible columns instead of "
+            "the default columns. This may not work well on some terminals."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        metavar="FORMAT",
+        type=str,
+        help="The columns to display in output. Provide a comma-"
+        "separated list of column names.",
+    )
+    parser.add_argument(
+        "--no-truncation",
+        action="store_true",
+        default=False,
+        help="Prevent the truncation of long values in command outputs.",
+    )
+    parser.add_argument(
+        "--single-table",
+        action="store_true",
+        help="Disable printing multiple tables for complex API responses.",
+    )
+    parser.add_argument(
+        "--table",
+        type=str,
+        action="append",
+        help="The specific table(s) to print in output of a command.",
+    )
+    parser.add_argument(
+        "--column-width",
+        type=int,
+        default=None,
+        help="Sets the maximum width of each column in outputted tables. "
+        "By default, columns are dynamically sized to fit the terminal.",
+    )
+
+
+def get_output_handler(parsed: Namespace, suppress_warnings: bool = False):
+    output_handler = OutputHandler()
+    configure_output_handler(parsed, output_handler, suppress_warnings)
+
+
+def configure_output_handler(
+    parsed: Namespace,
+    output_handler: OutputHandler,
+    suppress_warnings: bool = False,
+):
+    if parsed.text:
+        output_handler.mode = OutputMode.delimited
+    elif parsed.json:
+        output_handler.mode = OutputMode.json
+        output_handler.columns = "*"
+    elif parsed.markdown:
+        output_handler.mode = OutputMode.markdown
+    elif parsed.ascii_table:
+        output_handler.mode = OutputMode.ascii_table
+
+    if parsed.delimiter:
+        output_handler.delimiter = parsed.delimiter
+    if parsed.pretty:
+        output_handler.mode = OutputMode.json
+        output_handler.pretty_json = True
+        output_handler.columns = "*"
+    if parsed.no_headers:
+        output_handler.headers = False
+
+    output_handler.suppress_warnings = parsed.suppress_warnings
+    output_handler.disable_truncation = parsed.no_truncation
+    output_handler.column_width = parsed.column_width
+    output_handler.single_table = parsed.single_table
+    output_handler.tables = parsed.table
+
+    if parsed.all_columns or parsed.all:
+        if parsed.all and not suppress_warnings:
+            print(
+                "WARNING: '--all' is a deprecated flag, "
+                "and will be removed in a future version. "
+                "Please consider use '--all-columns' instead."
+            )
+        output_handler.columns = "*"
+    elif parsed.format:
+        output_handler.columns = parsed.format

--- a/linodecli/output/output_handler.py
+++ b/linodecli/output/output_handler.py
@@ -4,7 +4,7 @@ Handles formatting the output of commands used in Linode CLI
 
 import copy
 import json
-from enum import Enum
+from enum import Enum, auto
 from sys import stdout
 from typing import IO, Any, Dict, List, Optional, Union, cast
 
@@ -21,11 +21,11 @@ class OutputMode(Enum):
     Enum for output modes
     """
 
-    table = 1
-    delimited = 2
-    json = 3
-    markdown = 4
-    ascii_table = 5
+    table = auto()
+    delimited = auto()
+    json = auto()
+    markdown = auto()
+    ascii_table = auto()
 
 
 class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance-attributes

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -12,7 +12,7 @@ from rich.align import Align
 from rich.console import Console
 from rich.table import Table
 
-from linodecli.output import OutputMode
+from linodecli.output.output_handler import OutputMode
 
 OUTPUT_OVERRIDES = {}
 

--- a/linodecli/plugins/obj/list.py
+++ b/linodecli/plugins/obj/list.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 
 from rich import print as rprint
 
-from linodecli.helpers import pagination_args_shared
+from linodecli.helpers import register_pagination_args_shared
 from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import PLUGIN_BASE
 from linodecli.plugins.obj.helpers import (
@@ -31,7 +31,7 @@ def list_objects_or_buckets(
     Lists buckets or objects
     """
     parser = inherit_plugin_args(ArgumentParser(PLUGIN_BASE + " ls"))
-    pagination_args_shared(parser)
+    register_pagination_args_shared(parser)
 
     parser.add_argument(
         "bucket",
@@ -130,7 +130,7 @@ def list_all_objects(
     """
     # this is for printing help when --help is in the args
     parser = inherit_plugin_args(ArgumentParser(PLUGIN_BASE + " la"))
-    pagination_args_shared(parser)
+    register_pagination_args_shared(parser)
 
     parsed = parser.parse_args(args)
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,6 +1,9 @@
 from argparse import ArgumentParser
 
-from linodecli.helpers import pagination_args_shared, register_args_shared
+from linodecli.helpers import (
+    register_args_shared,
+    register_pagination_args_shared,
+)
 
 
 class TestHelpers:
@@ -10,7 +13,7 @@ class TestHelpers:
 
     def test_pagination_args_shared(self):
         parser = ArgumentParser()
-        pagination_args_shared(parser)
+        register_pagination_args_shared(parser)
 
         args = parser.parse_args(
             ["--page", "2", "--page-size", "50", "--all-rows"]


### PR DESCRIPTION
## 📝 Description

This is to wrap up the reusable output classes and function for sharing with plugins

## ✔️ How to Test

```bash
make testunit
```

```bash
make smoketest
```

You can also try different output format arguments, for examples:
```bash
linode-cli kernels list --json --pretty 
```

```bash
linode-cli kernels list --ascii-table
```

```bash
linode-cli kernels list --delimiter , --text
```