### PR TITLE
test: fix unit tests caused by error output being routed to stderr instead of stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ testunit:
 	@orig_xdg_config_home=$${XDG_CONFIG_HOME:-}; \
 	export LINODE_CLI_TEST_MODE=1 XDG_CONFIG_HOME=/tmp/linode/.config; \
 	pytest -v tests/unit; \
-	export XDG_CONFIG_HOME=$$orig_xdg_config_home
+	exit_code=$$?; \
+	export XDG_CONFIG_HOME=$$orig_xdg_config_home; \
+	exit $$exit_code
 
 .PHONY: testint
 testint:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -80,7 +80,7 @@ mysql_engine = mysql/8.0.26"""
         f = io.StringIO()
 
         with pytest.raises(SystemExit) as err:
-            with contextlib.redirect_stdout(f):
+            with contextlib.redirect_stderr(f):
                 conf.set_user("bad_user")
 
         assert err.value.code == 4
@@ -98,7 +98,7 @@ mysql_engine = mysql/8.0.26"""
         f = io.StringIO()
 
         with pytest.raises(SystemExit) as err:
-            with contextlib.redirect_stdout(f):
+            with contextlib.redirect_stderr(f):
                 conf.remove_user("cli-dev")
 
         assert "default user!" in f.getvalue()
@@ -131,7 +131,7 @@ mysql_engine = mysql/8.0.26"""
 
         f = io.StringIO()
         with pytest.raises(SystemExit) as err:
-            with contextlib.redirect_stdout(f):
+            with contextlib.redirect_stderr(f):
                 conf.set_default_user("bad_user")
 
         assert err.value.code == 4
@@ -226,7 +226,7 @@ mysql_engine = mysql/8.0.26"""
         ]
 
         f = io.StringIO()
-        with contextlib.redirect_stdout(f):
+        with contextlib.redirect_stderr(f):
             result = vars(conf.update(ns, allowed_defaults))
 
         assert "--no-defaults" in f.getvalue()

--- a/tests/unit/test_plugin_image_upload.py
+++ b/tests/unit/test_plugin_image_upload.py
@@ -28,7 +28,7 @@ def test_no_file(mock_cli, capsys: CaptureFixture):
             PluginContext("REALTOKEN", mock_cli),
         )
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 8
     assert "No file at blah.txt" in captured_text
@@ -43,7 +43,7 @@ def test_file_too_large(mock_cli, capsys: CaptureFixture):
     with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 8
     assert "File blah.txt is too large" in captured_text
@@ -61,7 +61,7 @@ def test_unauthorized(mock_cli, capsys: CaptureFixture):
     with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 2
     assert "Your token was not authorized to use this endpoint" in captured_text
@@ -79,7 +79,7 @@ def test_non_beta(mock_cli, capsys: CaptureFixture):
     with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 2
     assert (
@@ -99,7 +99,7 @@ def test_non_beta(mock_cli, capsys: CaptureFixture):
     with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 2
     assert (
@@ -118,7 +118,7 @@ def test_failed_upload(mock_cli, capsys: CaptureFixture):
     with pytest.raises(SystemExit) as err:
         plugin.call(args, ctx)
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert err.value.code == 2
     assert (

--- a/tests/unit/test_plugin_ssh.py
+++ b/tests/unit/test_plugin_ssh.py
@@ -30,7 +30,7 @@ def test_windows_error(capsys: CaptureFixture):
 
     assert err.value.code == 2
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
     assert "This plugin is not currently supported in Windows." in captured_text
 
 
@@ -54,7 +54,7 @@ def test_target_not_running(mock_cli, capsys: CaptureFixture):
 
     assert err.value.code == 2
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
     assert (
         f"{test_label} is not running (status is provisioning)" in captured_text
     )
@@ -163,7 +163,7 @@ def test_find_api_error(mock_cli, capsys: CaptureFixture):
 
     assert err.value.code == 2
 
-    captured_text = capsys.readouterr().out
+    captured_text = capsys.readouterr().err
 
     assert "Could not retrieve Linode: 500 error" in captured_text
 


### PR DESCRIPTION
## 📝 Description
Unit tests have been failing due to error output being routed to stderr instead of stdout introduced by this [PR](https://github.com/linode/linode-cli/pull/644)

The reason why it wasn't detected in  the workflow in the first place is because our makefile returned status of export command instead of actual exit code of pytest command. 
E.g. 
```
.PHONY: testunit
testunit:
	@mkdir -p /tmp/linode/.config
	@orig_xdg_config_home=$${XDG_CONFIG_HOME:-}; \
	export LINODE_CLI_TEST_MODE=1 XDG_CONFIG_HOME=/tmp/linode/.config; \
	pytest -v tests/unit; \
	export XDG_CONFIG_HOME=$$orig_xdg_config_home;
```

This fix is also in this [PR](https://github.com/linode/linode-cli/pull/662)

## ✔️ How to Test

`make testunit`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**