### PR TITLE
Add Paginator to Recursively Delete All Objects Before Delete Bucket

### DIFF
--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -426,7 +426,8 @@ def call(
             COMMAND_MAP[parsed.command](
                 get_client, args, suppress_warnings=parsed.suppress_warnings
             )
-        except ClientError:
+        except ClientError as e:
+            print(e)
             sys.exit(ExitCodes.REQUEST_FAILED)
     elif parsed.command == "regenerate-keys":
         regenerate_s3_credentials(

--- a/linodecli/plugins/obj/buckets.py
+++ b/linodecli/plugins/obj/buckets.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 from linodecli.exit_codes import ExitCodes
 from linodecli.plugins import inherit_plugin_args
 from linodecli.plugins.obj.config import PLUGIN_BASE
+from linodecli.plugins.obj.helpers import _delete_all_objects
 
 
 def create_bucket(
@@ -61,23 +62,9 @@ def delete_bucket(
     bucket_name = parsed.name
 
     if parsed.recursive:
-        objects = [
-            {"Key": obj.get("Key")}
-            for obj in client.list_objects_v2(Bucket=bucket_name).get(
-                "Contents", []
-            )
-            if obj.get("Key")
-        ]
-        client.delete_objects(
-            Bucket=bucket_name,
-            Delete={
-                "Objects": objects,
-                "Quiet": False,
-            },
-        )
+        _delete_all_objects(client, bucket_name)
 
     client.delete_bucket(Bucket=bucket_name)
-
     print(f"Bucket {parsed.name} removed")
 
     sys.exit(ExitCodes.SUCCESS)

--- a/linodecli/plugins/obj/helpers.py
+++ b/linodecli/plugins/obj/helpers.py
@@ -142,3 +142,50 @@ def flip_to_page(iterable: Iterable, page: int = 1):
             sys.exit(ExitCodes.REQUEST_FAILED)
 
     return next(iterable)
+
+
+def _get_objects_for_deletion_from_page(object_type, page, versioned=False):
+    return [
+        (
+            {"Key": obj["Key"], "VersionId": obj["VersionId"]}
+            if versioned
+            else {"Key": obj["Key"]}
+        )
+        for obj in page.get(object_type, [])
+    ]
+
+
+def _delete_all_objects(client, bucket_name):
+    pages = client.get_paginator("list_objects_v2").paginate(
+        Bucket=bucket_name, PaginationConfig={"PageSize": 1000}
+    )
+    for page in pages:
+        client.delete_objects(
+            Bucket=bucket_name,
+            Delete={
+                "Objects": _get_objects_for_deletion_from_page(
+                    "Contents", page
+                ),
+                "Quiet": False,
+            },
+        )
+
+    for page in client.get_paginator("list_object_versions").paginate(
+        Bucket=bucket_name, PaginationConfig={"PageSize": 1000}
+    ):
+        client.delete_objects(
+            Bucket=bucket_name,
+            Delete={
+                "Objects": _get_objects_for_deletion_from_page(
+                    "Versions", page, True
+                )
+            },
+        )
+        client.delete_objects(
+            Bucket=bucket_name,
+            Delete={
+                "Objects": _get_objects_for_deletion_from_page(
+                    "DeleteMarkers", page, True
+                )
+            },
+        )

--- a/tests/integration/obj/test_obj_plugin.py
+++ b/tests/integration/obj/test_obj_plugin.py
@@ -94,8 +94,8 @@ def create_bucket(
     for bk in created_buckets:
         try:
             delete_bucket(bk)
-        except:
-            logging.exception(f"Failed to cleanup bucket: {bk}")
+        except Exception as e:
+            logging.exception(f"Failed to cleanup bucket: {bk}, {e}")
 
 
 def delete_bucket(bucket_name: str, force: bool = True):
@@ -208,6 +208,27 @@ def test_multi_files_multi_bucket(
             output = process.stdout.decode()
             assert "100.0%" in output
             assert "Done" in output
+
+
+@pytest.mark.skip(reason="Long run test case")
+def test_large_number_of_files_single_bucket(
+    create_bucket: Callable[[Optional[str]], str],
+    generate_test_files: GetTestFilesType,
+    keys: Keys,
+    monkeypatch: MonkeyPatch,
+):
+    patch_keys(keys, monkeypatch)
+
+    number = 1005
+    bucket_name = create_bucket()
+    file_paths = generate_test_files(number)
+    for file in file_paths:
+        process = exec_test_command(
+            BASE_CMD + ["put", str(file.resolve()), bucket_name]
+        )
+        output = process.stdout.decode()
+        assert "100.0%" in output
+        assert "Done" in output
 
 
 def test_all_rows(


### PR DESCRIPTION
## 📝 Description

- Fixed issues:
  - A `ClientError` happens in the S3 client doesn't have any error message output
  - Versioned buckets containing objects can't be deleted recursively
  - Buckets containing more than 1000 objects can't be deleted recursively

## ✔️ How to Test

### Automated Testing
```bash
pytest tests/integration/obj/test_obj_plugin.py -k "test_large_number_of_files_single_bucket"
```

### Manual Testing
You can create these objects and buckets with OpenTofu/Terraform, but they will run for a very long time to create 2010 objects.

```bash
tofu apply -parallelism=100
```

```terraform
provider "linode" {
  obj_bucket_force_delete = true
}

resource "linode_object_storage_bucket" "nonversioned-bucket" {
  region = "us-mia"
  label  = "test-cli-recursive-rb1"
}

resource "linode_object_storage_bucket" "versioned-bucket" {
  region = "us-mia"
  label  = "test-cli-recursive-rb2"
  versioning = true
}

resource "linode_object_storage_key" "foobar" {
  label   = "my-key"
}

resource "linode_object_storage_object" "objects" {
  count  = 1005
  bucket = linode_object_storage_bucket.nonversioned-bucket.label
  region = linode_object_storage_bucket.nonversioned-bucket.region
  key    = "myobj-${count.index}"

  access_key = linode_object_storage_key.foobar.access_key
  secret_key = linode_object_storage_key.foobar.secret_key

  content          = "haha"
  content_type     = "text/plain"
  content_language = "en"
}

resource "linode_object_storage_object" "versioned-objects" {
  count  = 1005
  bucket = linode_object_storage_bucket.versioned-bucket.label
  region = linode_object_storage_bucket.versioned-bucket.region
  key    = "myobj-${count.index}"

  access_key = linode_object_storage_key.foobar.access_key
  secret_key = linode_object_storage_key.foobar.secret_key

  content          = "haha"
  content_type     = "text/plain"
  content_language = "en"
}
```

And then remove them via CLI:
```bash
linode obj rb test-cli-recursive-rb1 --recursive;
linode obj rb test-cli-recursive-rb2 --recursive;
```
