### PR TITLE
test: fix unit tests to not overwrite existing cli config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,12 @@ clean:
 	rm -rf dist linode_cli.egg-info build
 
 .PHONY: testunit
-testunit: export LINODE_CLI_TEST_MODE = 1
 testunit:
-	pytest -v tests/unit
+	@mkdir -p /tmp/linode/.config
+	@orig_xdg_config_home=$${XDG_CONFIG_HOME:-}; \
+	export LINODE_CLI_TEST_MODE=1 XDG_CONFIG_HOME=/tmp/linode/.config; \
+	pytest -v tests/unit; \
+	export XDG_CONFIG_HOME=$$orig_xdg_config_home
 
 .PHONY: testint
 testint:

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -374,9 +374,9 @@ def _attempt_warn_old_version(ctx, result):
                 "with --suppress-warnings",
                 file=sys.stderr,
             )
-        suppress_version_warning = ctx.config.get_bool("suppress-version-warning") or os.getenv(
-            "LINODE_CLI_SUPPRESS_VERSION_WARNING"
-        )
+        suppress_version_warning = ctx.config.get_bool(
+            "suppress-version-warning"
+        ) or os.getenv("LINODE_CLI_SUPPRESS_VERSION_WARNING")
         if new_version_exists and not suppress_version_warning:
             print(
                 f"The API responded with version {spec_version}, which is newer than "


### PR DESCRIPTION
## 📝 Description

Running unit tests caused existing config in `~/.config/linode-cli` to be overwritten, this PR fixes this issue by setting the environment variable prior to the test execution so the config file will get written in temporary location. After the execution the environment variable will be reverted to original value.

## ✔️ How to Test

1. unset `LINODE_CLI_TOKEN`
2. `make install`
3. `linode-cli linodes ls` - Expected to fail
4. `make testunit`
5. verify ~/.config/linode-cli is not overwritten

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**