### PR TITLE
fix: get-kubeconfig merge into empty lists

### DIFF
--- a/linodecli/plugins/get-kubeconfig.py
+++ b/linodecli/plugins/get-kubeconfig.py
@@ -161,7 +161,9 @@ def _merge_dict(dict_1, dict_2):
         if dict_1_value is None and (dict_2_value := dict_2.get(key)):
             # Replace null value in previous config
             result[key] = dict_2_value
-        elif isinstance(dict_1_value, list) and (dict_2_value := dict_2.get(key)):
+        elif isinstance(dict_1_value, list) and (
+            dict_2_value := dict_2.get(key)
+        ):
             merge_map = {sub["name"]: sub for sub in dict_1_value}
             for list_2_item in dict_2_value:
                 if (list_2_name := list_2_item["name"]) not in merge_map:


### PR DESCRIPTION
## 📝 Description

This PR fixes the plugin `get-kubeconfig` merging a Kubeconfig from the Linode API with a local kubeconfig file, in the case that all other clusters, contexts, or users have been discarded before. The problem can occur because standard kubeconfig editing tools (e.g. `kubectl config`) set the list entries to `null` instead of an empty list `[]`.

Also the output when adding the `--dry-run` parameter is now showing YAML output (i.e. the expected Kubeconfig update after running the command) instead of a Python dict.

## ✔️ How to Test

1. From an existing Kubeconfig file, remove all contexts using `kubectl config delete-context <context_name>`.
2. Note that the value in this Kubeconfig file now contains a root level value `contexts: null` instead of `contexts: []`.
3. Run `linode-cli get-kubeconfig --label <cluster_label>` to fetch a new config file.
    * Without the PR, the Kubeconfig file is not updated.
    * With the patch, the `contexts` root level item now contains the entry retrieved from the Linode API.
4. Running `linode-cli get-kubeconfig --label <cluster_label> --dry-run`
    * without the patch dumps the string representation of a Python dict which looks somewhat similar to JSON but is not usable
    * with the patch shows the output that would have been written to the Kubeconfig file.

The following unit test has been added to cover the specific case of merging entries into `null` lists:
`pytest tests/unit/test_plugin_kubeconfig.py::test_merge_to_empty_config`