### PR TITLE
new: Break out command help page logic; sort actions in output

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -27,6 +27,7 @@ from .configuration import ENV_TOKEN_NAME
 from .help_pages import (
     HELP_TOPICS,
     print_help_action,
+    print_help_command_actions,
     print_help_commands,
     print_help_default,
     print_help_env_vars,
@@ -224,23 +225,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         and parsed.action is None
         and parsed.command in cli.ops
     ):
-        print(f"linode-cli {parsed.command} [ACTION]")
-        print()
-        print("Available actions: ")
-
-        content = [
-            [", ".join([action, *op.action_aliases]), op.summary]
-            for action, op in cli.ops[parsed.command].items()
-        ]
-
-        table = Table(
-            Column(header="action", no_wrap=True),
-            Column(header="summary", style="cyan"),
-        )
-        for row in content:
-            table.add_row(*row)
-
-        rprint(table)
+        print_help_command_actions(cli.ops, parsed.command)
         sys.exit(ExitCodes.SUCCESS)
 
     if parsed.command is not None and parsed.action is not None:

--- a/linodecli/help_pages.py
+++ b/linodecli/help_pages.py
@@ -3,15 +3,16 @@ This module contains various helper functions related to outputting
 help pages.
 """
 
+import sys
 import textwrap
 from collections import defaultdict
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from rich import box
 from rich import print as rprint
 from rich.console import Console
 from rich.padding import Padding
-from rich.table import Table
+from rich.table import Column, Table
 from rich.text import Text
 
 from linodecli import plugins
@@ -138,6 +139,36 @@ def print_help_default():
         "For comprehensive documentation, "
         "visit https://www.linode.com/docs/api/"
     )
+
+
+def print_help_command_actions(
+    ops: Dict[str, Dict[str, OpenAPIOperation]],
+    command: Optional[str],
+    file=sys.stdout,
+):
+    """
+    Prints the help page for a single command, including all actions
+    under the given command.
+
+    :param ops: A dictionary mapping CLI commands -> actions -> operations.
+    :param command: The command to print the help page for.
+    """
+
+    print(f"linode-cli {command} [ACTION]\n\nAvailable actions: ", file=file)
+
+    content = [
+        [", ".join([action, *op.action_aliases]), op.summary]
+        for action, op in sorted(ops[command].items(), key=lambda v: v[0])
+    ]
+
+    table = Table(
+        Column(header="action", no_wrap=True),
+        Column(header="summary", style="cyan"),
+    )
+    for row in content:
+        table.add_row(*row)
+
+    rprint(table, file=file)
 
 
 def print_help_action(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import configparser
+from typing import List
 
 import pytest
 from openapi3 import OpenAPI
@@ -321,3 +322,22 @@ def mocked_config():
             pass
 
     return Config()
+
+
+def assert_contains_ordered_substrings(target: str, entries: List[str]):
+    """
+    Asserts whether the given string contains the given entries in order,
+    ignoring any irrelevant characters in-between.
+
+    :param target: The string to search.
+    :param entries: The ordered list of entries to search for.
+    """
+
+    start_index = 0
+
+    for entry in entries:
+        find_index = target[start_index:].find(entry)
+        assert find_index >= 0
+
+        # Search for the next entry after the end of this entry
+        start_index = find_index + len(entry)


### PR DESCRIPTION
## 📝 Description

This pull request breaks the CLI command help page logic out into a separate function and implements the logic to sort action entries by name. This should improve the readability of certain groups since the order of actions in the spec is not guaranteed to be readable.

Additionally, this PR adds a new test case to validate the output of this help page.

## ✔️ How to Test

The following test steps expect you have pulled down this PR and run `make install`.

### Unit Testing

```shell
make testunit
```

### Manual Testing

1. View the help page for a single CLI command/group:

```shell
linode-cli networking --help
```

2. Ensure all printed actions are sorted by name.