### PR TITLE
Only use +and in filters when necessary

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -162,26 +162,29 @@ def _build_filter_header(
     order_by = parsed_args_dict.pop("order_by")
     order = parsed_args_dict.pop("order") or "asc"
 
-    # The "+and" list to be used in the filter header
-    filter_list = []
+    result = {}
 
-    for k, v in parsed_args_dict.items():
-        if v is None:
+    # A list filter allows a user to filter on multiple values in a list
+    # e.g. --tags foobar --tags foobar2
+    list_filters = []
+
+    for key, value in parsed_args_dict.items():
+        if value is None:
             continue
 
-        # If this is a list, flatten it out
-        new_filters = [{k: j} for j in v] if isinstance(v, list) else [{k: v}]
-        filter_list.extend(new_filters)
+        if not isinstance(value, list):
+            result[key] = value
+            continue
 
-    result = {}
-    if len(filter_list) > 0:
-        if len(filter_list) == 1:
-            result = filter_list[0]
-        else:
-            result["+and"] = filter_list
+        list_filters.extend(iter({key: entry} for entry in value))
+
+    if len(list_filters) > 0:
+        result["+and"] = list_filters
+
     if order_by is not None:
         result["+order_by"] = order_by
         result["+order"] = order
+
     return json.dumps(result) if len(result) > 0 else None
 
 

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -204,11 +204,11 @@ class TestAPIRequest:
         assert (
             json.dumps(
                 {
+                    "filterable_result": "bar",
                     "+and": [
-                        {"filterable_result": "bar"},
                         {"filterable_list_result": "foo"},
                         {"filterable_list_result": "bar"},
-                    ]
+                    ],
                 }
             )
             == result
@@ -267,8 +267,8 @@ class TestAPIRequest:
         assert (
             json.dumps(
                 {
+                    "filterable_result": "bar",
                     "+and": [
-                        {"filterable_result": "bar"},
                         {"filterable_list_result": "foo"},
                         {"filterable_list_result": "bar"},
                     ],
@@ -293,8 +293,8 @@ class TestAPIRequest:
         assert (
             json.dumps(
                 {
+                    "filterable_result": "bar",
                     "+and": [
-                        {"filterable_result": "bar"},
                         {"filterable_list_result": "foo"},
                         {"filterable_list_result": "bar"},
                     ],
@@ -331,11 +331,11 @@ class TestAPIRequest:
             assert url == "http://localhost/v4/foo/bar?page=1&page_size=100"
             assert headers["X-Filter"] == json.dumps(
                 {
+                    "filterable_result": "cool",
                     "+and": [
-                        {"filterable_result": "cool"},
                         {"filterable_list_result": "foo"},
                         {"filterable_list_result": "bar"},
-                    ]
+                    ],
                 }
             )
             assert headers["User-Agent"] == mock_cli.user_agent


### PR DESCRIPTION
## 📝 Description

This pull request updates the filter generation logic to only use `+and` when necessary, which should reduce the impact of bugs when filtering on special-case fields (e.g. `entity.type`, `entity.id`). 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make testunit
```

### Manual Testing

1. Run the following command to create an instance with label `foobar` and tags `foobar` and `barfoo`:

```bash
linode-cli linodes create --type g6-nanode-1 --region us-mia --label foobar --tags foobar --tags barfoo
```

2. Run the following command to list instances matching the above conditions:

```bash
linode-cli linodes ls --label foobar --tags foobar --tags barfoo --debug
```

3. Ensure the debug output contains the following filter JSON:

```bash
X-Filter: {"label": "foobar", "+and": [{"tags": "foobar"}, {"tags": "barfoo"}]}
```

4. Ensure the instance is displayed in the command's output.
