### PR TITLE
Change Clusters Choice in OBJ Plugin Config to be Text Input

### DIFF
--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -18,7 +18,7 @@ from rich.table import Table
 
 from linodecli.cli import CLI
 from linodecli.configuration import _do_get_request
-from linodecli.configuration.helpers import _default_thing_input
+from linodecli.configuration.helpers import _default_text_input
 from linodecli.plugins import PluginContext, inherit_plugin_args
 from linodecli.plugins.obj.buckets import create_bucket, delete_bucket
 from linodecli.plugins.obj.config import (
@@ -60,18 +60,6 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-
-
-def get_available_cluster(cli: CLI):
-    """Get list of possible clusters for the account"""
-    return [
-        c["id"]
-        for c in _do_get_request(  # pylint: disable=protected-access
-            cli.config.base_url,
-            "/object-storage/clusters",
-            token=cli.config.get_token(),
-        )["data"]
-    ]
 
 
 def generate_url(get_client, args, **kwargs):  # pylint: disable=unused-argument
@@ -290,7 +278,7 @@ def print_help(parser: ArgumentParser):
     print("See --help for individual commands for more information")
 
 
-def get_obj_args_parser(clusters: List[str]):
+def get_obj_args_parser():
     """
     Initialize and return the argument parser for the obj plug-in.
     """
@@ -307,7 +295,6 @@ def get_obj_args_parser(clusters: List[str]):
         "--cluster",
         metavar="CLUSTER",
         type=str,
-        choices=clusters,
         help="The cluster to use for the operation",
     )
 
@@ -369,8 +356,7 @@ def call(
 
         sys.exit(2)  # requirements not met - we can't go on
 
-    clusters = get_available_cluster(context.client) if not is_help else None
-    parser = get_obj_args_parser(clusters)
+    parser = get_obj_args_parser()
     parsed, args = parser.parse_known_args(args)
 
     # don't mind --no-defaults if it's there; the top-level parser already took care of it
@@ -553,15 +539,12 @@ def _configure_plugin(client: CLI):
     """
     Configures a default cluster value.
     """
-    clusters = get_available_cluster(client)
 
-    cluster = _default_thing_input(  # pylint: disable=protected-access
+    cluster = _default_text_input(  # pylint: disable=protected-access
         "Configure a default Cluster for operations.",
-        clusters,
-        "Default Cluster: ",
-        "Please select a valid Cluster",
-        optional=False,  # this is the only configuration right now
+        optional=True,
     )
 
-    client.config.plugin_set_value("cluster", cluster)
+    if cluster:
+        client.config.plugin_set_value("cluster", cluster)
     client.config.write_config()

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -541,7 +541,7 @@ def _configure_plugin(client: CLI):
     """
 
     cluster = _default_text_input(  # pylint: disable=protected-access
-        "Configure a default Cluster for operations.",
+        "Default cluster for operations (e.g. `us-mia-1`)",
         optional=True,
     )
 

--- a/tests/unit/test_plugin_obj.py
+++ b/tests/unit/test_plugin_obj.py
@@ -5,7 +5,7 @@ from linodecli.plugins.obj import get_obj_args_parser, helpers, print_help
 
 
 def test_print_help(mock_cli: CLI, capsys: CaptureFixture):
-    parser = get_obj_args_parser(["us-mia-1"])
+    parser = get_obj_args_parser()
     print_help(parser)
     captured_text = capsys.readouterr()
     assert parser.format_help() in captured_text.out


### PR DESCRIPTION
## 📝 Description

The upcoming MultiCluster OBJ service will introduce multiple clusters per region, and clusters list API will be deprecated.

Removing clusters list when doing `linode obj configure` and change it to a text input.

## ✔️ How to Test

### Automated Testing

```
pytest tests/integration/obj
```

```bash
make testunit
```

### Manual Testing

```bash
linode obj configure
```

Then type any cluster you want:

```
(venv) myusername@mylaptop linode-cli % linode obj configure

Configure a default Cluster for operations. (Optional): us-mia-1
```

Or leave it blank:
```
(venv) myusername@mylaptop linode-cli % linode obj configure

Configure a default Cluster for operations. (Optional):
```

And then try any obj plugin commands, for examples:
```
linode obj la
```

```
linode obj la --cluster us-east-1
```

