### PR TITLE
fix: Resolve cell rendering error in OBJ plugin

### DIFF
--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -125,7 +125,7 @@ def _borderless_table(data):
     """
     tab = Table.grid(padding=(0, 2, 0, 2))
     for row in data:
-        tab.add_row(*row)
+        tab.add_row(*[str(v) for v in row])
 
     return tab
 


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that caused the following error to be raised when attempting to render cells with an integer value in the OBJ plugin:

```
rich.errors.NotRenderableError: unable to render int; a string or other renderable object is required
```

## ✔️ How to Test

The following test steps assume you have pulled down this PR and run `make install`.

### Integration Testing

```
make MODULE=obj testint
```

### Manual Testing

N/A