### PR TITLE
Bump minimal Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "linode-cli"
 authors = [{ name = "Akamai Technologies Inc.", email = "developers@linode.com" }]
 description = "The official command-line interface for interacting with the Linode API."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 classifiers = []
 dependencies = [
@@ -54,7 +54,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311"]
 
 [tool.autoflake]
 expand-star-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.autoflake]
 expand-star-imports = true

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -447,8 +447,9 @@ class TestAPIRequest:
             status_code=200, reason="OK", headers={"X-Spec-Version": "1.1.0"}
         )
 
-        with contextlib.redirect_stderr(stderr_buf), patch(
-            "linodecli.api_request.requests.get", mock_http_response
+        with (
+            contextlib.redirect_stderr(stderr_buf),
+            patch("linodecli.api_request.requests.get", mock_http_response),
         ):
             api_request._attempt_warn_old_version(mock_cli, mock_response)
 
@@ -491,8 +492,9 @@ class TestAPIRequest:
             status_code=200, reason="OK", headers={"X-Spec-Version": "1.1.0"}
         )
 
-        with contextlib.redirect_stderr(stderr_buf), patch(
-            "linodecli.api_request.requests.get", mock_http_response
+        with (
+            contextlib.redirect_stderr(stderr_buf),
+            patch("linodecli.api_request.requests.get", mock_http_response),
         ):
             api_request._attempt_warn_old_version(mock_cli, mock_response)
 
@@ -525,8 +527,9 @@ class TestAPIRequest:
             status_code=200, reason="OK", headers={"X-Spec-Version": "1.0.0"}
         )
 
-        with contextlib.redirect_stderr(stderr_buf), patch(
-            "linodecli.api_request.requests.get", mock_http_response
+        with (
+            contextlib.redirect_stderr(stderr_buf),
+            patch("linodecli.api_request.requests.get", mock_http_response),
         ):
             api_request._attempt_warn_old_version(mock_cli, mock_response)
 

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -35,10 +35,13 @@ class TestOverrides:
             OUTPUT_OVERRIDES[override_signature](*a)
             return True
 
-        with patch(
-            "linodecli.baked.operation.OUTPUT_OVERRIDES",
-            {override_signature: patch_func},
-        ), patch.object(mock_cli.output_handler, "print") as p:
+        with (
+            patch(
+                "linodecli.baked.operation.OUTPUT_OVERRIDES",
+                {override_signature: patch_func},
+            ),
+            patch.object(mock_cli.output_handler, "print") as p,
+        ):
             list_operation_for_overrides_test.process_response_json(
                 response_json, mock_cli.output_handler
             )


### PR DESCRIPTION
## 📝 Description

Python 3.8 has been EOL, upgrade minimal Python version to 3.9 so we can use the features added in 3.9.