### PR TITLE
test: Add Calico Inbound and Outbound policies to LKE nodes for E2E

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -39,7 +39,6 @@ jobs:
           chmod +x calicoctl-linux-amd64 kubectl
           mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
           mv kubectl /usr/local/bin/kubectl
-        id: calico_dependencies
 
       - name: Install Package
         run: make install
@@ -59,7 +58,6 @@ jobs:
           cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-        needs: calico_dependencies
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -59,8 +59,7 @@ jobs:
           cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-        needs:
-          - calico_dependencies
+        needs: calico_dependencies
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -38,7 +38,7 @@ jobs:
           chmod +x kubectl
           mv kubectl scripts/
           curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl
+          chmod +x calicoctl-linux-amd64
           mv calicoctl-linux-amd64 scripts/
 
       - name: Install Package

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          make testint TEST_ARGS="--junitxml=${report_filename}" MODULE="lke"
+          make testint TEST_ARGS="--junitxml=${report_filename}"
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Download kubectl and calicoctl for LKE clusters
         run: |
           curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl
-          mv kubectl scripts/
           curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64
-          mv calicoctl-linux-amd64 scripts/
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+        id: calico_dependencies
 
       - name: Install Package
         run: make install
@@ -59,6 +59,8 @@ jobs:
           cd scripts && ./lke_calico_rules_e2e.sh
         env:
           LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+        needs:
+          - calico_dependencies
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -54,6 +54,7 @@ jobs:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
       - name: Apply Calico Rules to LKE
+        if: always()
         run: |
           cd scripts && ./lke_calico_rules_e2e.sh
         env:

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -37,7 +37,7 @@ jobs:
           curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
           chmod +x kubectl
           mv kubectl scripts/
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64”
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
           chmod +x calicoctl
           mv calicoctl-linux-amd64 scripts/
 

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -26,14 +26,20 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install Python deps
-        run: pip install wheel boto3
+      - name: Install Python dependencies and update cert
+        run: |
+          pip install wheel boto3 && \
+          pip install certifi -U && \
+          pip install .[obj,dev]
 
-      - name: Update cert
-        run: pip install certifi -U
-
-      - name: Install deps
-        run: pip install .[obj,dev]
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl scripts/
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64”
+          chmod +x calicoctl
+          mv calicoctl-linux-amd64 scripts/
 
       - name: Install Package
         run: make install
@@ -44,9 +50,15 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          make testint TEST_ARGS="--junitxml=${report_filename}"
+          make testint TEST_ARGS="--junitxml=${report_filename}" MODULE="lke"
         env:
           LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd scripts && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
       - name: Upload test results
         if: always()

--- a/scripts/lke-policy.yaml
+++ b/scripts/lke-policy.yaml
@@ -1,0 +1,78 @@
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: lke-rules
+spec:
+  preDNAT: true
+  applyOnForward: true
+  order: 100
+  # Remember to run calicoctl patch command for this to work
+  selector: ""
+  ingress:
+  # Allow ICMP
+  - action: Allow
+    protocol: ICMP
+  - action: Allow
+    protocol: ICMPv6
+
+  # Allow LKE-required ports
+  - action: Allow
+    protocol: TCP
+    destination:
+      nets:
+      - 192.168.128.0/17
+      - 10.0.0.0/8
+      ports:
+      - 10250
+      - 10256
+      - 179
+  - action: Allow
+    protocol: UDP
+    destination:
+      nets:
+      - 192.168.128.0/17
+      - 10.2.0.0/16
+      ports:
+      - 51820
+
+  # Allow NodeBalancer ingress to the Node Ports & Allow DNS
+  - action: Allow
+    protocol: TCP
+    source:
+      nets:
+      - 192.168.255.0/24
+      - 10.0.0.0/8
+    destination:
+      ports:
+      - 53
+      - 30000:32767
+  - action: Allow
+    protocol: UDP
+    source:
+      nets:
+      - 192.168.255.0/24
+      - 10.0.0.0/8
+    destination:
+      ports:
+      - 53
+      - 30000:32767
+
+  # Allow cluster internal communication
+  - action: Allow
+    destination:
+      nets:
+      - 10.0.0.0/8
+  - action: Allow
+    source:
+      nets:
+      - 10.0.0.0/8
+
+  # 127.0.0.1/32 is needed for kubectl exec and node-shell
+  - action: Allow
+    destination:
+      nets:
+      - 127.0.0.1/32
+
+  # Block everything else
+  - action: Deny
+  - action: Log

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -13,13 +13,16 @@ fi
 
 for ID in $CLUSTER_IDS; do
     echo "Cluster ID: $ID"
-    echo "Applying Calico Rules to Nodes:"
-    ./kubectl get nodes
 
+    # Download cluster configuration file
     curl -sH "Authorization: Bearer $LINODE_TOKEN" \
         "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig" | jq -r '.[] | @base64d' > "${ID}_config.yaml"
 
+    # Export downloaded config file for
     export KUBECONFIG="$(pwd)/${ID}_config.yaml"
+
+    echo "Applying Calico Rules to Nodes:"
+    ./kubectl get nodes
 
     ./calicoctl-linux-amd64 patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
 

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Fetch the list of LKE cluster IDs
+CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://api.linode.com/v4/lke/clusters" | jq -r '.data[].id')
+
+# Check if CLUSTER_IDS is empty
+if [ -z "$CLUSTER_IDS" ]; then
+    echo "No clusters are present."
+    exit 0
+fi
+
+for ID in $CLUSTER_IDS; do
+    echo "Cluster ID: $ID"
+    echo "Applying Calico Rules to Nodes:"
+    ./kubectl get nodes
+
+    curl -sH "Authorization: Bearer $LINODE_TOKEN" \
+        "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig" | jq -r '.[] | @base64d' > "${ID}_config.yaml"
+
+    export KUBECONFIG="$(pwd)/${ID}_config.yaml"
+
+    ./calicoctl-linux-amd64 patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
+
+    ./calicoctl-linux-amd64 apply -f "$(pwd)/lke-policy.yaml"
+done

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -27,7 +27,7 @@ CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
 
 # Check if CLUSTER_IDS is empty
 if [ -z "$CLUSTER_IDS" ]; then
-    echo "No clusters are present."
+    echo "All clusters have been cleaned and properly destroyed. No need to apply inbound or outbound rules"
     exit 0
 fi
 

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -46,7 +46,7 @@ for ID in $CLUSTER_IDS; do
     done
 
     if [[ $config_response == *"kubeconfig is not yet available"* ]]; then
-        echo "Cluster $ID not available after $RETRIES attempts. Skipping..."
+        echo "kubeconfig for cluster id:$ID not available after $RETRIES attempts, mostly likely it is an empty cluster. Skipping..."
     else
         # Export downloaded config file
         export KUBECONFIG="$(pwd)/${ID}_config.yaml"

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -22,9 +22,9 @@ for ID in $CLUSTER_IDS; do
     export KUBECONFIG="$(pwd)/${ID}_config.yaml"
 
     echo "Applying Calico Rules to Nodes:"
-    ./kubectl get nodes
+    kubectl get nodes
 
-    ./calicoctl-linux-amd64 patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
+    calicoctl patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
 
-    ./calicoctl-linux-amd64 apply -f "$(pwd)/lke-policy.yaml"
+    calicoctl apply -f "$(pwd)/lke-policy.yaml"
 done

--- a/scripts/lke_calico_rules_e2e.sh
+++ b/scripts/lke_calico_rules_e2e.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+RETRIES=3
+DELAY=30
+
+# Function to retry a command with exponential backoff
+retry_command() {
+    local retries=$1
+    local wait_time=60
+    shift
+    until "$@"; do
+        if ((retries == 0)); then
+            echo "Command failed after multiple retries. Exiting."
+            exit 1
+        fi
+        echo "Command failed. Retrying in $wait_time seconds..."
+        sleep $wait_time
+        ((retries--))
+        wait_time=$((wait_time * 2))
+    done
+}
+
 # Fetch the list of LKE cluster IDs
 CLUSTER_IDS=$(curl -s -H "Authorization: Bearer $LINODE_TOKEN" \
     -H "Content-Type: application/json" \
@@ -12,19 +32,29 @@ if [ -z "$CLUSTER_IDS" ]; then
 fi
 
 for ID in $CLUSTER_IDS; do
-    echo "Cluster ID: $ID"
+    echo "Applying Calico rules to nodes in Cluster ID: $ID"
 
-    # Download cluster configuration file
-    curl -sH "Authorization: Bearer $LINODE_TOKEN" \
-        "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig" | jq -r '.[] | @base64d' > "${ID}_config.yaml"
+    # Download cluster configuration file with retry
+    for ((i=1; i<=RETRIES; i++)); do
+        config_response=$(curl -sH "Authorization: Bearer $LINODE_TOKEN" "https://api.linode.com/v4/lke/clusters/$ID/kubeconfig")
+        if [[ $config_response != *"kubeconfig is not yet available"* ]]; then
+            echo $config_response | jq -r '.[] | @base64d' > "${ID}_config.yaml"
+            break
+        fi
+        echo "Attempt $i to download kubeconfig for cluster $ID failed. Retrying in $DELAY seconds..."
+        sleep $DELAY
+    done
 
-    # Export downloaded config file for
-    export KUBECONFIG="$(pwd)/${ID}_config.yaml"
+    if [[ $config_response == *"kubeconfig is not yet available"* ]]; then
+        echo "Cluster $ID not available after $RETRIES attempts. Skipping..."
+    else
+        # Export downloaded config file
+        export KUBECONFIG="$(pwd)/${ID}_config.yaml"
 
-    echo "Applying Calico Rules to Nodes:"
-    kubectl get nodes
+        retry_command $RETRIES kubectl get nodes
 
-    calicoctl patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
+        retry_command $RETRIES calicoctl patch kubecontrollersconfiguration default --patch='{"spec": {"controllers": {"node": {"hostEndpoint": {"autoCreate": "Enabled"}}}}}'
 
-    calicoctl apply -f "$(pwd)/lke-policy.yaml"
+        retry_command $RETRIES calicoctl apply -f "$(pwd)/lke-policy.yaml"
+    fi
 done

--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -61,7 +61,7 @@ def test_deploy_an_lke_cluster():
     # Sleep needed here for proper deletion of linodes that are related to lke cluster
     time.sleep(15)
 
-    remove_lke_clusters()
+    # remove_lke_clusters()
 
 
 def test_lke_cluster_list():

--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -61,7 +61,7 @@ def test_deploy_an_lke_cluster():
     # Sleep needed here for proper deletion of linodes that are related to lke cluster
     time.sleep(15)
 
-    # remove_lke_clusters()
+    remove_lke_clusters()
 
 
 def test_lke_cluster_list():


### PR DESCRIPTION
## 📝 Description

A new script, `lke_calico_rules_e2e.sh`, has been added and is called in the E2E workflow file after the `Run the integration test suite step` in `e2e-suite.yml`

Key Points:
- `kubectl` and `calicoctl` binaries are required as pre-req which are downloed in the e2e worflow file
- The script retrieves all LKE clusters in the test account and applies Calico rules to the corresponding nodes. If no clusters exist, no action is taken. In most cases, clusters are cleaned and deleted properly after test execution
- Due to the delay in the availability of LKE cluster configurations and the provisioning times of node instances, it is challenging to apply Calico rules directly within the test framework. Therefore, the script is separated and executed independently in the workflow file

## ✔️ How to Test

PR has been checked out 
1. Comment out `    remove_lke_clusters()` line 64 in `test_clusters.py`
2. Run `make MODULE="lke" testint`
3. Run shell script `cd scripts && ./lke_calico_rules_e2e.sh`
4. Calico rule is applied to the cluster

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**