### PR TITLE
test: Add Linode Cloud Firewall for all test linode instances

### DIFF
--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: make INTEGRATION_TEST_PATH="${{ inputs.test_path }}" TEST_ARGS="-s" MODULE="ssh" testint
+      - run: make INTEGRATION_TEST_PATH="${{ inputs.test_path }}" testint
         if: ${{ steps.validate-tests.outputs.match == '' }}
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}

--- a/.github/workflows/e2e-suite-pr.yml
+++ b/.github/workflows/e2e-suite-pr.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: make INTEGRATION_TEST_PATH="${{ inputs.test_path }}" testint
+      - run: make INTEGRATION_TEST_PATH="${{ inputs.test_path }}" TEST_ARGS="-s" MODULE="ssh" testint
         if: ${{ steps.validate-tests.outputs.match == '' }}
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,7 @@ def linode_cloud_firewall():
 
     def get_public_ip(ip_version="ipv4"):
         url = (
-            f"https://api6.ipify.org?format=json"
+            f"https://api64.ipify.org?format=json"
             if ip_version == "ipv6"
             else f"https://api.ipify.org?format=json"
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -69,10 +69,10 @@ def linode_cloud_firewall():
                 "action": "ACCEPT",
             }
         ]
-        if is_valid_ipv4(ipv4_address):  # Check if ipv6_address is not empty
+        if is_valid_ipv4(ipv4_address):
             rule[0]["addresses"]["ipv4"] = [f"{ipv4_address}/32"]
 
-        if is_valid_ipv6(ipv6_address):  # Check if ipv6_address is not empty
+        if is_valid_ipv6(ipv6_address):
             rule[0]["addresses"]["ipv6"] = [f"{ipv6_address}/128"]
 
         return json.dumps(rule, indent=4)
@@ -85,29 +85,27 @@ def linode_cloud_firewall():
 
     label = "cloud_firewall_" + str(int(time.time()))
 
-    firewall_id = (
-        exec_test_command(
-            [
-                "linode-cli",
-                "firewalls",
-                "create",
-                "--label",
-                label,
-                "--rules.outbound_policy",
-                "ACCEPT",
-                "--rules.inbound_policy",
-                "DROP",
-                "--rules.inbound",
-                inbound_rule,
-                "--text",
-                "--no-headers",
-                "--format",
-                "id",
-            ]
-        )
-        .stdout.decode()
-        .rstrip()
-    )
+    # Base command list
+    command = [
+        "linode-cli",
+        "firewalls",
+        "create",
+        "--label",
+        label,
+        "--rules.outbound_policy",
+        "ACCEPT",
+        "--rules.inbound_policy",
+        "DROP",
+        "--text",
+        "--no-headers",
+        "--format",
+        "id",
+    ]
+
+    if is_valid_ipv4(ipv4_address) or is_valid_ipv6(ipv6_address):
+        command.extend(["--rules.inbound", inbound_rule])
+
+    firewall_id = exec_test_command(command).stdout.decode().rstrip()
 
     yield firewall_id
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -63,6 +63,8 @@ def linode_cloud_firewall():
     ipv4_address = get_public_ip("ipv4")
     ipv6_address = get_public_ip("ipv6")
 
+    print("IP:::", ipv4_address, ipv6_address)
+
     inbound_rule = create_inbound_rule(ipv4_address, ipv6_address)
 
     label = "cloud_firewall_" + str(int(time.time()))

--- a/tests/integration/firewalls/test_firewalls.py
+++ b/tests/integration/firewalls/test_firewalls.py
@@ -15,7 +15,6 @@ FIREWALL_LABEL = "label-fw-test" + str(int(time.time()))
 
 @pytest.fixture
 def test_firewall_id():
-    # Create one domain for some tests in this suite
     firewall_id = (
         exec_test_command(
             BASE_CMD
@@ -38,7 +37,7 @@ def test_firewall_id():
     )
 
     yield firewall_id
-    # teardown - delete all firewalls
+
     delete_target_id(target="firewalls", id=firewall_id)
 
 

--- a/tests/integration/linodes/helpers_linodes.py
+++ b/tests/integration/linodes/helpers_linodes.py
@@ -71,7 +71,7 @@ def wait_until(linode_id: "str", timeout, status: "str", period=5):
     return False
 
 
-def create_linode(test_region=DEFAULT_REGION):
+def create_linode(firewall_id: "str", test_region=DEFAULT_REGION):
     # create linode
     linode_id = (
         exec_test_command(
@@ -87,6 +87,8 @@ def create_linode(test_region=DEFAULT_REGION):
                 DEFAULT_TEST_IMAGE,
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
+                "--firewall_id",
+                firewall_id,
                 "--format=id",
                 "--text",
                 "--no-headers",
@@ -99,7 +101,9 @@ def create_linode(test_region=DEFAULT_REGION):
     return linode_id
 
 
-def create_linode_backup_disabled(test_region=DEFAULT_REGION):
+def create_linode_backup_disabled(
+    firewall_id: "str", test_region=DEFAULT_REGION
+):
     result = set_backups_enabled_in_account_settings(toggle=False)
 
     # create linode
@@ -117,6 +121,8 @@ def create_linode_backup_disabled(test_region=DEFAULT_REGION):
                 DEFAULT_TEST_IMAGE,
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
+                "--firewall_id",
+                firewall_id,
                 "--format=id",
                 "--text",
                 "--no-headers",
@@ -172,9 +178,10 @@ def remove_linodes():
 
 
 def create_linode_and_wait(
+    firewall_id: "str",
+    ssh_key="",
     test_plan=DEFAULT_LINODE_TYPE,
     test_image=DEFAULT_TEST_IMAGE,
-    ssh_key="",
     test_region=DEFAULT_REGION,
 ):
     linode_type = test_plan
@@ -200,6 +207,8 @@ def create_linode_and_wait(
                     DEFAULT_RANDOM_PASS,
                     "--authorized_keys",
                     ssh_key,
+                    "--firewall_id",
+                    firewall_id,
                     "--format=id",
                     "--backups_enabled",
                     "true",
@@ -225,6 +234,8 @@ def create_linode_and_wait(
                     test_image,
                     "--root_pass",
                     DEFAULT_RANDOM_PASS,
+                    "--firewall_id",
+                    firewall_id,
                     "--format=id",
                     "--backups_enabled",
                     "true",

--- a/tests/integration/linodes/test_backups.py
+++ b/tests/integration/linodes/test_backups.py
@@ -20,8 +20,8 @@ snapshot_label = "test_snapshot1"
 
 
 @pytest.fixture
-def create_linode_setup(cloud_init_firewall):
-    linode_id = create_linode(firewall_id=cloud_init_firewall)
+def create_linode_setup(linode_cloud_firewall):
+    linode_id = create_linode(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 
@@ -29,7 +29,7 @@ def create_linode_setup(cloud_init_firewall):
 
 
 @pytest.fixture
-def create_linode_backup_disabled_setup(cloud_init_firewall):
+def create_linode_backup_disabled_setup(linode_cloud_firewall):
     res = set_backups_enabled_in_account_settings(toggle=False)
 
     if res == "True":
@@ -37,7 +37,7 @@ def create_linode_backup_disabled_setup(cloud_init_firewall):
             "Backups are unexpectedly enabled before setting up the test."
         )
 
-    linode_id = create_linode_backup_disabled(firewall_id=cloud_init_firewall)
+    linode_id = create_linode_backup_disabled(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_backups.py
+++ b/tests/integration/linodes/test_backups.py
@@ -20,8 +20,8 @@ snapshot_label = "test_snapshot1"
 
 
 @pytest.fixture
-def create_linode_setup():
-    linode_id = create_linode()
+def create_linode_setup(cloud_init_firewall):
+    linode_id = create_linode(firewall_id=cloud_init_firewall)
 
     yield linode_id
 
@@ -29,7 +29,7 @@ def create_linode_setup():
 
 
 @pytest.fixture
-def create_linode_backup_disabled_setup():
+def create_linode_backup_disabled_setup(cloud_init_firewall):
     res = set_backups_enabled_in_account_settings(toggle=False)
 
     if res == "True":
@@ -37,7 +37,7 @@ def create_linode_backup_disabled_setup():
             "Backups are unexpectedly enabled before setting up the test."
         )
 
-    linode_id = create_linode_backup_disabled()
+    linode_id = create_linode_backup_disabled(firewall_id=cloud_init_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_interfaces.py
+++ b/tests/integration/linodes/test_interfaces.py
@@ -18,7 +18,7 @@ linode_label = DEFAULT_LABEL + timestamp
 
 
 @pytest.fixture
-def linode_with_vpc_interface():
+def linode_with_vpc_interface(cloud_init_firewall):
     vpc_json = create_vpc_w_subnet()
 
     vpc_region = vpc_json["region"]
@@ -38,6 +38,8 @@ def linode_with_vpc_interface():
                 DEFAULT_TEST_IMAGE,
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
+                "--firewall_id",
+                cloud_init_firewall,
                 "--interfaces.purpose",
                 "vpc",
                 "--interfaces.primary",
@@ -67,7 +69,7 @@ def linode_with_vpc_interface():
 
 
 @pytest.fixture
-def linode_with_vpc_interface_as_json():
+def linode_with_vpc_interface_as_json(cloud_init_firewall):
     vpc_json = create_vpc_w_subnet()
 
     vpc_region = vpc_json["region"]
@@ -87,6 +89,8 @@ def linode_with_vpc_interface_as_json():
                 DEFAULT_TEST_IMAGE,
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
+                "--firewall_id",
+                cloud_init_firewall,
                 "--interfaces",
                 json.dumps(
                     [

--- a/tests/integration/linodes/test_interfaces.py
+++ b/tests/integration/linodes/test_interfaces.py
@@ -18,7 +18,7 @@ linode_label = DEFAULT_LABEL + timestamp
 
 
 @pytest.fixture
-def linode_with_vpc_interface(cloud_init_firewall):
+def linode_with_vpc_interface(linode_cloud_firewall):
     vpc_json = create_vpc_w_subnet()
 
     vpc_region = vpc_json["region"]
@@ -39,7 +39,7 @@ def linode_with_vpc_interface(cloud_init_firewall):
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--interfaces.purpose",
                 "vpc",
                 "--interfaces.primary",
@@ -69,7 +69,7 @@ def linode_with_vpc_interface(cloud_init_firewall):
 
 
 @pytest.fixture
-def linode_with_vpc_interface_as_json(cloud_init_firewall):
+def linode_with_vpc_interface_as_json(linode_cloud_firewall):
     vpc_json = create_vpc_w_subnet()
 
     vpc_region = vpc_json["region"]
@@ -90,7 +90,7 @@ def linode_with_vpc_interface_as_json(cloud_init_firewall):
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--interfaces",
                 json.dumps(
                     [

--- a/tests/integration/linodes/test_linodes.py
+++ b/tests/integration/linodes/test_linodes.py
@@ -21,7 +21,7 @@ linode_label = DEFAULT_LABEL + timestamp
 
 
 @pytest.fixture(scope="package", autouse=True)
-def setup_linodes(cloud_init_firewall):
+def setup_linodes(linode_cloud_firewall):
     linode_id = (
         exec_test_command(
             BASE_CMD
@@ -38,7 +38,7 @@ def setup_linodes(cloud_init_firewall):
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--text",
                 "--delimiter",
                 ",",

--- a/tests/integration/linodes/test_linodes.py
+++ b/tests/integration/linodes/test_linodes.py
@@ -21,7 +21,7 @@ linode_label = DEFAULT_LABEL + timestamp
 
 
 @pytest.fixture(scope="package", autouse=True)
-def setup_linodes():
+def setup_linodes(cloud_init_firewall):
     linode_id = (
         exec_test_command(
             BASE_CMD
@@ -37,6 +37,8 @@ def setup_linodes():
                 linode_label,
                 "--root_pass",
                 DEFAULT_RANDOM_PASS,
+                "--firewall_id",
+                cloud_init_firewall,
                 "--text",
                 "--delimiter",
                 ",",

--- a/tests/integration/linodes/test_power_status.py
+++ b/tests/integration/linodes/test_power_status.py
@@ -10,8 +10,8 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture
-def test_linode_id(cloud_init_firewall):
-    linode_id = create_linode(firewall_id=cloud_init_firewall)
+def test_linode_id(linode_cloud_firewall):
+    linode_id = create_linode(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 
@@ -19,8 +19,8 @@ def test_linode_id(cloud_init_firewall):
 
 
 @pytest.fixture
-def create_linode_in_running_state(cloud_init_firewall):
-    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
+def create_linode_in_running_state(linode_cloud_firewall):
+    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_power_status.py
+++ b/tests/integration/linodes/test_power_status.py
@@ -10,8 +10,8 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture
-def test_linode_id():
-    linode_id = create_linode()
+def test_linode_id(cloud_init_firewall):
+    linode_id = create_linode(firewall_id=cloud_init_firewall)
 
     yield linode_id
 
@@ -19,8 +19,8 @@ def test_linode_id():
 
 
 @pytest.fixture
-def create_linode_in_running_state():
-    linode_id = create_linode_and_wait()
+def create_linode_in_running_state(cloud_init_firewall):
+    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_rebuild.py
+++ b/tests/integration/linodes/test_rebuild.py
@@ -16,8 +16,8 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture
-def test_linode_id(cloud_init_firewall):
-    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
+def test_linode_id(linode_cloud_firewall):
+    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_rebuild.py
+++ b/tests/integration/linodes/test_rebuild.py
@@ -16,8 +16,8 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture
-def test_linode_id():
-    linode_id = create_linode_and_wait()
+def test_linode_id(cloud_init_firewall):
+    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
 
     yield linode_id
 

--- a/tests/integration/linodes/test_resize.py
+++ b/tests/integration/linodes/test_resize.py
@@ -15,7 +15,7 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture(scope="session")
-def test_linode_id():
+def test_linode_id(cloud_init_firewall):
     plan = (
         exec_test_command(
             [
@@ -32,7 +32,9 @@ def test_linode_id():
         .rstrip()
         .splitlines()[1]
     )
-    linode_id = create_linode_and_wait(test_plan=plan)
+    linode_id = create_linode_and_wait(
+        firewall_id=cloud_init_firewall, test_plan=plan
+    )
 
     yield linode_id
 

--- a/tests/integration/linodes/test_resize.py
+++ b/tests/integration/linodes/test_resize.py
@@ -15,7 +15,7 @@ from tests.integration.linodes.helpers_linodes import (
 
 
 @pytest.fixture(scope="session")
-def test_linode_id(cloud_init_firewall):
+def test_linode_id(linode_cloud_firewall):
     plan = (
         exec_test_command(
             [
@@ -33,7 +33,7 @@ def test_linode_id(cloud_init_firewall):
         .splitlines()[1]
     )
     linode_id = create_linode_and_wait(
-        firewall_id=cloud_init_firewall, test_plan=plan
+        firewall_id=linode_cloud_firewall, test_plan=plan
     )
 
     yield linode_id

--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -11,12 +11,6 @@ from tests.integration.helpers import (
 BASE_CMD = ["linode-cli", "lke"]
 
 
-@pytest.fixture(autouse=True)
-def clean_up_clusters():
-    yield "setup"
-    remove_lke_clusters()
-
-
 @pytest.mark.smoke
 def test_deploy_an_lke_cluster():
     timestamp = str(time.time_ns())

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -14,8 +14,8 @@ BASE_CMD = ["linode-cli", "networking"]
 
 
 @pytest.fixture(scope="package")
-def test_linode_id():
-    linode_id = create_linode_and_wait()
+def test_linode_id(cloud_init_firewall):
+    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
 
     yield linode_id
 
@@ -23,12 +23,16 @@ def test_linode_id():
 
 
 @pytest.fixture(scope="package")
-def test_linode_id_shared_ipv4():
+def test_linode_id_shared_ipv4(cloud_init_firewall):
     target_region = "us-mia"
 
     linode_ids = (
-        create_linode(test_region=target_region),
-        create_linode(test_region=target_region),
+        create_linode(
+            test_region=target_region, firewall_id=cloud_init_firewall
+        ),
+        create_linode(
+            test_region=target_region, firewall_id=cloud_init_firewall
+        ),
     )
 
     yield linode_ids

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -14,8 +14,8 @@ BASE_CMD = ["linode-cli", "networking"]
 
 
 @pytest.fixture(scope="package")
-def test_linode_id(cloud_init_firewall):
-    linode_id = create_linode_and_wait(firewall_id=cloud_init_firewall)
+def test_linode_id(linode_cloud_firewall):
+    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 
@@ -23,15 +23,15 @@ def test_linode_id(cloud_init_firewall):
 
 
 @pytest.fixture(scope="package")
-def test_linode_id_shared_ipv4(cloud_init_firewall):
+def test_linode_id_shared_ipv4(linode_cloud_firewall):
     target_region = "us-mia"
 
     linode_ids = (
         create_linode(
-            test_region=target_region, firewall_id=cloud_init_firewall
+            test_region=target_region, firewall_id=linode_cloud_firewall
         ),
         create_linode(
-            test_region=target_region, firewall_id=cloud_init_firewall
+            test_region=target_region, firewall_id=linode_cloud_firewall
         ),
     )
 

--- a/tests/integration/nodebalancers/test_node_balancers.py
+++ b/tests/integration/nodebalancers/test_node_balancers.py
@@ -14,7 +14,7 @@ nodebalancer_created = "[0-9]+,balancer[0-9]+,us-ord,[0-9]+-[0-9]+-[0-9]+-[0-9]+
 
 
 @pytest.fixture(scope="package")
-def test_node_balancers():
+def test_node_balancers(cloud_init_firewall):
     # create a default nodebalancer
     nodebalancer_id = (
         exec_test_command(
@@ -23,6 +23,8 @@ def test_node_balancers():
                 "create",
                 "--region",
                 "us-ord",
+                "--firewall_id",
+                cloud_init_firewall,
                 "--text",
                 "--delimiter",
                 ",",
@@ -71,6 +73,8 @@ def test_node_balancers():
                 "true",
                 "--image",
                 DEFAULT_TEST_IMAGE,
+                "--firewall_id",
+                cloud_init_firewall,
                 "--text",
                 "--delimiter",
                 ",",
@@ -121,7 +125,7 @@ def test_node_balancers():
 
 
 @pytest.fixture
-def create_linode_to_add():
+def create_linode_to_add(cloud_init_firewall):
     linode = (
         exec_test_command(
             [
@@ -140,6 +144,8 @@ def create_linode_to_add():
                 "true",
                 "--image",
                 DEFAULT_TEST_IMAGE,
+                "--firewall_id",
+                cloud_init_firewall,
                 "--text",
                 "--delimiter",
                 ",",

--- a/tests/integration/nodebalancers/test_node_balancers.py
+++ b/tests/integration/nodebalancers/test_node_balancers.py
@@ -14,7 +14,7 @@ nodebalancer_created = "[0-9]+,balancer[0-9]+,us-ord,[0-9]+-[0-9]+-[0-9]+-[0-9]+
 
 
 @pytest.fixture(scope="package")
-def test_node_balancers(cloud_init_firewall):
+def test_node_balancers(linode_cloud_firewall):
     # create a default nodebalancer
     nodebalancer_id = (
         exec_test_command(
@@ -24,7 +24,7 @@ def test_node_balancers(cloud_init_firewall):
                 "--region",
                 "us-ord",
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--text",
                 "--delimiter",
                 ",",
@@ -74,7 +74,7 @@ def test_node_balancers(cloud_init_firewall):
                 "--image",
                 DEFAULT_TEST_IMAGE,
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--text",
                 "--delimiter",
                 ",",
@@ -125,7 +125,7 @@ def test_node_balancers(cloud_init_firewall):
 
 
 @pytest.fixture
-def create_linode_to_add(cloud_init_firewall):
+def create_linode_to_add(linode_cloud_firewall):
     linode = (
         exec_test_command(
             [
@@ -145,7 +145,7 @@ def create_linode_to_add(cloud_init_firewall):
                 "--image",
                 DEFAULT_TEST_IMAGE,
                 "--firewall_id",
-                cloud_init_firewall,
+                linode_cloud_firewall,
                 "--text",
                 "--delimiter",
                 ",",

--- a/tests/integration/ssh/test_plugin_ssh.py
+++ b/tests/integration/ssh/test_plugin_ssh.py
@@ -26,7 +26,7 @@ POLL_INTERVAL = 5
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 @pytest.fixture
-def target_instance(ssh_key_pair_generator, cloud_init_firewall):
+def target_instance(ssh_key_pair_generator, linode_cloud_firewall):
     instance_label = f"cli-test-{get_random_text(length=6)}"
 
     pubkey_file, privkey_file = ssh_key_pair_generator
@@ -52,7 +52,7 @@ def target_instance(ssh_key_pair_generator, cloud_init_firewall):
             "--authorized_keys",
             pubkey,
             "--firewall_id",
-            cloud_init_firewall,
+            linode_cloud_firewall,
         ]
         + COMMAND_JSON_OUTPUT
     )

--- a/tests/integration/ssh/test_plugin_ssh.py
+++ b/tests/integration/ssh/test_plugin_ssh.py
@@ -26,7 +26,7 @@ POLL_INTERVAL = 5
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 @pytest.fixture
-def target_instance(ssh_key_pair_generator):
+def target_instance(ssh_key_pair_generator, cloud_init_firewall):
     instance_label = f"cli-test-{get_random_text(length=6)}"
 
     pubkey_file, privkey_file = ssh_key_pair_generator
@@ -51,6 +51,8 @@ def target_instance(ssh_key_pair_generator):
             TEST_ROOT_PASS,
             "--authorized_keys",
             pubkey,
+            "--firewall_id",
+            cloud_init_firewall,
         ]
         + COMMAND_JSON_OUTPUT
     )

--- a/tests/integration/ssh/test_ssh.py
+++ b/tests/integration/ssh/test_ssh.py
@@ -15,7 +15,7 @@ SSH_SLEEP_PERIOD = 50
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 @pytest.fixture(scope="package")
-def linode_in_running_state(ssh_key_pair_generator):
+def linode_in_running_state(ssh_key_pair_generator, cloud_init_firewall):
     pubkey_file, privkey_file = ssh_key_pair_generator
 
     with open(pubkey_file, "r") as f:
@@ -57,7 +57,10 @@ def linode_in_running_state(ssh_key_pair_generator):
     )
 
     linode_id = create_linode_and_wait(
-        test_plan=plan, test_image=alpine_image, ssh_key=pubkey
+        test_plan=plan,
+        test_image=alpine_image,
+        ssh_key=pubkey,
+        firewall_id=cloud_init_firewall,
     )
 
     yield linode_id

--- a/tests/integration/ssh/test_ssh.py
+++ b/tests/integration/ssh/test_ssh.py
@@ -15,7 +15,7 @@ SSH_SLEEP_PERIOD = 50
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 @pytest.fixture(scope="package")
-def linode_in_running_state(ssh_key_pair_generator, cloud_init_firewall):
+def linode_in_running_state(ssh_key_pair_generator, linode_cloud_firewall):
     pubkey_file, privkey_file = ssh_key_pair_generator
 
     with open(pubkey_file, "r") as f:
@@ -60,7 +60,7 @@ def linode_in_running_state(ssh_key_pair_generator, cloud_init_firewall):
         test_plan=plan,
         test_image=alpine_image,
         ssh_key=pubkey,
-        firewall_id=cloud_init_firewall,
+        firewall_id=linode_cloud_firewall,
     )
 
     yield linode_id

--- a/tests/integration/support/test_support.py
+++ b/tests/integration/support/test_support.py
@@ -7,8 +7,8 @@ BASE_CMD = ["linode-cli", "tickets"]
 
 # this will create a support ticket on your account
 @pytest.mark.skip(reason="this will create a support ticket")
-def test_create_support_ticket(created_linode_id):
-    linode_id = created_linode_id
+def test_create_support_ticket(support_test_linode_id):
+    linode_id = support_test_linode_id
     exec_test_command(
         BASE_CMD
         + [


### PR DESCRIPTION
## 📝 Description

This PR implements Linode Cloud Firewall for integration tests to enhance security. 
More info can be found in [Best Practices to keep VMs safe](https://docs.google.com/document/d/1XowpyiU09AfsXxtt1Jnmeev8W9o6GuwaShW7kK-zjlM/edit?parentUrl=https%3A%2F%2Fac-aloha.akamai.com%2Fhome%2Flinode-vm-best-practices%2Flinode-vm-best-practices&iframeId=b8819df3-0010-5c00-8d3a-26aa6d14b1a5#heading=h.r7cjnl29apd1).

Note: GHA does not support ipv6 so only ipv4 will get added in firewall during GHA execution. However, ipv6 will get added automatically if ipv6 address and route exist

## ✔️ How to Test

`make testint`

https://github.com/linode/linode-cli/actions/runs/9217506829


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**