### PR TITLE
Response bodies included in debug output

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -300,6 +300,7 @@ def _print_response_debug_info(response):
     """
     # these come back as ints, convert to HTTP version
     http_version = response.raw.version / 10
+    body = response.content.decode("utf-8", errors="replace")
 
     print(
         f"< HTTP/{http_version:.1f} {response.status_code} {response.reason}",
@@ -307,6 +308,8 @@ def _print_response_debug_info(response):
     )
     for k, v in response.headers.items():
         print(f"< {k}: {v}", file=sys.stderr)
+    print("< Body:", file=sys.stderr)
+    print("<  ", body or "", file=sys.stderr)
     print("< ", file=sys.stderr)
 
 

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -28,7 +28,7 @@ class TestAPIRequest:
             status_code=200,
             reason="OK",
             headers={"cool": "test"},
-            content=b"cool body"
+            content=b"cool body",
         )
 
         with contextlib.redirect_stderr(stderr_buf):

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -28,6 +28,7 @@ class TestAPIRequest:
             status_code=200,
             reason="OK",
             headers={"cool": "test"},
+            content=b"cool body"
         )
 
         with contextlib.redirect_stderr(stderr_buf):
@@ -36,6 +37,9 @@ class TestAPIRequest:
         output = stderr_buf.getvalue()
         assert "< HTTP/1.1 200 OK" in output
         assert "< cool: test" in output
+        assert "< Body:" in output
+        assert "<   cool body" in output
+        assert "< " in output
 
     def test_request_debug_info(self):
         stderr_buf = io.StringIO()


### PR DESCRIPTION
## 📝 Description

Updated response debug output to include body.

## ✔️ How to Test

Pull down this PR and run `make install`.

### Unit Tests
`make testunit`

### Manual Tests
After running make install, run any CLI command with the debug flag (i.e. `linode-cli firewalls list --debug`) and verify that the response body is printed.