### PR TITLE
Account for edge case where apiVersion param has no default

### DIFF
--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -447,7 +447,13 @@ class OpenAPIOperation:
             None,
         )
         if version_param is not None:
-            return version_param.schema.default or version_param.schema.enum[0]
+            schema = version_param.schema
+
+            if schema.default:
+                return schema.default
+
+            if schema.enum and len(schema.enum) > 0:
+                return schema.enum[0]
 
         return None
 
@@ -476,8 +482,6 @@ class OpenAPIOperation:
 
         url_base = urlparse(url_server)._replace(path="").geturl()
         url_path = operation.path[-2]
-
-        print(operation.path, [f"{param.name} {param.in_}" for param in params])
 
         api_version = OpenAPIOperation._resolve_api_version(params, url_server)
         if api_version is None:

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -447,7 +447,7 @@ class OpenAPIOperation:
             None,
         )
         if version_param is not None:
-            return version_param.schema.default
+            return version_param.schema.default or version_param.schema.enum[0]
 
         return None
 
@@ -476,6 +476,8 @@ class OpenAPIOperation:
 
         url_base = urlparse(url_server)._replace(path="").geturl()
         url_path = operation.path[-2]
+
+        print(operation.path, [f"{param.name} {param.in_}" for param in params])
 
         api_version = OpenAPIOperation._resolve_api_version(params, url_server)
         if api_version is None:

--- a/tests/fixtures/api_url_components_test.yaml
+++ b/tests/fixtures/api_url_components_test.yaml
@@ -46,3 +46,21 @@ paths:
           description: foobar
           content:
             application/json: {}
+
+  /{apiVersion}/bar:
+    parameters:
+    - name: apiVersion
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - v1000
+          - v1000beta
+    get:
+      operationId: barGet
+      responses:
+        '200':
+          description: foobar
+          content:
+            application/json: {}

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -296,6 +296,25 @@ class TestOperation:
             operation=root.paths["/{apiVersion}/bar/foo"].post, params=[]
         ) == ("http://localhost", "/{apiVersion}/bar/foo", "v100beta")
 
+    def test_resolve_api_version(self, get_openapi_for_api_components_tests):
+        root = get_openapi_for_api_components_tests
+
+        assert (
+            OpenAPIOperation._resolve_api_version(
+                params=root.paths["/{apiVersion}/bar/foo"].parameters,
+                server_url="http://localhost",
+            )
+            == "v9canary"
+        )
+
+        assert (
+            OpenAPIOperation._resolve_api_version(
+                params=root.paths["/{apiVersion}/bar"].parameters,
+                server_url="http://localhost",
+            )
+            == "v1000"
+        )
+
     def test_resolve_docs_url_legacy(self, get_openapi_for_docs_url_tests):
         root = get_openapi_for_docs_url_tests
 


### PR DESCRIPTION
## 📝 Description

This pull request adds logic to account for an edge case where the apiVersion parameter exists but has no defined default, causing `OpenAPIOperation._resolve_api_version(...)` to fail. This error is occurring when building against a pre-release version of the OpenAPI spec.


## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```shell
make testunit
```

### Manual Testing

1. Manually bundle the Linode OpenAPI specification from the latest commit in the internal documentation repository.
2. Build and install the Linode CLI using the newly bundled spec:

```shell
make SPEC=/path/to/my/bundled/spec.json install
```

3. Ensure the CLI builds and installs successfully.
