### PR TITLE
Add suppress-version-warning config option

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -374,11 +374,9 @@ def _attempt_warn_old_version(ctx, result):
                 "with --suppress-warnings",
                 file=sys.stderr,
             )
-        suppress_version_warning = False
-        if ctx.config.get_bool("suppress-version-warning") or os.getenv(
+        suppress_version_warning = ctx.config.get_bool("suppress-version-warning") or os.getenv(
             "LINODE_CLI_SUPPRESS_VERSION_WARNING"
-        ):
-            suppress_version_warning = True
+        )
         if new_version_exists and not suppress_version_warning:
             print(
                 f"The API responded with version {spec_version}, which is newer than "

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -4,6 +4,7 @@ This module is responsible for handling HTTP requests to the Linode API.
 
 import itertools
 import json
+import os
 import sys
 import time
 from typing import Any, Iterable, List, Optional
@@ -373,8 +374,12 @@ def _attempt_warn_old_version(ctx, result):
                 "with --suppress-warnings",
                 file=sys.stderr,
             )
-
-        if new_version_exists:
+        suppress_version_warning = False
+        if ctx.config.get_bool("suppress-version-warning") or os.getenv(
+            "LINODE_CLI_SUPPRESS_VERSION_WARNING"
+        ):
+            suppress_version_warning = True
+        if new_version_exists and not suppress_version_warning:
             print(
                 f"The API responded with version {spec_version}, which is newer than "
                 f"the CLI's version of {ctx.spec_version}.  Please update the CLI to get "

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -186,6 +186,30 @@ class CLIConfig:
 
         return self.config.get(username, key)
 
+    def get_bool(self, key: str) -> bool:
+        """
+        Retrieves and returns an existing config boolean for the current user.  This
+        is intended for plugins to use instead of having to deal with figuring out
+        who the current user is when accessing their config.
+
+        .. warning::
+           Plugins _MUST NOT_ set values for the user's config except through
+           ``plugin_set_value`` below.
+
+        :param key: The key to look up.
+        :type key: str
+
+        :returns: The boolean for that key, or False if the key doesn't exist for the
+                  current user.
+        :rtype: any
+        """
+        username = self.username or self.default_username()
+
+        if not self.config.has_option(username, key):
+            return False
+
+        return self.config.getboolean(username, key)
+
     # plugin methods - these are intended for plugins to utilize to store their
     # own persistent config information
     def plugin_set_value(self, key: str, value: Any):
@@ -448,6 +472,9 @@ class CLIConfig:
 
         if _bool_input("Configure a custom API target?", default=False):
             self._configure_api_target(config)
+
+        if _bool_input("Suppress API Version Warnings?", default=False):
+            config["suppress-version-warning"] = "true"
 
         # save off the new configuration
         if username != "DEFAULT" and not self.config.has_section(username):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -265,6 +265,7 @@ mysql_engine = mysql/8.0.26"""
                 "foobar.linode.com",
                 "v4beta",
                 "https",
+                "n",
             ]
         )
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -38,6 +38,7 @@ image = linode/alpine3.16
 plugin-testplugin-testkey = plugin-test-value
 authorized_users = cli-dev
 mysql_engine = mysql/8.0.26
+suppress-version-warning = true
 
 [cli-dev2]
 token = {test_token}2
@@ -155,6 +156,14 @@ mysql_engine = mysql/8.0.26"""
         conf = self._build_test_config()
         assert conf.get_value("notakey") == None
         assert conf.get_value("region") == "us-east"
+
+    def test_get_bool(self):
+        """
+        Test CLIConfig.get_bool({key})
+        """
+        conf = self._build_test_config()
+        assert conf.get_bool("notakey") == False
+        assert conf.get_bool("suppress-version-warning") == True
 
     def test_plugin_set_value(self):
         """

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -320,7 +320,7 @@ mysql_engine = mysql/8.0.26"""
         """
         conf = configuration.CLIConfig(self.base_url, skip_config=True)
 
-        answers = iter(["1", "1", "1", "1", "1", "1", "n"])
+        answers = iter(["1", "1", "1", "1", "1", "1", "n", "n"])
 
         def mock_input(prompt):
             if not prompt:

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -38,6 +38,9 @@ without having a configuration file, which is desirable in some situations.
 You may also specify the path to a custom Certificate Authority file using the `LINODE_CLI_CA`
 environment variable.
 
+If you wish to hide the API Version warning you can use the `LINODE_CLI_SUPPRESS_VERSION_WARNING`
+environment variable.
+
 ## Configurable API URL
 
 In some cases you may want to run linode-cli against a non-default Linode API URL.


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Adds `get_bool('value')` method for configuration options and adds a step in configuration to support `suppress-version-warning`.
Also adds support for `LINODE_CLI_SUPPRESS_VERSION_WARNING` environment variable.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

1. Install the new version of the CLI
```bash
make install
```
2. Go through the configuration process
```bash
lin configure
```
3. The last question should ask you about suppressing API Version Warnings
4. Use the CLI and see if you view this warning

### Environment variable

1. Install the new CLI or delete the value from your config
2. Use the cli after setting the environment variable
```bash
export LINODE_CLI_SUPPRESS_VERSION_WARNING=true
lin linodes ls
unset $LINODE_CLI_SUPPRESS_VERSION_WARNING
lin linodes ls
```
3. Verify the output doesn't have the error.

**How do I run the relevant unit/integration tests?**

```bash
make testunit
```

resolves #582 