### PR TITLE
Sanitize Bearer Token in debug output

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -285,7 +285,7 @@ def _print_request_debug_info(method, url, headers, body):
     for k, v in headers.items():
         # If this is the Authorization header, sanitize the token
         if k.lower() == "authorization":
-            v = "Bearer *******************************"
+            v = "Bearer " + "*" * 64
         print(f"> {k}: {v}", file=sys.stderr)
     print("> Body:", file=sys.stderr)
     print(">  ", body or "", file=sys.stderr)

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -283,6 +283,9 @@ def _print_request_debug_info(method, url, headers, body):
     """
     print(f"> {method.__name__.upper()} {url}", file=sys.stderr)
     for k, v in headers.items():
+        # If this is the Authorization header, sanitize the token
+        if k.lower() == "authorization":
+            v = "Bearer *******************************"
         print(f"> {k}: {v}", file=sys.stderr)
     print("> Body:", file=sys.stderr)
     print(">  ", body or "", file=sys.stderr)

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -44,13 +44,14 @@ class TestAPIRequest:
             api_request._print_request_debug_info(
                 SimpleNamespace(__name__="get"),
                 "https://definitely.linode.com/",
-                {"cool": "test"},
+                {"cool": "test", "Authorization": "sensitiveinfo"},
                 "cool body",
             )
 
         output = stderr_buf.getvalue()
         assert "> GET https://definitely.linode.com/" in output
         assert "> cool: test" in output
+        assert "> Authorization: Bearer *******************************" in output
         assert "> Body:" in output
         assert ">   cool body" in output
         assert "> " in output

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -51,7 +51,9 @@ class TestAPIRequest:
         output = stderr_buf.getvalue()
         assert "> GET https://definitely.linode.com/" in output
         assert "> cool: test" in output
-        assert "> Authorization: Bearer *******************************" in output
+        assert (
+            "> Authorization: Bearer *******************************" in output
+        )
         assert "> Body:" in output
         assert ">   cool body" in output
         assert "> " in output

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -51,9 +51,7 @@ class TestAPIRequest:
         output = stderr_buf.getvalue()
         assert "> GET https://definitely.linode.com/" in output
         assert "> cool: test" in output
-        assert (
-            "> Authorization: Bearer *******************************" in output
-        )
+        assert f"> Authorization: Bearer {'*' * 64}" in output
         assert "> Body:" in output
         assert ">   cool body" in output
         assert "> " in output


### PR DESCRIPTION
## 📝 Description

Updated debug output to sanitize bearer token

## ✔️ How to Test

Pull down this PR and run `make install`

### Unit Tests
`make testunit`

### Manual Tests
After running `make install`, run any CLI command with the debug flag (i.e. `linode-cli firewalls list --debug`) and verify that the Bearer Token is sanitized in the output.