### PR TITLE
new: Changes for CLI/TechDocs spec compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test/.env
 .tmp*
 MANIFEST
 venv
+openapi*.yaml

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -51,7 +51,11 @@ skip_config = (
     or TEST_MODE
 )
 
-cli = CLI(VERSION, handle_url_overrides(BASE_URL), skip_config=skip_config)
+cli = CLI(
+    VERSION,
+    handle_url_overrides(BASE_URL, override_path=True),
+    skip_config=skip_config,
+)
 
 
 def main():  # pylint: disable=too-many-branches,too-many-statements

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -13,7 +13,7 @@ from packaging import version
 from requests import Response
 
 from linodecli.exit_codes import ExitCodes
-from linodecli.helpers import API_CA_PATH
+from linodecli.helpers import API_CA_PATH, API_VERSION_OVERRIDE
 
 from .baked.operation import (
     ExplicitEmptyListValue,
@@ -185,14 +185,22 @@ def _build_filter_header(
 
 
 def _build_request_url(ctx, operation, parsed_args) -> str:
-    target_server = handle_url_overrides(
+    url_base = handle_url_overrides(
         operation.url_base,
         host=ctx.config.get_value("api_host"),
-        version=ctx.config.get_value("api_version"),
         scheme=ctx.config.get_value("api_scheme"),
     )
 
-    result = f"{target_server}{operation.url_path}".format(**vars(parsed_args))
+    result = f"{url_base}{operation.url_path}".format(
+        # {apiVersion} is defined in the endpoint paths for
+        # the TechDocs API specs
+        apiVersion=(
+            API_VERSION_OVERRIDE
+            or ctx.config.get_value("api_version")
+            or operation.default_api_version
+        ),
+        **vars(parsed_args),
+    )
 
     if operation.method == "get":
         result += f"?page={ctx.page}&page_size={ctx.page_size}"

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -11,10 +11,11 @@ import sys
 from collections import defaultdict
 from getpass import getpass
 from os import environ, path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import openapi3.paths
-from openapi3.paths import Operation
+from openapi3.paths import Operation, Parameter
 
 from linodecli.baked.request import OpenAPIFilteringRequest, OpenAPIRequest
 from linodecli.baked.response import OpenAPIResponse
@@ -295,7 +296,9 @@ class OpenAPIOperation:
     This is the class that should be pickled when building the CLI.
     """
 
-    def __init__(self, command, operation: Operation, method, params):
+    def __init__(
+        self, command, operation: Operation, method, params
+    ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """
         Wraps an openapi3.Operation object and handles pulling out values relevant
         to the Linode CLI.
@@ -355,18 +358,17 @@ class OpenAPIOperation:
 
         self.summary = operation.summary
         self.description = operation.description.split(".")[0]
-        self.params = [OpenAPIOperationParameter(c) for c in params]
 
-        # These fields must be stored separately
-        # to allow them to be easily modified
-        # at runtime.
-        self.url_base = (
-            operation.servers[0].url
-            if operation.servers
-            else operation._root.servers[0].url
+        # The apiVersion attribute should not be specified as a positional argument
+        self.params = [
+            OpenAPIOperationParameter(param)
+            for param in params
+            if param.name not in {"apiVersion"}
+        ]
+
+        self.url_base, self.url_path, self.default_api_version = (
+            self._get_api_url_components(operation, params)
         )
-
-        self.url_path = operation.path[-2]
 
         self.url = self.url_base + self.url_path
 
@@ -409,6 +411,85 @@ class OpenAPIOperation:
         new_tag = tag.lower()
         new_tag = re.sub(r"[^a-z ]", "", new_tag).replace(" ", "-")
         return new_tag
+
+    @staticmethod
+    def _resolve_api_version(
+        params: List[Parameter], server_url: str
+    ) -> Optional[str]:
+        """
+        Returns the API version for a given list of params and target URL.
+
+        :param params: The params for this operation's endpoint path.
+        :type params: List[Parameter]
+        :param server_url: The URL of server for this operation.
+        :type server_url: str
+
+        :returns: The default API version if the URL has a version, else None.
+        :rtype: Optional[str]
+        """
+
+        # Remove empty segments from the URL path, stripping the first,
+        # last and any duplicate slashes if necessary.
+        # There shouldn't be a case where this is needed, but it's
+        # always good to make things more resilient :)
+        url_path_segments = [
+            seg for seg in urlparse(server_url).path.split("/") if len(seg) > 0
+        ]
+        if len(url_path_segments) > 0:
+            return "/".join(url_path_segments)
+
+        version_param = next(
+            (
+                param
+                for param in params
+                if param.name == "apiVersion" and param.in_ == "path"
+            ),
+            None,
+        )
+        if version_param is not None:
+            return version_param.schema.default
+
+        return None
+
+    @staticmethod
+    def _get_api_url_components(
+        operation: Operation, params: List[Parameter]
+    ) -> Tuple[str, str, str]:
+        """
+        Returns the URL components for a given operation.
+
+        :param operation: The operation to get the URL components for.
+        :type operation: Operation
+        :param params: The parameters for this operation's route.
+        :type params: List[Parameter]
+
+        :returns: The base URL, path, and default API version of the operation.
+        :rtype: Tuple[str, str, str]
+        """
+
+        url_server = (
+            operation.servers[0].url
+            if operation.servers
+            # pylint: disable-next=protected-access
+            else operation._root.servers[0].url
+        )
+
+        url_base = urlparse(url_server)._replace(path="").geturl()
+        url_path = operation.path[-2]
+
+        api_version = OpenAPIOperation._resolve_api_version(params, url_server)
+        if api_version is None:
+            raise ValueError(
+                f"Failed to resolve API version for operation {operation}"
+            )
+
+        # The apiVersion is only specified in the new-style OpenAPI spec,
+        # so we need to manually insert it into the path to maintain
+        # backwards compatibility
+        if "{apiVersion}" not in url_path:
+            url_path = "/{apiVersion}" + url_path
+
+        return url_base, url_path, api_version
 
     def process_response_json(
         self, json: Dict[str, Any], handler: OutputHandler

--- a/linodecli/baked/parsing.py
+++ b/linodecli/baked/parsing.py
@@ -1,0 +1,184 @@
+"""
+This module contains logic related to string parsing and replacement.
+"""
+
+import functools
+import re
+from html import unescape
+from typing import List, Tuple
+
+# Sentence delimiter, split on a period followed by any type of
+# whitespace (space, new line, tab, etc.)
+REGEX_SENTENCE_DELIMITER = re.compile(r"\.(?:\s|$)")
+
+# Matches on pattern __prefix__ at the beginning of a description
+# or after a comma
+REGEX_TECHDOCS_PREFIX = re.compile(r"(?:, |\A)__([\w-]+)__")
+
+# Matches on pattern [link title](https://.../)
+REGEX_MARKDOWN_LINK = re.compile(r"\[(?P<text>.*?)]\((?P<link>.*?)\)")
+
+MARKDOWN_RICH_TRANSLATION = [
+    # Inline code blocks (e.g. `cool code`)
+    (
+        re.compile(
+            r"`(?P<text>[^`]+)`",
+        ),
+        "italic deep_pink3 on grey15",
+    ),
+    # Bold tag (e.g. `**bold**` or `__bold__`)
+    (
+        re.compile(
+            r"\*\*(?P<text>[^_\s]+)\*\*",
+        ),
+        "b",
+    ),
+    (
+        re.compile(
+            r"__(?P<text>[^_\s]+)__",
+        ),
+        "b",
+    ),
+    # Italics tag (e.g. `*italics*` or `_italics_`)
+    (
+        re.compile(
+            r"\*(?P<text>[^*\s]+)\*",
+        ),
+        "i",
+    ),
+    (
+        re.compile(
+            r"_(?P<text>[^_\s]+)_",
+        ),
+        "i",
+    ),
+]
+
+
+def markdown_to_rich_markup(markdown: str) -> str:
+    """
+    This function returns a version of the given argument description
+    with the appropriate color tags.
+
+    NOTE, Rich does support Markdown rendering, but it isn't suitable for this
+    use-case quite yet due to some Group(...) padding issues and limitations
+    with syntax themes.
+
+    :param markdown: The argument description to colorize.
+    :type markdown: str
+
+    :returns: The translated Markdown
+    """
+
+    result = markdown
+
+    for exp, style in MARKDOWN_RICH_TRANSLATION:
+        result = exp.sub(
+            # Necessary to avoid cell-var-in-loop linter fer
+            functools.partial(
+                lambda style, match: f"[{style}]{match['text']}[/]", style
+            ),
+            result,
+        )
+
+    return result
+
+
+def extract_markdown_links(description: str) -> Tuple[str, List[str]]:
+    """
+    Extracts all Markdown links from the given description and
+    returns them alongside the stripped description.
+
+    :param description: The description of a CLI argument.
+    :type description: str
+
+    :returns: The stripped description and a list of extracted links.
+    :rtype: Tuple[str, List[str]]
+    """
+    result_links = []
+
+    def _sub_handler(match: re.Match) -> str:
+        link = match["link"]
+        if link.startswith("/"):
+            link = f"https://linode.com{link}"
+
+        result_links.append(link)
+        return match["text"]
+
+    result_description = REGEX_MARKDOWN_LINK.sub(_sub_handler, description)
+
+    return result_description, result_links
+
+
+def get_short_description(description: str) -> str:
+    """
+    Gets the first relevant sentence in the given description.
+
+    :param description: The description of a CLI argument.
+    :type description: str
+
+    :returns: A single sentence from the description.
+    :rtype: set
+    """
+
+    target_lines = description.splitlines()
+    relevant_lines = None
+
+    for i, line in enumerate(target_lines):
+        # Edge case for descriptions starting with a note
+        if line.lower().startswith("__note__"):
+            continue
+
+        relevant_lines = target_lines[i:]
+        break
+
+    if relevant_lines is None:
+        raise ValueError(
+            f"description does not contain any relevant lines: {description}",
+        )
+
+    return REGEX_SENTENCE_DELIMITER.split("\n".join(relevant_lines), 1)[0] + "."
+
+
+def strip_techdocs_prefixes(description: str) -> str:
+    """
+    Removes all bold prefixes from the given description.
+
+    :param description: The description of a CLI argument.
+    :type description: str
+
+    :returns: The stripped description
+    :rtype: str
+    """
+    result_description = REGEX_TECHDOCS_PREFIX.sub(
+        "", description.lstrip()
+    ).lstrip()
+
+    return result_description
+
+
+def process_arg_description(description: str) -> Tuple[str, str]:
+    """
+    Processes the given raw request argument description into one suitable
+    for help pages, etc.
+
+    :param description: The original description for a request argument.
+    :type description: str
+
+    :returns: The description in Rich markup and original Markdown format.
+    :rtype: Tuple[str, str]
+    """
+
+    if description == "":
+        return "", ""
+
+    result = get_short_description(description)
+    result = strip_techdocs_prefixes(result)
+    result = result.replace("\n", " ").replace("\r", " ")
+
+    description, links = extract_markdown_links(result)
+
+    if len(links) > 0:
+        description += f" See: {'; '.join(links)}"
+
+    return unescape(markdown_to_rich_markup(description)), unescape(description)

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -2,6 +2,8 @@
 Request details for a CLI Operation
 """
 
+from linodecli.baked.parsing import process_arg_description
+
 
 class OpenAPIRequestArg:
     """
@@ -44,10 +46,15 @@ class OpenAPIRequestArg:
         #: the larger response model
         self.path = prefix + "." + name if prefix else name
 
-        #: The description of this argument, for help display
-        self.description = (
-            schema.description.split(".")[0] if schema.description else ""
+        description_rich, description = process_arg_description(
+            schema.description or ""
         )
+
+        #: The description of this argument for Markdown/plaintext display
+        self.description = description
+
+        #: The description of this argument for display on the help page
+        self.description_rich = description_rich
 
         #: If this argument is required for requests
         self.required = required

--- a/linodecli/help_pages.py
+++ b/linodecli/help_pages.py
@@ -205,7 +205,7 @@ def _help_action_print_filter_args(console: Console, op: OpenAPIOperation):
     if filterable_attrs:
         console.print("[bold]You may filter results with:[/]")
         for attr in filterable_attrs:
-            console.print(f"  [bold magenta]--{attr.name}[/]")
+            console.print(f"  [bold green]--{attr.name}[/]")
 
         console.print(
             "\nAdditionally, you may order results using --order-by and --order."

--- a/linodecli/help_pages.py
+++ b/linodecli/help_pages.py
@@ -3,7 +3,6 @@ This module contains various helper functions related to outputting
 help pages.
 """
 
-import re
 import textwrap
 from collections import defaultdict
 from typing import List, Optional
@@ -13,6 +12,7 @@ from rich import print as rprint
 from rich.console import Console
 from rich.padding import Padding
 from rich.table import Table
+from rich.text import Text
 
 from linodecli import plugins
 from linodecli.baked import OpenAPIOperation
@@ -239,15 +239,13 @@ def _help_action_print_body_args(
 
             prefix = f" ({', '.join(metadata)})" if len(metadata) > 0 else ""
 
-            description = _markdown_links_to_rich(
-                arg.description.replace("\n", " ").replace("\r", " ")
+            arg_text = Text.from_markup(
+                f"[bold green]--{arg.path}[/][bold]{prefix}:[/] {arg.description_rich}"
             )
 
-            arg_str = (
-                f"[bold magenta]--{arg.path}[/][bold]{prefix}[/]: {description}"
+            console.print(
+                Padding.indent(arg_text, (arg.depth * 2) + 2),
             )
-
-            console.print(Padding.indent(arg_str.rstrip(), (arg.depth * 2) + 2))
 
         console.print()
 
@@ -278,8 +276,8 @@ def _help_group_arguments(
         # leave it as is in the result
         if len(group) > 1:
             groups.append(
-                # Required arguments should come first in groups
-                sorted(group, key=lambda v: not v.required),
+                # Args should be ordered by least depth -> required -> path
+                sorted(group, key=lambda v: (v.depth, not v.required, v.path)),
             )
             continue
 
@@ -304,30 +302,5 @@ def _help_group_arguments(
         result.append(ungrouped)
 
     result += groups
-
-    return result
-
-
-def _markdown_links_to_rich(text):
-    """
-    Returns the given text with Markdown links converted to Rich-compatible links.
-    """
-
-    result = text
-
-    # Find all Markdown links
-    r = re.compile(r"\[(?P<text>.*?)]\((?P<link>.*?)\)")
-
-    for match in r.finditer(text):
-        url = match.group("link")
-
-        # Expand the URL if necessary
-        if url.startswith("/"):
-            url = f"https://linode.com{url}"
-
-        # Replace with more readable text
-        result = result.replace(
-            match.group(), f"{match.group('text')} ([link={url}]{url}[/link])"
-        )
 
     return result

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -19,17 +19,23 @@ API_CA_PATH = os.getenv("LINODE_CLI_CA", None) or True
 
 
 def handle_url_overrides(
-    url: str, host: str = None, version: str = None, scheme: str = None
+    url: str,
+    host: str = None,
+    version: str = None,
+    scheme: str = None,
+    override_path=False,
 ):
     """
     Returns the URL with the API URL environment overrides applied.
+    If override_path is True and the API version env var is specified,
+    the URL path will be updated accordingly.
     """
 
     parsed_url = urlparse(url)
 
     overrides = {
         "netloc": API_HOST_OVERRIDE or host,
-        "path": API_VERSION_OVERRIDE or version,
+        "path": (API_VERSION_OVERRIDE or version) if override_path else None,
         "scheme": API_SCHEME_OVERRIDE or scheme,
     }
 

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -20,10 +20,10 @@ API_CA_PATH = os.getenv("LINODE_CLI_CA", None) or True
 
 def handle_url_overrides(
     url: str,
-    host: str = None,
-    version: str = None,
-    scheme: str = None,
-    override_path=False,
+    host: Optional[str] = None,
+    version: Optional[str] = None,
+    scheme: Optional[str] = None,
+    override_path: bool = False,
 ):
     """
     Returns the URL with the API URL environment overrides applied.

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -6,6 +6,7 @@ import glob
 import os
 from argparse import ArgumentParser
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 API_HOST_OVERRIDE = os.getenv("LINODE_CLI_API_HOST")

--- a/linodecli/output/output_handler.py
+++ b/linodecli/output/output_handler.py
@@ -4,6 +4,7 @@ Handles formatting the output of commands used in Linode CLI
 
 import copy
 import json
+import sys
 from argparse import Namespace
 from enum import Enum, auto
 from sys import stdout
@@ -243,8 +244,8 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
             for col in self.columns.split(","):
                 for attr in attrs:
                     # Display this column if the format string
-                    # matches the column_name or path of this column
-                    if col in (attr.column_name, attr.name):
+                    # matches the path of this column
+                    if col == attr.name:
                         attrs.remove(attr)
                         columns.append(attr)
 
@@ -444,7 +445,8 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
                 print(
                     "WARNING: '--all' is a deprecated flag, "
                     "and will be removed in a future version. "
-                    "Please consider use '--all-columns' instead."
+                    "Please consider use '--all-columns' instead.",
+                    file=sys.stderr,
                 )
             self.columns = "*"
         elif parsed.format:

--- a/tests/fixtures/api_request_test_foobar_get.yaml
+++ b/tests/fixtures/api_request_test_foobar_get.yaml
@@ -4,7 +4,6 @@ info:
   version: 1.0.0
 servers:
   - url: http://localhost/v4
-
 paths:
   /foo/bar:
     get:

--- a/tests/fixtures/api_request_test_foobar_post.yaml
+++ b/tests/fixtures/api_request_test_foobar_post.yaml
@@ -3,7 +3,7 @@ info:
   title: API Specification
   version: 1.0.0
 servers:
-  - url: http://localhost
+  - url: http://localhost/v4
 
 paths:
   /foo/bar:

--- a/tests/fixtures/api_url_components_test.yaml
+++ b/tests/fixtures/api_url_components_test.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+info:
+  title: API Specification
+  version: 1.0.0
+servers:
+  - url: http://localhost/v19
+paths:
+  /foo/bar:
+    get:
+      operationId: fooBarGet
+      responses:
+        '200':
+          description: foobar
+          content:
+            application/json: {}
+    delete:
+      operationId: fooBarDelete
+      servers:
+        - url: http://localhost/v12beta
+      responses:
+        '200':
+          description: foobar
+          content:
+            application/json: {}
+  /{apiVersion}/bar/foo:
+    parameters:
+    - name: apiVersion
+      in: path
+      required: true
+      schema:
+        type: string
+        default: v9canary
+    get:
+      operationId: barFooGet
+      responses:
+        '200':
+          description: foobar
+          content:
+            application/json: {}
+    post:
+      operationId: barFooPost
+      servers:
+        - url: http://localhost/v100beta
+      responses:
+        '200':
+          description: foobar
+          content:
+            application/json: {}

--- a/tests/fixtures/docs_url_test.yaml
+++ b/tests/fixtures/docs_url_test.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.1
+info:
+  title: API Specification
+  version: 1.0.0
+servers:
+  - url: http://localhost/v4
+paths:
+  /foo/bar:
+    get:
+      summary: get info
+      operationId: BarGet
+      description: This is description
+      tags:
+        - Foo
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      externalDocs:
+        description: cool docs url
+        url: https://techdocs.akamai.com/linode-api/reference/cool-docs-url
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}

--- a/tests/fixtures/output_test_get.yaml
+++ b/tests/fixtures/output_test_get.yaml
@@ -3,7 +3,7 @@ info:
   title: API Specification
   version: 1.0.0
 servers:
-  - url: http://localhost
+  - url: http://localhost/v4
 
 paths:
   /foo/bar:

--- a/tests/fixtures/overrides_test_get.yaml
+++ b/tests/fixtures/overrides_test_get.yaml
@@ -3,7 +3,7 @@ info:
   title: API Specification
   version: 1.0.0
 servers:
-  - url: http://localhost
+  - url: http://localhost/v4
 
 paths:
   /foo/bar:

--- a/tests/fixtures/response_test_get.yaml
+++ b/tests/fixtures/response_test_get.yaml
@@ -3,7 +3,7 @@ info:
   title: API Specification
   version: 1.0.0
 servers:
-  - url: http://localhost
+  - url: http://localhost/v4
 
 paths:
   /foo/bar:

--- a/tests/fixtures/subtable_test_get.yaml
+++ b/tests/fixtures/subtable_test_get.yaml
@@ -3,7 +3,7 @@ info:
   title: API Specification
   version: 1.0.0
 servers:
-  - url: http://localhost
+  - url: http://localhost/v4
 
 paths:
   /foo/bar:

--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -244,7 +244,7 @@ def get_user_id():
                 "--delimiter",
                 ",",
                 "--format",
-                "id",
+                "username",
             ]
         )
         .stdout.decode()

--- a/tests/integration/beta/test_beta_program.py
+++ b/tests/integration/beta/test_beta_program.py
@@ -22,7 +22,7 @@ def test_beta_list():
 
 @pytest.fixture
 def get_beta_id():
-    beta_id = (
+    beta_ids = (
         exec_test_command(
             BASE_CMD
             + [
@@ -39,7 +39,10 @@ def get_beta_id():
         .rstrip()
         .splitlines()
     )
-    first_id = beta_id[0]
+    if not beta_ids or beta_ids == [""]:
+        pytest.skip("No betas available to test.")
+
+    first_id = beta_ids[0]
     yield first_id
 
 

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -2,7 +2,10 @@ import textwrap
 
 import pytest
 
-from tests.integration.helpers import exec_test_command
+from tests.integration.helpers import (
+    contains_at_least_one_of,
+    exec_test_command,
+)
 
 
 @pytest.mark.smoke
@@ -11,11 +14,18 @@ def test_help_page_for_non_aliased_actions():
     output = process.stdout.decode()
     wrapped_output = textwrap.fill(output, width=150).replace("\n", "")
 
-    assert "Linodes List" in wrapped_output
-    assert (
-        "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list"
-        in wrapped_output
+    assert contains_at_least_one_of(
+        wrapped_output, ["Linodes List", "List Linodes"]
     )
+
+    assert contains_at_least_one_of(
+        wrapped_output,
+        [
+            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list",
+            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#list-linodes",
+        ],
+    )
+
     assert "You may filter results with:" in wrapped_output
     assert "--tags" in wrapped_output
 
@@ -26,10 +36,17 @@ def test_help_page_for_aliased_actions():
     output = process.stdout.decode()
     wrapped_output = textwrap.fill(output, width=150).replace("\n", "")
 
-    assert "Linodes List" in wrapped_output
-    assert (
-        "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list"
-        in wrapped_output
+    assert contains_at_least_one_of(
+        wrapped_output, ["Linodes List", "List Linodes"]
     )
+
+    assert contains_at_least_one_of(
+        wrapped_output,
+        [
+            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list",
+            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#list-linodes",
+        ],
+    )
+
     assert "You may filter results with:" in wrapped_output
     assert "--tags" in wrapped_output

--- a/tests/integration/cli/test_help.py
+++ b/tests/integration/cli/test_help.py
@@ -22,7 +22,7 @@ def test_help_page_for_non_aliased_actions():
         wrapped_output,
         [
             "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list",
-            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#list-linodes",
+            "API Documentation:  https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
         ],
     )
 
@@ -44,7 +44,7 @@ def test_help_page_for_aliased_actions():
         wrapped_output,
         [
             "API Documentation:  https://www.linode.com/docs/api/linode-instances/#linodes-list",
-            "API Documentation:  https://www.linode.com/docs/api/linode-instances/#list-linodes",
+            "API Documentation:  https://techdocs.akamai.com/linode-api/reference/get-linode-instances",
         ],
     )
 

--- a/tests/integration/cli/test_host_overrides.py
+++ b/tests/integration/cli/test_host_overrides.py
@@ -8,7 +8,9 @@ from tests.integration.helpers import INVALID_HOST, exec_failing_test_command
 def test_cli_command_fails_to_access_invalid_host(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("LINODE_CLI_API_HOST", INVALID_HOST)
 
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"])
+    process = exec_failing_test_command(
+        ["linode-cli", "linodes", "ls"], expected_code=1
+    )
     output = process.stderr.decode()
 
     expected_output = ["Max retries exceeded with url:", "wrongapi.linode.com"]
@@ -29,7 +31,9 @@ def test_cli_command_fails_to_access_invalid_api_scheme(
     monkeypatch: MonkeyPatch,
 ):
     monkeypatch.setenv("LINODE_CLI_API_SCHEME", "ssh")
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"])
+    process = exec_failing_test_command(
+        ["linode-cli", "linodes", "ls"], expected_code=1
+    )
     output = process.stderr.decode()
 
     assert "ssh://" in output

--- a/tests/integration/domains/test_domain_records.py
+++ b/tests/integration/domains/test_domain_records.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.integration.helpers import (
     SUCCESS_STATUS_CODE,
+    contains_at_least_one_of,
     delete_target_id,
     exec_test_command,
 )
@@ -207,7 +208,9 @@ def test_help_records_list(test_domain_and_record):
     )
     output = process.stdout.decode()
 
-    assert "Domain Records List" in output
+    assert contains_at_least_one_of(
+        output, ["List domain records", "Domain Records List"]
+    )
     assert "You may filter results with:" in output
     assert "--type" in output
     assert "--name" in output

--- a/tests/integration/events/test_events.py
+++ b/tests/integration/events/test_events.py
@@ -43,10 +43,15 @@ def test_print_events_usage_information():
     output = process.stdout.decode()
 
     assert "linode-cli events [ACTION]" in output
-    assert re.search("mark-read.*Event Mark as Read", output)
-    assert re.search("mark-seen.*Event Mark as Seen", output)
-    assert re.search("list.*Events List", output)
-    assert re.search("view.*Event View", output)
+
+    assert re.search(
+        "mark-read.*(Event Mark as Read|Mark an event as read)", output
+    )
+    assert re.search(
+        "mark-seen.*(Event Mark as Seen|Mark an event as seen)", output
+    )
+    assert re.search("list.*(Events List|List events)", output)
+    assert re.search("view.*(Event View|Get an event)", output)
 
 
 @pytest.mark.smoke

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,13 +2,18 @@ import random
 import subprocess
 import time
 from string import ascii_lowercase
-from typing import Callable, List
+from typing import Callable, Container, Iterable, List, TypeVar
+
+from linodecli import ExitCodes
 
 BASE_URL = "https://api.linode.com/v4/"
 INVALID_HOST = "https://wrongapi.linode.com"
 SUCCESS_STATUS_CODE = 0
 FAILED_STATUS_CODE = 256
 COMMAND_JSON_OUTPUT = ["--suppress-warnings", "--no-defaults", "--json"]
+
+# TypeVars for generic type hints below
+T = TypeVar("T")
 
 
 def get_random_text(length: int = 10):
@@ -34,7 +39,9 @@ def exec_test_command(args: List[str]):
     return process
 
 
-def exec_failing_test_command(args: List[str], expected_code: int = 1):
+def exec_failing_test_command(
+    args: List[str], expected_code: int = ExitCodes.REQUEST_FAILED
+):
     process = subprocess.run(args, stderr=subprocess.PIPE)
     assert process.returncode == expected_code
     return process
@@ -137,3 +144,7 @@ def count_lines(text: str):
 def assert_headers_in_lines(headers, lines):
     for header in headers:
         assert header in lines[0]
+
+
+def contains_at_least_one_of(target: Container[T], search_for: Iterable[T]):
+    return any(v in target for v in search_for)

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -8,6 +8,7 @@ from typing import List
 
 import pytest
 
+from linodecli import ExitCodes
 from tests.integration.helpers import get_random_text
 
 REGION = "us-iad"
@@ -57,7 +58,7 @@ def test_invalid_file(
     )
     output = process.stdout.decode()
 
-    assert process.returncode == 2
+    assert process.returncode == ExitCodes.FILE_ERROR
     assert f"No file at {file_path}" in output
 
 

--- a/tests/integration/linodes/test_backups.py
+++ b/tests/integration/linodes/test_backups.py
@@ -73,7 +73,7 @@ def test_create_linode_with_backup_disabled(
             "list",
             "--id",
             linode_id,
-            "--format=id,enabled",
+            "--format=id,backups.enabled",
             "--delimiter",
             ",",
             "--text",
@@ -102,7 +102,7 @@ def test_enable_backups(create_linode_setup):
         BASE_CMD
         + [
             "list",
-            "--format=id,enabled",
+            "--format=id,backups.enabled",
             "--delimiter",
             ",",
             "--text",
@@ -119,7 +119,7 @@ def test_create_backup_with_backup_enabled(linode_backup_enabled):
         BASE_CMD
         + [
             "list",
-            "--format=id,enabled",
+            "--format=id,backups.enabled",
             "--delimiter",
             ",",
             "--text",

--- a/tests/integration/support/test_support.py
+++ b/tests/integration/support/test_support.py
@@ -52,7 +52,7 @@ def tickets_id():
         )
         .stdout.decode()
         .rstrip()
-        .split(",")
+        .splitlines()
     )
     first_id = ticket_ids[0]
     yield first_id

--- a/tests/integration/volumes/test_volumes.py
+++ b/tests/integration/volumes/test_volumes.py
@@ -147,10 +147,20 @@ def test_fail_to_create_volume_with_all_numberic_label():
 
 def test_list_volume(test_volume_id):
     result = exec_test_command(
-        BASE_CMD + ["list", "--text", "--no-headers", "--delimiter", ","]
+        BASE_CMD
+        + [
+            "list",
+            "--text",
+            "--no-headers",
+            "--delimiter",
+            ",",
+            "--format",
+            "id,label,status,region,size,linode_id,linode_label",
+        ]
     ).stdout.decode()
     assert re.search(
-        "[0-9]+,[A-Za-z0-9].*,.*,(creating|active|offline),.*", result
+        "[0-9]+,[A-Za-z0-9-]+,(creating|active|offline),[A-Za-z0-9-]+,[0-9]+,,",
+        result,
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -299,6 +299,16 @@ def get_openapi_for_api_components_tests() -> OpenAPI:
 
 
 @pytest.fixture
+def get_openapi_for_docs_url_tests() -> OpenAPI:
+    """
+    Creates a set of OpenAPI operations with a GET endpoint using the
+    legacy-style docs URL and a POST endpoint using the new-style docs URL.
+    """
+
+    return _get_parsed_spec("docs_url_test.yaml")
+
+
+@pytest.fixture
 def mocked_config():
     """
     mock config representing cli.config

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -106,7 +106,7 @@ def list_operation():
 
     linode-cli foo bar --filterable_result [value]
 
-    GET http://localhost/foo/bar
+    GET http://localhost/v4/foo/bar
     {}
 
     X-Filter: {"filterable_result": "value"}
@@ -135,7 +135,7 @@ def create_operation():
 
     linode-cli foo bar --generic_arg [generic_arg] test_param
 
-    POST http://localhost/foo/bar
+    POST http://localhost/v4/foo/bar
     {
         "generic_arg": "[generic_arg]",
         "test_param": test_param
@@ -164,7 +164,7 @@ def list_operation_for_output_tests():
     """
     Creates the following CLI operation:
 
-    GET http://localhost/foo/bar
+    GET http://localhost/v4/foo/bar
     {}
 
     X-Filter: {"cool": "value"}
@@ -192,7 +192,7 @@ def list_operation_for_overrides_test():
     """
     Creates the following CLI operation:
 
-    GET http://localhost/foo/bar
+    GET http://localhost/v4/foo/bar
     {}
 
     X-Filter: {"cool": "value"}
@@ -221,7 +221,7 @@ def list_operation_for_response_test():
     """
     Creates the following CLI operation:
 
-    GET http://localhost/foo/bar
+    GET http://localhost/v4/foo/bar
     {}
 
     X-Filter: {"cool": "value"}
@@ -250,7 +250,7 @@ def get_operation_for_subtable_test():
     """
     Creates the following CLI operation:
 
-    GET http://localhost/foo/bar
+    GET http://localhost/v4/foo/bar
 
     Returns {
         "table": [
@@ -286,6 +286,16 @@ def get_operation_for_subtable_test():
     method = "get"
 
     return make_test_operation(command, operation, method, path.parameters)
+
+
+@pytest.fixture
+def get_openapi_for_api_components_tests() -> OpenAPI:
+    """
+    Creates a set of OpenAPI operations with various apiVersion and
+    `server` configurations.
+    """
+
+    return _get_parsed_spec("api_url_components_test.yaml")
 
 
 @pytest.fixture

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -187,7 +187,7 @@ class TestAPIRequest:
             mock_cli, create_operation, SimpleNamespace()
         )
 
-        assert "http://localhost/foo/bar" == result
+        assert "http://localhost/v4/foo/bar" == result
 
     def test_build_filter_header(self, list_operation):
         result = api_request._build_filter_header(
@@ -363,7 +363,7 @@ class TestAPIRequest:
         mock_response = Mock(status_code=200, reason="OK")
 
         def validate_http_request(url, headers=None, data=None, **kwargs):
-            assert url == "http://localhost/foo/bar"
+            assert url == "http://localhost/v4/foo/bar"
             assert data == json.dumps(
                 {
                     "test_param": 12345,

--- a/tests/unit/test_help_pages.py
+++ b/tests/unit/test_help_pages.py
@@ -4,55 +4,58 @@ from linodecli import help_pages
 
 
 class TestHelpPages:
-    def test_filter_markdown_links(self):
-        """
-        Ensures that Markdown links are properly converted to their rich equivalents.
-        """
-
-        original_text = "Here's [a relative link](/docs/cool) and [an absolute link](https://cloud.linode.com)."
-        expected_text = (
-            "Here's a relative link ([link=https://linode.com/docs/cool]https://linode.com/docs/cool[/link]) "
-            "and an absolute link ([link=https://cloud.linode.com]https://cloud.linode.com[/link])."
-        )
-
-        assert (
-            help_pages._markdown_links_to_rich(original_text) == expected_text
-        )
-
     def test_group_arguments(self, capsys):
         # NOTE: We use SimpleNamespace here so we can do deep comparisons using ==
         args = [
             SimpleNamespace(
-                read_only=False,
-                required=True,
-                path="foo",
+                read_only=False, required=False, depth=0, path="foobaz"
             ),
-            SimpleNamespace(read_only=False, required=False, path="foo.bar"),
-            SimpleNamespace(read_only=False, required=False, path="foobaz"),
-            SimpleNamespace(read_only=False, required=False, path="foo.foo"),
-            SimpleNamespace(read_only=False, required=False, path="foobar"),
-            SimpleNamespace(read_only=False, required=True, path="barfoo"),
+            SimpleNamespace(
+                read_only=False, required=False, depth=0, path="foobar"
+            ),
+            SimpleNamespace(
+                read_only=False, required=True, depth=0, path="barfoo"
+            ),
+            SimpleNamespace(
+                read_only=False, required=False, depth=0, path="foo"
+            ),
+            SimpleNamespace(
+                read_only=False, required=False, depth=1, path="foo.bar"
+            ),
+            SimpleNamespace(
+                read_only=False, required=False, depth=1, path="foo.foo"
+            ),
+            SimpleNamespace(
+                read_only=False, required=True, depth=1, path="foo.baz"
+            ),
         ]
 
         expected = [
             [
-                SimpleNamespace(read_only=False, required=True, path="barfoo"),
+                SimpleNamespace(
+                    read_only=False, required=True, path="barfoo", depth=0
+                ),
             ],
             [
-                SimpleNamespace(read_only=False, required=False, path="foobar"),
-                SimpleNamespace(read_only=False, required=False, path="foobaz"),
+                SimpleNamespace(
+                    read_only=False, required=False, path="foobar", depth=0
+                ),
+                SimpleNamespace(
+                    read_only=False, required=False, path="foobaz", depth=0
+                ),
             ],
             [
                 SimpleNamespace(
-                    read_only=False,
-                    required=True,
-                    path="foo",
+                    read_only=False, required=False, path="foo", depth=0
                 ),
                 SimpleNamespace(
-                    read_only=False, required=False, path="foo.bar"
+                    read_only=False, required=True, path="foo.baz", depth=1
                 ),
                 SimpleNamespace(
-                    read_only=False, required=False, path="foo.foo"
+                    read_only=False, required=False, path="foo.bar", depth=1
+                ),
+                SimpleNamespace(
+                    read_only=False, required=False, path="foo.foo", depth=1
                 ),
             ],
         ]
@@ -136,6 +139,7 @@ class TestHelpPages:
                 required=True,
                 path="path",
                 description="test description",
+                description_rich="test description",
                 depth=0,
             ),
             mocker.MagicMock(
@@ -143,6 +147,7 @@ class TestHelpPages:
                 required=False,
                 path="path2",
                 description="test description 2",
+                description_rich="test description 2",
                 format="json",
                 nullable=True,
                 depth=0,

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -4,7 +4,11 @@ import io
 import json
 
 from linodecli.baked import operation
-from linodecli.baked.operation import ExplicitEmptyListValue, ExplicitNullValue
+from linodecli.baked.operation import (
+    ExplicitEmptyListValue,
+    ExplicitNullValue,
+    OpenAPIOperation,
+)
 
 
 class TestOperation:
@@ -272,3 +276,22 @@ class TestOperation:
         # User specifies a normal value and an empty list value
         result = parser.parse_args(["--foo", "foo", "--foo", "[]"])
         assert getattr(result, "foo") == ["foo", "[]"]
+
+    def test_resolve_api_components(self, get_openapi_for_api_components_tests):
+        root = get_openapi_for_api_components_tests
+
+        assert OpenAPIOperation._get_api_url_components(
+            operation=root.paths["/foo/bar"].get, params=[]
+        ) == ("http://localhost", "/{apiVersion}/foo/bar", "v19")
+
+        assert OpenAPIOperation._get_api_url_components(
+            operation=root.paths["/foo/bar"].delete, params=[]
+        ) == ("http://localhost", "/{apiVersion}/foo/bar", "v12beta")
+
+        assert OpenAPIOperation._get_api_url_components(
+            operation=root.paths["/{apiVersion}/bar/foo"].get, params=[]
+        ) == ("http://localhost", "/{apiVersion}/bar/foo", "v19")
+
+        assert OpenAPIOperation._get_api_url_components(
+            operation=root.paths["/{apiVersion}/bar/foo"].post, params=[]
+        ) == ("http://localhost", "/{apiVersion}/bar/foo", "v100beta")

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -295,3 +295,19 @@ class TestOperation:
         assert OpenAPIOperation._get_api_url_components(
             operation=root.paths["/{apiVersion}/bar/foo"].post, params=[]
         ) == ("http://localhost", "/{apiVersion}/bar/foo", "v100beta")
+
+    def test_resolve_docs_url_legacy(self, get_openapi_for_docs_url_tests):
+        root = get_openapi_for_docs_url_tests
+
+        assert (
+            OpenAPIOperation._resolve_operation_docs_url(
+                root.paths["/foo/bar"].get
+            )
+            == "https://www.linode.com/docs/api/foo/#get-info"
+        )
+        assert (
+            OpenAPIOperation._resolve_operation_docs_url(
+                root.paths["/foo/bar"].post
+            )
+            == "https://techdocs.akamai.com/linode-api/reference/cool-docs-url"
+        )

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -1,0 +1,103 @@
+from linodecli.baked.parsing import (
+    extract_markdown_links,
+    get_short_description,
+    markdown_to_rich_markup,
+    strip_techdocs_prefixes,
+)
+
+
+class TestParsing:
+    """
+    Unit tests for linodecli.parsing
+    """
+
+    def test_extract_markdown_links(self):
+        """
+        Ensures that Markdown links are properly extracted and removed from a string.
+        """
+
+        original_text = "Here's [a relative link](/docs/cool) and [an absolute link](https://cloud.linode.com)."
+
+        result_text, result_links = extract_markdown_links(original_text)
+
+        assert result_text == "Here's a relative link and an absolute link."
+        assert result_links == [
+            "https://linode.com/docs/cool",
+            "https://cloud.linode.com",
+        ]
+
+    def test_get_first_sentence(self):
+        assert (
+            get_short_description(
+                "This is a sentence. This is another sentence."
+            )
+            == "This is a sentence."
+        )
+
+        # New line delimiter
+        assert (
+            get_short_description(
+                "This is a sentence.\nThis is another sentence."
+            )
+            == "This is a sentence."
+        )
+
+        # Multi-space delimiter
+        assert (
+            get_short_description(
+                "This is a sentence.   This is another sentence."
+            )
+            == "This is a sentence."
+        )
+
+        # Tab delimiter
+        assert (
+            get_short_description(
+                "This is a sentence.    This is another sentence."
+            )
+            == "This is a sentence."
+        )
+
+        assert (
+            get_short_description("This is a sentence.")
+            == "This is a sentence."
+        )
+
+        assert (
+            get_short_description(
+                "__Note__. This might be a sentence.\nThis is a sentence."
+            )
+            == "This is a sentence."
+        )
+
+    def test_get_techdocs_prefixes(self):
+        assert (
+            strip_techdocs_prefixes(
+                "__Read-only__ The last successful backup date. 'null' if there was no previous backup.",
+            )
+            == "The last successful backup date. 'null' if there was no previous backup."
+        )
+
+        assert (
+            strip_techdocs_prefixes(
+                "__Filterable__, __Read-only__ This Linode's ID which "
+                "must be provided for all operations impacting this Linode.",
+            )
+            == "This Linode's ID which must be provided for all operations impacting this Linode."
+        )
+
+        assert (
+            strip_techdocs_prefixes(
+                "Do something cool.",
+            )
+            == "Do something cool."
+        )
+
+    def test_markdown_to_rich_markup(self):
+        assert (
+            markdown_to_rich_markup(
+                "very *cool* **test** _string_*\n__wow__ *cool** `code block` `"
+            )
+            == "very [i]cool[/] [b]test[/] [i]string[/]*\n[b]wow[/] [i]cool[/]* "
+            "[italic deep_pink3 on grey15]code block[/] `"
+        )


### PR DESCRIPTION
## 📝 Description

This pull request resolves a few issues in the OpenAPI spec generation/baking logic that prevented it from being compatible with the upcoming new TechDocs OpenAPI spec. The changes in this PR were also made to be backwards compatible to make sure the transition between specs goes smoothly 🙂 

Because this PR needed to be all-encompassing, it also includes a bunch of minor fixes that should get previously failing integration tests passing.

Additionally this PR requires a few minor changes to the internal documentation linked in TPT-3016.

## ✔️ How to Test

**NOTE: You will need to opt into Linode Managed for the managed-related tests to pass. If you would like to subsequently opt-out of Linode Managed, see the description of TPT-3016.**

The following test steps assume you have pulled down this PR locally.

### Building & Installing the CLI 

#### With the TechDocs OpenAPI Spec

1. Download the (modified) new OpenAPI spec YAML file to `openapi-techdocs.yaml` (see TPT-3016's description). 
2. Install the local version of the CLI using the new spec file:

```
make SPEC=$PWD/openapi-techdocs.yaml install
```

From here you should be able to run and test arbitrary commands using `linode-cli`.

#### With the Legacy (linode-api-docs) OpenAPI Spec

1. Install the local version of the CLI without specifying the `SPEC` argument:

```
make install
```

From here you should be able to run and test arbitrary commands using `linode-cli`.

### Integration Testing

**NOTE: This test command should be run for both versions of the CLI installed above.**

```
make testint
```

NOTE: The following tests are expected to fail when running against the legacy spec due to bug fixes that were only applied to the TechDocs spec:
* account/test_account.py::test_user_view


### Unit Testing

```
make testunit
```