### PR TITLE
new: Allow specifying a custom configuration path through environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ testunit:
 	@mkdir -p /tmp/linode/.config
 	@orig_xdg_config_home=$${XDG_CONFIG_HOME:-}; \
 	export LINODE_CLI_TEST_MODE=1 XDG_CONFIG_HOME=/tmp/linode/.config; \
-	pytest -vv tests/unit; \
+	pytest -v tests/unit; \
 	export XDG_CONFIG_HOME=$$orig_xdg_config_home
 
 .PHONY: testint

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ testunit:
 	@mkdir -p /tmp/linode/.config
 	@orig_xdg_config_home=$${XDG_CONFIG_HOME:-}; \
 	export LINODE_CLI_TEST_MODE=1 XDG_CONFIG_HOME=/tmp/linode/.config; \
-	pytest -v tests/unit; \
+	pytest -vv tests/unit; \
 	export XDG_CONFIG_HOME=$$orig_xdg_config_home
 
 .PHONY: testint

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -290,7 +290,10 @@ class CLIConfig:
         ):
             print(f"User {username} is not configured.")
             sys.exit(ExitCodes.USERNAME_ERROR)
-        if not self.config.has_section(username) or allowed_defaults is None:
+        if (
+            not self.config.has_section(username)
+            and self.config.default_section is None
+        ) or allowed_defaults is None:
             return namespace
 
         warn_dict = {}

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -335,12 +335,6 @@ class CLIConfig:
         to save values they've set, and is used internally to update the config
         on disk when a new user if configured.
         """
-
-        # Create the config path isf necessary
-        config_path = f"{os.path.expanduser('~')}/.config"
-        if not os.path.exists(config_path):
-            os.makedirs(config_path)
-
         with open(_get_config_path(), "w", encoding="utf-8") as f:
             self.config.write(f)
 

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -15,6 +15,8 @@ CONFIG_DIR = os.environ.get(
     "XDG_CONFIG_HOME", f"{os.path.expanduser('~')}/.config"
 )
 
+ENV_CONFIG_FILE_PATH = "LINODE_CLI_CONFIG"
+
 # this is a list of browser that _should_ work for web-based auth.  This is mostly
 # intended to exclude lynx and other terminal browsers which could be opened, but
 # won't work.
@@ -38,11 +40,23 @@ def _get_config_path() -> str:
     :returns: The path to the local config file.
     :rtype: str
     """
+    custom_path = os.getenv(ENV_CONFIG_FILE_PATH, None)
+
+    if custom_path is not None:
+        custom_path = os.path.expanduser(custom_path)
+        if not os.path.exists(custom_path):
+            os.makedirs(os.path.dirname(custom_path), exist_ok=True)
+        return custom_path
+
     path = f"{LEGACY_CONFIG_DIR}/{LEGACY_CONFIG_NAME}"
     if os.path.exists(path):
         return path
 
-    return f"{CONFIG_DIR}/{CONFIG_NAME}"
+    path = f"{CONFIG_DIR}/{CONFIG_NAME}"
+    if not os.path.exists(path):
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+
+    return path
 
 
 def _get_config(load: bool = True):

--- a/linodecli/help_pages.py
+++ b/linodecli/help_pages.py
@@ -30,6 +30,8 @@ HELP_ENV_VARS = {
     "(e.g. 'v4beta')",
     "LINODE_CLI_API_SCHEME": "Overrides the target scheme used for API requests. "
     "(e.g. 'https')",
+    "LINODE_CLI_CONFIG": "Overrides the default configuration file path. "
+    "(e.g '~/.linode/my-cli-config')",
 }
 
 HELP_TOPICS = {

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -609,3 +609,27 @@ mysql_engine = mysql/8.0.26"""
         output = stdout_buf.getvalue()
         assert "foo [y/N]: " in output
         assert result
+
+    def test_custom_config_path(self, monkeypatch, tmp_path):
+        """
+        Test use a custom configuration path
+        """
+        conf = self._build_test_config()
+
+        tmp_path.mkdir(exist_ok=True)
+        custom_path = tmp_path / "test-cli-config"
+        with (
+            patch.dict(
+                os.environ,
+                {"LINODE_CLI_CONFIG": custom_path.absolute().as_posix()},
+            ),
+        ):
+            conf.write_config()
+
+            configs = custom_path.read_text().splitlines()
+            expected_configs = self.mock_config_file.splitlines()
+
+            assert len(configs) == len(expected_configs) + 1
+
+            for i, _ in enumerate(expected_configs):
+                assert expected_configs[i] == configs[i]

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -615,9 +615,8 @@ mysql_engine = mysql/8.0.26"""
         Test use a custom configuration path
         """
         conf = self._build_test_config()
-
-        tmp_path.mkdir(exist_ok=True)
         custom_path = tmp_path / "test-cli-config"
+
         with (
             patch.dict(
                 os.environ,

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -41,6 +41,9 @@ environment variable.
 If you wish to hide the API Version warning you can use the `LINODE_CLI_SUPPRESS_VERSION_WARNING`
 environment variable.
 
+You may also specify a custom configuration path using the `LINODE_CLI_CONFIG` environment variable 
+to replace the default path `~/.config/linode-cli`. 
+
 ## Configurable API URL
 
 In some cases you may want to run linode-cli against a non-default Linode API URL.

--- a/wiki/development/Development - Overview.md
+++ b/wiki/development/Development - Overview.md
@@ -51,7 +51,8 @@ configure the following:
 - Overrides for the target API URL (hostname, version, scheme, etc.)
 
 This command serves as an interactive prompt and outputs a configuration file to `~/.config/linode-cli`.
-This file is in a simple INI format and can be easily modified manually by users.
+This file is in a simple INI format and can be easily modified manually by users. 
+You may also specify a custom configuration file path using the `LINODE_CLI_CONFIG` environment variable.
 
 Additionally, multiple users can be created for the CLI which can be designated when running commands using the `--as-user` argument
 or using the `default-user` config variable.


### PR DESCRIPTION
## 📝 Description

User can specify a custom configuration path to replace the default one through a new environment variable `LINODE_CLI_CONFIG`. If this path does not exist yet, we'll create it inexplicably. 

Fixed a behavior change to allow config update look for DEFAULT section. 

## ✔️ How to Test

### Unit Test:
```
make testunit
```

### Manual Test
1. Pull this PR and install the change locally:
```
make install
```
2. Run the help topic and see the new environment variable is available in the list:
```
linode-cli env-var
```
3. Set a custom config path, i.e.:
```
export LINODE_CLI_CONFIG="~/.test-config/cli-config"
```
4. Reconfigure CLI:
```
linode-cli configure
```
5. Find the reconfigure finished successfully and configuration is written into the new file.
6. Run a command and observe that the allowed default values are used, i.e.: 
```
linode-cli linodes create --debug
```
This command will fail due to missing root_pass, but we can see the configed defaults are passed in the body.
8. Unset the `LINODE_CLI_CONFIG`
9. Reconfigure CLI and find it's successfully written into the default file