### PR TITLE
fix: Updated OBJ plugin default cluster configurataion to be required

### DIFF
--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -553,7 +553,7 @@ def _configure_plugin(client: CLI):
 
     cluster = _default_text_input(  # pylint: disable=protected-access
         "Default cluster for operations (e.g. `us-mia-1`)",
-        optional=True,
+        optional=False,
     )
 
     if cluster:


### PR DESCRIPTION
## 📝 Description

Requires that the user configures a default cluster when running `linode-cli obj mb` to prevent error.

## ✔️ How to Test

The following steps assume you have pulled down this PR locally and ran `make install`.

### Integration Tests
`make MODULE=obj testint`

### Unit Tests
`make testunit`

### Manual Tests
Run `linode-cli obj mb bug-test` and try not providing a default cluster to verify that the user is prompted for it again.

## 📷 Preview

![image](https://github.com/user-attachments/assets/0485d802-e168-4976-b730-0c525de07c31)