### PR TITLE
test: Separate applying calico rules to different job; add job to apply cfw after integration tests are executed; update test_invalid_file test case

### DIFF
--- a/.github/workflows/e2e-suite-windows.yml
+++ b/.github/workflows/e2e-suite-windows.yml
@@ -103,3 +103,60 @@ jobs:
               conclusion: process.env.conclusion
             });
             return result;
+
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ secrets.LINODE_TOKEN_2 }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ secrets.LINODE_TOKEN_2 }}

--- a/.github/workflows/e2e-suite-windows.yml
+++ b/.github/workflows/e2e-suite-windows.yml
@@ -106,7 +106,7 @@ jobs:
 
   apply-calico-rules:
     runs-on: ubuntu-latest
-    needs: [integration_tests]
+    needs: [integration-fork-windows]
     if: ${{ success() || failure() }}
 
     steps:
@@ -132,7 +132,7 @@ jobs:
 
   add-fw-to-remaining-instances:
     runs-on: ubuntu-latest
-    needs: [integration_tests]
+    needs: [integration-fork-windows]
     if: ${{ success() || failure() }}
 
     steps:

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -91,14 +91,6 @@ jobs:
           pip install certifi -U && \
           pip install .[obj,dev]
 
-      - name: Download kubectl and calicoctl for LKE clusters
-        run: |
-          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
-          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
-          chmod +x calicoctl-linux-amd64 kubectl
-          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
-          mv kubectl /usr/local/bin/kubectl
-
       - name: Install Package
         run: make install
         env:
@@ -116,13 +108,6 @@ jobs:
         if: ${{ steps.validate-tests.outputs.match == '' || inputs.test_path == '' }}
         env:
           LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
-
-      - name: Apply Calico Rules to LKE
-        if: always()
-        run: |
-          cd scripts && ./lke_calico_rules_e2e.sh
-        env:
-          LINODE_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
 
       - name: Upload test results
         if: always()
@@ -168,10 +153,75 @@ jobs:
             });
             return result;
 
+  apply-calico-rules:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set LINODE_CLI_TOKEN
+        run: |
+          echo "LINODE_CLI_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
+
+      - name: Download kubectl and calicoctl for LKE clusters
+        run: |
+          curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -LO "https://github.com/projectcalico/calico/releases/download/v3.25.0/calicoctl-linux-amd64"
+          chmod +x calicoctl-linux-amd64 kubectl
+          mv calicoctl-linux-amd64 /usr/local/bin/calicoctl
+          mv kubectl /usr/local/bin/kubectl
+
+      - name: Apply Calico Rules to LKE
+        run: |
+          cd e2e_scripts/cloud_security_scripts/lke_calico_rules/ && ./lke_calico_rules_e2e.sh
+        env:
+          LINODE_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
+
+  add-fw-to-remaining-instances:
+    runs-on: ubuntu-latest
+    needs: [integration_tests]
+    if: ${{ success() || failure() }}
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Linode CLI
+        run: |
+          pip install linode-cli
+
+      - name: Set LINODE_CLI_TOKEN
+        run: |
+          echo "LINODE_CLI_TOKEN=${{ secrets[inputs.use_minimal_test_account == 'true' && 'MINIMAL_LINODE_TOKEN' || 'LINODE_TOKEN'] }}" >> $GITHUB_ENV
+
+      - name: Create Firewall and Attach to Instances
+        run: |
+          FIREWALL_ID=$(linode-cli firewalls create --label "e2e-fw-$(date +%s)" --rules.inbound_policy "DROP" --rules.outbound_policy "ACCEPT" --text --format=id --no-headers)
+          echo "Created Firewall with ID: $FIREWALL_ID"
+          
+          for instance_id in $(linode-cli linodes list --format "id" --text --no-header); do
+            echo "Attaching firewall to instance: $instance_id"
+            if linode-cli firewalls device-create "$FIREWALL_ID" --id "$instance_id" --type linode; then
+              echo "Firewall attached to instance $instance_id successfully."
+            else
+              echo "An error occurred while attaching firewall to instance $instance_id. Skipping..."
+            fi
+          done
+        env:
+          LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
+
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) && github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -7,12 +7,12 @@ on:
         description: 'Use minimal test account'
         required: false
         default: 'false'
-      test_path:
-        description: "The path from 'test/integration' to the target to be tested, e.g. 'cli'"
+      module:
+        description: "The module from 'test/integration' to the target to be tested, e.g. 'cli, domains, events, etc'"
         required: false
       sha:
         description: 'The hash value of the commit.'
-        required: false
+        required: true
         default: ''
       pull_request_number:
         description: 'The number of the PR. Ensure sha value is provided'
@@ -28,15 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && inputs.sha != '' || github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
-      - name: Validate Test Path
-        uses: actions-ecosystem/action-regex-match@v2
-        id: validate-tests
-        if: ${{ inputs.test_path != '' }}
-        with:
-          text: ${{ inputs.test_path }}
-          regex: '[^a-z0-9-:.\/_]'  # Tests validation
-          flags: gi
-
       - name: Checkout Repository with SHA
         if: ${{ inputs.sha != '' }}
         uses: actions/checkout@v4
@@ -104,8 +95,7 @@ jobs:
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
           report_filename="${timestamp}_cli_test_report.xml"
-          make testint TEST_ARGS="--junitxml=${report_filename}"
-        if: ${{ steps.validate-tests.outputs.match == '' || inputs.test_path == '' }}
+          make testint TEST_ARGS="--junitxml=${report_filename}" MODULE="${{ inputs.module }}"
         env:
           LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
 

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -8,7 +8,11 @@ from typing import List
 
 import pytest
 
-from tests.integration.helpers import get_random_text, exec_failing_test_command, assert_headers_in_lines
+from tests.integration.helpers import (
+    assert_headers_in_lines,
+    exec_failing_test_command,
+    get_random_text,
+)
 
 REGION = "us-iad"
 BASE_CMD = ["linode-cli", "image-upload", "--region", REGION]

--- a/tests/integration/image/test_plugin_image_upload.py
+++ b/tests/integration/image/test_plugin_image_upload.py
@@ -8,7 +8,7 @@ from typing import List
 
 import pytest
 
-from tests.integration.helpers import assert_headers_in_lines, get_random_text
+from tests.integration.helpers import get_random_text, exec_failing_test_command, assert_headers_in_lines
 
 REGION = "us-iad"
 BASE_CMD = ["linode-cli", "image-upload", "--region", REGION]
@@ -52,13 +52,13 @@ def test_invalid_file(
     fake_image_file,
 ):
     file_path = fake_image_file + "_fake"
-    process = exec_test_command(
-        BASE_CMD + ["--label", "notimportant", file_path]
+    process = exec_failing_test_command(
+        BASE_CMD + ["--label", "notimportant", file_path], expected_code=8
     )
-    output = process.stdout.decode()
+    error_output = process.stderr.decode()
 
     assert process.returncode == 8
-    assert f"No file at {file_path}" in output
+    assert f"No file at {file_path}" in error_output
 
 
 @pytest.mark.smoke

--- a/tests/integration/ssh/test_plugin_ssh.py
+++ b/tests/integration/ssh/test_plugin_ssh.py
@@ -9,6 +9,7 @@ from tests.integration.helpers import (
     COMMAND_JSON_OUTPUT,
     get_random_text,
     wait_for_condition,
+    exec_failing_test_command,
 )
 
 TEST_REGION = "us-southeast"
@@ -83,9 +84,9 @@ def test_help():
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 def test_ssh_instance_provisioning(target_instance: Dict[str, Any]):
-    process = exec_test_command(BASE_CMD + ["root@" + target_instance["label"]])
+    process = exec_failing_test_command(BASE_CMD + ["root@" + target_instance["label"]], expected_code=2)
     assert process.returncode == 2
-    output = process.stdout.decode()
+    output = process.stderr.decode()
 
     assert "is not running" in output
 

--- a/tests/integration/ssh/test_plugin_ssh.py
+++ b/tests/integration/ssh/test_plugin_ssh.py
@@ -7,9 +7,9 @@ import pytest
 
 from tests.integration.helpers import (
     COMMAND_JSON_OUTPUT,
+    exec_failing_test_command,
     get_random_text,
     wait_for_condition,
-    exec_failing_test_command,
 )
 
 TEST_REGION = "us-southeast"
@@ -84,7 +84,9 @@ def test_help():
 
 @pytest.mark.skipif(platform == "win32", reason="Test N/A on Windows")
 def test_ssh_instance_provisioning(target_instance: Dict[str, Any]):
-    process = exec_failing_test_command(BASE_CMD + ["root@" + target_instance["label"]], expected_code=2)
+    process = exec_failing_test_command(
+        BASE_CMD + ["root@" + target_instance["label"]], expected_code=2
+    )
     assert process.returncode == 2
     output = process.stderr.decode()
 


### PR DESCRIPTION
## 📝 Description

Improvements to e2e CI:
- Separated security steps in different jobs including: applying calico script, applying cfw to any remaining instances/nodes
- Changed `test_path` to `module` for simplicity
e.g. 
![image](https://github.com/user-attachments/assets/e7d9625e-ae9d-4fb2-af48-f8b96fb43bd4)


Test cases `test_invalid_file` and `test_ssh_instance_provisioning` are updated accordingly to reflect recent stderr change


## ✔️ How to Test

`make TEST_CASE="test_invalid_file" testint`
`make TEST_CASE="test_ssh_instance_provisioning" testint`

Tested in forked - https://github.com/ykim-1/linode-cli/actions/runs/11506669904
note: failed cases are not related to this PR but verified the security steps after integration job is finished

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**