### PR TITLE
Support dictionary values in API responses

### DIFF
--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -169,13 +169,21 @@ def _parse_response_model(schema, prefix=None, nested_list_depth=0):
         )
 
     attrs = []
+
     if schema.properties is None:
         return attrs
 
     for k, v in schema.properties.items():
         pref = prefix + "." + k if prefix else k
 
-        if v.type == "object":
+        if v.type == "object" and v.properties is None and v.additionalProperties is not None:
+            # This is a dictionary with arbitrary keys
+            attrs.append(
+                OpenAPIResponseAttr(
+                    k, v, prefix=prefix, nested_list_depth=nested_list_depth
+                )
+            )
+        elif v.type == "object":
             attrs += _parse_response_model(v, prefix=pref)
         elif v.type == "array" and v.items.type == "object":
             attrs += _parse_response_model(
@@ -208,6 +216,7 @@ class OpenAPIResponse:
         self.is_paginated = _is_paginated(response)
 
         schema_override = response.extensions.get("linode-cli-use-schema")
+
         if schema_override:
             override = type(response)(
                 response.path, {"schema": schema_override}, response._root
@@ -222,6 +231,7 @@ class OpenAPIResponse:
             )
         else:
             self.attrs = _parse_response_model(response.schema)
+
         self.rows = response.extensions.get("linode-cli-rows")
         self.nested_list = response.extensions.get("linode-cli-nested-list")
         self.subtables = response.extensions.get("linode-cli-subtables")

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -176,7 +176,11 @@ def _parse_response_model(schema, prefix=None, nested_list_depth=0):
     for k, v in schema.properties.items():
         pref = prefix + "." + k if prefix else k
 
-        if v.type == "object" and v.properties is None and v.additionalProperties is not None:
+        if (
+            v.type == "object"
+            and v.properties is None
+            and v.additionalProperties is not None
+        ):
             # This is a dictionary with arbitrary keys
             attrs.append(
                 OpenAPIResponseAttr(

--- a/tests/fixtures/response_test_get.yaml
+++ b/tests/fixtures/response_test_get.yaml
@@ -29,6 +29,12 @@ paths:
                     $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
                   results:
                     $ref: '#/components/schemas/PaginationEnvelope/properties/results'
+                  dictLike:
+                    $ref: '#/components/schemas/DictionaryLikeObject'
+                  standard:
+                    $ref: '#/components/schemas/StandardObject'
+                  objectArray:
+                    $ref: '#/components/schemas/ArrayOfObjects'
 
 components:
   schemas:
@@ -62,3 +68,26 @@ components:
           readOnly: true
           description: The total number of results.
           example: 1
+    DictionaryLikeObject:
+      type: object
+      additionalProperties:
+        type: string  # Arbitrary keys with string values
+      description: Dictionary with arbitrary keys
+    StandardObject:
+      type: object
+      properties:
+        key1:
+          type: string
+        key2:
+          type: integer
+      description: Standard object with defined properties
+    ArrayOfObjects:
+      type: array
+      items:
+        type: object
+        properties:
+          subkey1:
+            type: string
+          subkey2:
+            type: boolean
+      description: Array of objects

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -22,7 +22,7 @@ class TestOutputHandler:
         ]
 
     def test_attr_get_value(self, list_operation_for_response_test):
-        model = {"foo": {"bar": "cool"}}
+        model = {"data": {"foo": {"bar": "cool"}}}
         attr = list_operation_for_response_test.response_model.attrs[0]
 
         result = attr._get_value(model)
@@ -30,7 +30,7 @@ class TestOutputHandler:
         assert result == "cool"
 
     def test_attr_get_string(self, list_operation_for_response_test):
-        model = {"foo": {"bar": ["cool1", "cool2"]}}
+        model = {"data": {"foo": {"bar": ["cool1", "cool2"]}}}
         attr = list_operation_for_response_test.response_model.attrs[0]
 
         result = attr.get_string(model)
@@ -38,10 +38,69 @@ class TestOutputHandler:
         assert result == "cool1 cool2"
 
     def test_attr_render_value(self, list_operation_for_response_test):
-        model = {"foo": {"bar": ["cool1", "cool2"]}}
+        model = {"data": {"foo": {"bar": ["cool1", "cool2"]}}}
         attr = list_operation_for_response_test.response_model.attrs[0]
         attr.color_map = {"default_": "yellow"}
 
         result = attr.render_value(model)
 
         assert result == "[yellow]cool1, cool2[/]"
+
+    def test_fix_json_string_type(self, list_operation_for_response_test):
+        model = list_operation_for_response_test.response_model
+        model.rows = ["foo.bar", "type"]
+
+        input_json = {"foo": {"bar": "string_value"}, "type": "example_type"}
+        result = model.fix_json(input_json)
+
+        assert result == ["string_value", "example_type"]
+
+    def test_fix_json_integer_type(self, list_operation_for_response_test):
+        model = list_operation_for_response_test.response_model
+        model.rows = ["size", "id"]
+
+        input_json = {"size": 42, "id": 123}
+        result = model.fix_json(input_json)
+
+        assert result == [42, 123]
+
+    def test_dictionary_like_property(self, list_operation_for_response_test):
+        model = list_operation_for_response_test.response_model
+
+        model.rows = ["dictLike"]
+
+        input_data = {"dictLike": {"keyA": "valueA", "keyB": "valueB"}}
+
+        result = model.fix_json(input_data)
+        assert result == [{"keyA": "valueA", "keyB": "valueB"}]
+
+    def test_standard_object_property(self, list_operation_for_response_test):
+        model = list_operation_for_response_test.response_model
+
+        # Set rows to include the standard object
+        model.rows = ["standard"]
+
+        # Simulate input data
+        input_data = {"standard": {"key1": "test", "key2": 42}}
+
+        result = model.fix_json(input_data)
+        assert result == [{"key1": "test", "key2": 42}]
+
+    def test_array_of_objects_property(self, list_operation_for_response_test):
+        model = list_operation_for_response_test.response_model
+
+        model.rows = ["objectArray"]
+
+        # Simulate input data
+        input_data = {
+            "objectArray": [
+                {"subkey1": "item1", "subkey2": True},
+                {"subkey1": "item2", "subkey2": False},
+            ]
+        }
+
+        result = model.fix_json(input_data)
+        assert result == [
+            {"subkey1": "item1", "subkey2": True},
+            {"subkey1": "item2", "subkey2": False},
+        ]


### PR DESCRIPTION
## 📝 Description

This pull request updates the OpenAPI spec baking logic to properly response dictionaries as defined in the [OpenAPI 3 documentation](https://swagger.io/docs/specification/v3_0/data-models/dictionaries/).

This is necessary to support an upcoming change to the LKE Node Pool `labels` field.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make testunit
```
