### PR TITLE
test: Add retry on flaky tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dev = [
     "requests-mock==1.12.1",
     "boto3-stubs[s3]",
     "build>=0.10.0",
-    "twine>=4.0.2"
+    "twine>=4.0.2",
+    "pytest-rerunfailures"
 ]
 
 [project.scripts]

--- a/tests/integration/linodes/test_power_status.py
+++ b/tests/integration/linodes/test_power_status.py
@@ -3,7 +3,6 @@ import pytest
 from tests.integration.helpers import delete_target_id, exec_test_command
 from tests.integration.linodes.helpers_linodes import (
     BASE_CMD,
-    create_linode,
     create_linode_and_wait,
     wait_until,
 )
@@ -11,7 +10,7 @@ from tests.integration.linodes.helpers_linodes import (
 
 @pytest.fixture
 def test_linode_id(linode_cloud_firewall):
-    linode_id = create_linode(firewall_id=linode_cloud_firewall)
+    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
 
     yield linode_id
 
@@ -52,6 +51,7 @@ def test_reboot_linode(create_linode_in_running_state):
     ), "Linode status has not changed to running from provisioning"
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_shutdown_linode(test_linode_id):
     linode_id = test_linode_id
 

--- a/tests/integration/linodes/test_rebuild.py
+++ b/tests/integration/linodes/test_rebuild.py
@@ -25,6 +25,7 @@ def test_linode_id(linode_cloud_firewall):
     delete_target_id(target="linodes", id=linode_id)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_rebuild_fails_without_image(test_linode_id):
     linode_id = test_linode_id
 

--- a/tests/integration/linodes/test_resize.py
+++ b/tests/integration/linodes/test_resize.py
@@ -42,6 +42,7 @@ def test_linode_id(linode_cloud_firewall):
     delete_target_id(target="linodes", id=linode_id)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_resize_fails_to_the_same_plan(test_linode_id):
     linode_id = test_linode_id
     linode_plan = (

--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -132,6 +132,7 @@ def test_update_kubernetes_cluster(get_cluster_id):
     assert new_label == updated_label
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_list_kubernetes_endpoint(get_cluster_id):
     cluster_id = get_cluster_id
     res = (


### PR DESCRIPTION
## 📝 Description

Following list of tests failed occasionally in recent builds, refer to TOD for details.
- test_rebuild_fails_without_image 
- test_resize_fails_to_the_same_plan 
- test_list_kubernetes_endpoint 
- test_shutdown_linode

This PR uses existing pytest library called pytest-rerunfailures to rerun tests with delay. Flaky tests now can simply be marked with
`@pytest.mark.flaky(reruns=3, reruns_delay=2)`

## ✔️ How to Test


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**