### PR TITLE
Override images replicate output

### DIFF
--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -4,7 +4,7 @@ This allows us to easily alter per-command outputs, etc. without making
 large changes to the OpenAPI spec.
 """
 
-from typing import Dict
+from typing import Dict, List
 
 from rich import box
 from rich import print as rprint
@@ -55,6 +55,15 @@ def handle_types_region_prices_list(
     Override the output of 'linode-cli linodes types' to display regional pricing.
     """
     return linode_types_with_region_prices(operation, output_handler, json_data)
+
+
+@output_override("images", "replicate", OutputMode.table)
+def handle_image_replicate(operation, output_handler, json_data) -> bool:
+    # pylint: disable=unused-argument
+    """
+    Override the output of 'linode-cli images replicate'.
+    """
+    return image_replicate_output(json_data)
 
 
 def linode_types_with_region_prices(
@@ -137,3 +146,50 @@ def format_region_prices(data: Dict[str, any]) -> any:
         sub_table.add_row(*region_price_row)
 
     return sub_table
+
+
+def build_replicas_output(replicas: List) -> Table:
+    """
+    Format nested replicas list to a sub-table.
+    """
+    replicas_output = Table(show_header=False, box=None)
+    replicas_headers = replicas[0].keys()
+    for replica in replicas:
+        row = []
+        for h in replicas_headers:
+            row.append(Align(str(replica[h]), align="left"))
+        replicas_output.add_row(*row)
+
+    return replicas_output
+
+
+def image_replicate_output(json_data) -> bool:
+    """
+    Parse and format the image replicate output table.
+    """
+    output = Table(
+        header_style="bold",
+        show_lines=True,
+    )
+
+    headers = json_data.keys()
+
+    for header in headers:
+        if header == "regions":
+            output.add_column("replicas", justify="center")
+        else:
+            output.add_column(header, justify="center")
+
+    row = []
+    for header in json_data.keys():
+        if header == "regions" and len(json_data[header]) > 0:
+            row.append(build_replicas_output(json_data[header]))
+        else:
+            row.append(Align(str(json_data[header]), align="left"))
+
+    output.add_row(*row)
+
+    console = Console()
+    console.print(output)
+
+    return False

--- a/linodecli/overrides.py
+++ b/linodecli/overrides.py
@@ -172,19 +172,14 @@ def image_replicate_output(json_data) -> bool:
         show_lines=True,
     )
 
-    headers = json_data.keys()
-
-    for header in headers:
-        if header == "regions":
-            output.add_column("replicas", justify="center")
-        else:
-            output.add_column(header, justify="center")
-
     row = []
     for header in json_data.keys():
         if header == "regions" and len(json_data[header]) > 0:
+            # leverage `replicas` in output for readability
+            output.add_column("replicas", justify="center")
             row.append(build_replicas_output(json_data[header]))
-        else:
+        elif json_data[header] is not None:
+            output.add_column(header, justify="center")
             row.append(Align(str(json_data[header]), align="left"))
 
     output.add_row(*row)


### PR DESCRIPTION
## 📝 Description

Override `images replicate` output to leverage `replicas`. Also improve the table format and make it more readable.

## ✔️ How to Test

1. Pull this PR and install this change:
```
make install
```
2. Replicate an existing image to some regions, i.e.:
```
linode images replicate private/123456 --regions us-iad --regions us-ord --regions us-east
```
3. Observe the command works successfully and the output looks good. An example output:
![Untitled](https://github.com/user-attachments/assets/82c6a0cb-efa2-42b6-8f41-2d0ace894526)

