### PR TITLE
test: Update SSH and VLAN test cases

### DIFF
--- a/tests/integration/linodes/test_disk.py
+++ b/tests/integration/linodes/test_disk.py
@@ -96,8 +96,7 @@ def test_disk_resize_clone_and_create(linode_instance_disk_tests):
         .rstrip()
     )
 
-    # #TODO:: Add "disk_encryption" when spec shows the header
-    headers = ["id", "label", "status", "size", "filesystem"]
+    headers = ["id", "label", "status", "size", "filesystem", "disk_encryption"]
 
     assert_headers_in_lines(headers, res.splitlines())
 
@@ -126,8 +125,7 @@ def test_disk_resize_clone_and_create(linode_instance_disk_tests):
         .rstrip()
     )
 
-    # TODO:: Add "disk_encryption" when spec shows the header
-    headers = ["id", "label", "status", "size", "filesystem"]
+    headers = ["id", "label", "status", "size", "filesystem", "disk_encryption"]
 
     assert_headers_in_lines(headers, res.splitlines())
 
@@ -183,8 +181,7 @@ def test_disk_update(linode_instance_disk_tests):
         .rstrip()
     )
 
-    # TODO:: Add "disk_encryption" when spec shows the header
-    headers = ["id", "label", "status", "size", "filesystem"]
+    headers = ["id", "label", "status", "size", "filesystem", "disk_encryption"]
 
     assert_headers_in_lines(headers, res.splitlines())
     assert update_label in res
@@ -208,7 +205,6 @@ def test_disks_list(linode_instance_disk_tests):
         .rstrip()
     )
 
-    # TODO:: Add "disk_encryption" when spec shows the header
-    headers = ["id", "label", "status", "size", "filesystem"]
+    headers = ["id", "label", "status", "size", "filesystem", "disk_encryption"]
 
     assert_headers_in_lines(headers, res.splitlines())

--- a/tests/integration/ssh/test_plugin_ssh.py
+++ b/tests/integration/ssh/test_plugin_ssh.py
@@ -8,12 +8,13 @@ import pytest
 from tests.integration.helpers import (
     COMMAND_JSON_OUTPUT,
     exec_failing_test_command,
+    get_random_region_with_caps,
     get_random_text,
     wait_for_condition,
 )
 
-TEST_REGION = "us-southeast"
-TEST_IMAGE = "linode/alpine3.16"
+TEST_REGION = get_random_region_with_caps(required_capabilities=["Linodes"])
+TEST_IMAGE = "linode/ubuntu24.10"
 TEST_TYPE = "g6-nanode-1"
 TEST_ROOT_PASS = "r00tp@ss!long-long-and-longer"
 

--- a/tests/integration/vlans/test_vlans.py
+++ b/tests/integration/vlans/test_vlans.py
@@ -35,7 +35,7 @@ def test_list_vlans_help_menu():
         .rstrip()
     )
 
-    assert "linode-cli vlans ls\nList VLANs\n" in help_menu
+    assert "linode-cli vlans ls\nList VLANs" in help_menu
     assert (
         "https://techdocs.akamai.com/linode-api/reference/get-vlans"
         in help_menu

--- a/tests/integration/vlans/test_vlans.py
+++ b/tests/integration/vlans/test_vlans.py
@@ -35,7 +35,7 @@ def test_list_vlans_help_menu():
         .rstrip()
     )
 
-    assert "linode-cli vlans ls\nList VLANs" in help_menu
+    assert "linode-cli vlans ls" in help_menu
     assert (
         "https://techdocs.akamai.com/linode-api/reference/get-vlans"
         in help_menu


### PR DESCRIPTION
## 📝 Description

This PR address failures in latest CLI integration test runs: 
- Test image  `linode/alpine3.16` is not available anymore hence updating the test image in SSH tests
- VLAN help message changed slightly so assertion was updated

## ✔️ How to Test

`make MODULE="ssh" testint`
`make TEST_CASE="test_list_vlans_help_menu -v" testint`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**