### PR TITLE
Fixed exit code related integration tests

### DIFF
--- a/tests/integration/cli/test_host_overrides.py
+++ b/tests/integration/cli/test_host_overrides.py
@@ -9,7 +9,9 @@ from tests.integration.helpers import INVALID_HOST, exec_failing_test_command
 def test_cli_command_fails_to_access_invalid_host(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("LINODE_CLI_API_HOST", INVALID_HOST)
 
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND)
+    process = exec_failing_test_command(
+        ["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND
+    )
     output = process.stderr.decode()
 
     expected_output = ["Max retries exceeded with url:", "wrongapi.linode.com"]
@@ -30,7 +32,9 @@ def test_cli_command_fails_to_access_invalid_api_scheme(
     monkeypatch: MonkeyPatch,
 ):
     monkeypatch.setenv("LINODE_CLI_API_SCHEME", "ssh")
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND)
+    process = exec_failing_test_command(
+        ["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND
+    )
     output = process.stderr.decode()
 
     assert "ssh://" in output

--- a/tests/integration/cli/test_host_overrides.py
+++ b/tests/integration/cli/test_host_overrides.py
@@ -2,13 +2,14 @@ import os
 
 from pytest import MonkeyPatch
 
+from linodecli.exit_codes import ExitCodes
 from tests.integration.helpers import INVALID_HOST, exec_failing_test_command
 
 
 def test_cli_command_fails_to_access_invalid_host(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("LINODE_CLI_API_HOST", INVALID_HOST)
 
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"])
+    process = exec_failing_test_command(["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND)
     output = process.stderr.decode()
 
     expected_output = ["Max retries exceeded with url:", "wrongapi.linode.com"]
@@ -29,7 +30,7 @@ def test_cli_command_fails_to_access_invalid_api_scheme(
     monkeypatch: MonkeyPatch,
 ):
     monkeypatch.setenv("LINODE_CLI_API_SCHEME", "ssh")
-    process = exec_failing_test_command(["linode-cli", "linodes", "ls"])
+    process = exec_failing_test_command(["linode-cli", "linodes", "ls"], ExitCodes.UNRECOGNIZED_COMMAND)
     output = process.stderr.decode()
 
     assert "ssh://" in output

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -36,7 +36,9 @@ def exec_test_command(args: List[str]):
     return process
 
 
-def exec_failing_test_command(args: List[str], expected_code: int = ExitCodes.REQUEST_FAILED):
+def exec_failing_test_command(
+    args: List[str], expected_code: int = ExitCodes.REQUEST_FAILED
+):
     process = subprocess.run(args, stderr=subprocess.PIPE)
     assert process.returncode == expected_code
     return process

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,8 @@ import time
 from string import ascii_lowercase
 from typing import Callable, List
 
+from linodecli.exit_codes import ExitCodes
+
 BASE_URL = "https://api.linode.com/v4/"
 INVALID_HOST = "https://wrongapi.linode.com"
 SUCCESS_STATUS_CODE = 0
@@ -34,7 +36,7 @@ def exec_test_command(args: List[str]):
     return process
 
 
-def exec_failing_test_command(args: List[str], expected_code: int = 1):
+def exec_failing_test_command(args: List[str], expected_code: int = ExitCodes.REQUEST_FAILED):
     process = subprocess.run(args, stderr=subprocess.PIPE)
     assert process.returncode == expected_code
     return process

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -57,7 +57,7 @@ def test_invalid_file(
     )
     output = process.stdout.decode()
 
-    assert process.returncode == 2
+    assert process.returncode == 8
     assert f"No file at {file_path}" in output
 
 


### PR DESCRIPTION
## 📝 Description

Fixed integration tests that were failing due to changes in exit codes across the project.

## ✔️ How to Test

`make testint`

NOTE: The following integration tests are failing for reasons unrelated to exit codes
- tests/integration/account/test_account.py::test_user_view
- tests/integration/support/test_support.py::test_tickets_view
- tests/integration/support/test_support.py::test_view_replies_support_ticket