### PR TITLE
test: Add option to run integration tests against minimal test account without any special customer tags

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -6,6 +6,10 @@ on:
         description: 'Use minimal test account'
         required: false
         default: 'false'
+      sha:
+        description: 'The hash value of the commit.'
+        required: false
+        default: ''
   push:
     branches:
       - main
@@ -14,11 +18,18 @@ jobs:
   integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
-    env:
-      EXIT_STATUS: 0
     steps:
-      - name: Clone Repository
-        uses: actions/checkout@v3
+      - name: Clone Repository with SHA
+        if: ${{ inputs.sha != '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+          ref: ${{ inputs.sha }}
+
+      - name: Clone Repository without SHA
+        if: ${{ inputs.sha == '' }}
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -1,6 +1,11 @@
 name: Integration Tests
 on:
-  workflow_dispatch: null
+  workflow_dispatch:
+    inputs:
+      use_minimal_test_account:
+        description: 'Use minimal test account'
+        required: false
+        default: 'false'
   push:
     branches:
       - main
@@ -45,20 +50,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set LINODE_CLI_TOKEN
+        run: |
+          echo "LINODE_CLI_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
+
       - name: Run the integration test suite
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
           make testint TEST_ARGS="--junitxml=${report_filename}"
-        env:
-          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}
 
       - name: Apply Calico Rules to LKE
         if: always()
         run: |
           cd scripts && ./lke_calico_rules_e2e.sh
         env:
-          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+          LINODE_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/nightly-smoke-tests.yml
+++ b/.github/workflows/nightly-smoke-tests.yml
@@ -32,4 +32,4 @@ jobs:
         run: |
           make smoketest
         env:
-          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_2 }}
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN }}


### PR DESCRIPTION
## 📝 Description

This PR adds option to run integration tests against minimal test account in `e2e-suite.yml` workflow

## ✔️ How to Test

Forked Run with specified SHA - https://github.com/ykim-1/linode-cli/actions/runs/9668566683
Forked Run merged to dev - https://github.com/ykim-1/linode-cli/actions/runs/9669162821

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**