### PR TITLE
bug: fixed broken links in 'Development - Index.md'

### DIFF
--- a/wiki/development/Development - Index.md
+++ b/wiki/development/Development - Index.md
@@ -2,10 +2,10 @@ This guide will help you get started developing against and contributing to the 
 
 ## Index
 
-1. [Overview](./Development%20-%20Overview)
-2. [Skeleton](./Development%20-%20Skeleton)
-3. [Setup](./Development%20-%20Setup)
-4. [Testing](./Development%20-%20Testing)
+1. [Overview](./Development%20-%20Overview.md)
+2. [Skeleton](./Development%20-%20Skeleton.md)
+3. [Setup](./Development%20-%20Setup.md)
+4. [Testing](./Development%20-%20Testing.md)
 
 ## Contributing
 


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Fixes some broken links on `Development - Index.md` wiki page.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

- Go to the `Development - Index` wiki page on the dev/main branch [here](https://github.com/linode/linode-cli/blob/dev/wiki/development/Development%20-%20Index.md) and try to navigate to any of the links in `Index`.
- You should see a 404 like this: 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9187da98-ee0d-43d0-af20-0534f677ed2f">

- Now go to the same page in this fork, you should be able to navigate properly.