### PR TITLE
Updated dockerfile to python 3.13, removed cache from pip3 to reduce size of the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS builder
+FROM python:3.13-slim AS builder
 
 ARG linode_cli_version
 
@@ -15,11 +15,11 @@ RUN make requirements
 
 RUN LINODE_CLI_VERSION=$linode_cli_version GITHUB_TOKEN=$github_token make build
 
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 COPY --from=builder /src/dist /dist
 
-RUN pip3 install /dist/*.whl boto3
+RUN pip3 install --no-cache-dir /dist/*.whl boto3
 
 RUN useradd -ms /bin/bash cli
 USER cli:cli


### PR DESCRIPTION
## 📝 Description

Updated dockerfile to python 3.12, removed cache from pip3 to reduce size of the docker image

**What does this PR do and why is this change necessary?**

Updated dockerfile to python 3.12, removed cache from pip3 to reduce size of the docker image
