### PR TITLE
Support oneOfs & anyOfs in operation request & response schema

### DIFF
--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -18,7 +18,11 @@ import openapi3.paths
 from openapi3.paths import Operation, Parameter
 
 from linodecli.baked.parsing import simplify_description
-from linodecli.baked.request import OpenAPIFilteringRequest, OpenAPIRequest
+from linodecli.baked.request import (
+    OpenAPIFilteringRequest,
+    OpenAPIRequest,
+    OpenAPIRequestArg,
+)
 from linodecli.baked.response import OpenAPIResponse
 from linodecli.exit_codes import ExitCodes
 from linodecli.output.output_handler import OutputHandler
@@ -414,6 +418,13 @@ class OpenAPIOperation:
         Return a list of attributes from the request schema
         """
         return self.request.attrs if self.request else []
+
+    @property
+    def arg_routes(self) -> Dict[str, List[OpenAPIRequestArg]]:
+        """
+        Return a list of attributes from the request schema
+        """
+        return self.request.attr_routes if self.request else []
 
     @staticmethod
     def _flatten_url_path(tag: str) -> str:

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -2,7 +2,7 @@
 Request details for a CLI Operation
 """
 
-pass
+import sys
 
 from openapi3.schemas import Schema
 
@@ -137,6 +137,13 @@ def _parse_request_model(schema, prefix=None, parent=None, depth=0):
     :rtype: list[OpenAPIRequestArg]
     """
     args = []
+
+    if depth > 0 and schema.oneOf is not None:
+        print(
+            f"WARN: {'.'.join(schema.path)}: "
+            f"Ignoring oneOf because it is not defined at the request schema's root level.",
+            file=sys.stderr,
+        )
 
     if schema.properties is None:
         return args

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -238,6 +238,11 @@ class OpenAPIRequest:
         if schema.oneOf is not None:
             for entry in schema.oneOf:
                 entry_schema = Schema(schema.path, entry, request._root)
+                if entry_schema.title is None:
+                    raise ValueError(
+                        f"No title for oneOf entry in {schema.path}"
+                    )
+
                 self.attr_routes[entry_schema.title] = _parse_request_model(
                     entry_schema
                 )

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -143,7 +143,11 @@ def _parse_request_model(schema, prefix=None, parent=None, depth=0):
         return args
 
     for k, v in properties.items():
-        if v.type == "object" and not v.readOnly and v.properties:
+        if (
+            v.type == "object"
+            and not v.readOnly
+            and len(_aggregate_schema_properties(v)[0]) > 0
+        ):
             # nested objects receive a prefix and are otherwise parsed normally
             pref = prefix + "." + k if prefix else k
 

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -137,7 +137,7 @@ def _parse_request_model(schema, prefix=None, parent=None, depth=0):
     """
     args = []
 
-    properties = _aggregate_schema_properties(schema)
+    properties, required = _aggregate_schema_properties(schema)
 
     if properties is None:
         return args
@@ -185,17 +185,11 @@ def _parse_request_model(schema, prefix=None, parent=None, depth=0):
                 depth=depth + 1,
             )
         else:
-            # required fields are defined in the schema above the property, so
-            # we have to check here if required fields are defined/if this key
-            # is among them and pass it into the OpenAPIRequestArg class.
-            required = False
-            if schema.required:
-                required = k in schema.required
             args.append(
                 OpenAPIRequestArg(
                     k,
                     v,
-                    required,
+                    k in required,
                     prefix=prefix,
                     parent=parent,
                     depth=depth,

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -172,7 +172,7 @@ def _parse_response_model(schema, prefix=None, nested_list_depth=0):
 
     attrs = []
 
-    properties = _aggregate_schema_properties(schema)
+    properties, _ = _aggregate_schema_properties(schema)
 
     if properties is None:
         return attrs

--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -3,7 +3,8 @@ Converting the processed OpenAPI Responses into something the CLI can work with
 """
 
 from openapi3.paths import MediaType
-from openapi3.schemas import Schema
+
+from linodecli.baked.util import _aggregate_schema_properties
 
 
 def _is_paginated(response):
@@ -171,20 +172,7 @@ def _parse_response_model(schema, prefix=None, nested_list_depth=0):
 
     attrs = []
 
-    properties = {}
-
-    if schema.properties is not None:
-        properties.update(dict(schema.properties))
-
-    # We dynamically merge oneOf values here to ensure they are all accounted for
-    # in the response model.
-    if schema.oneOf is not None:
-        for entry in schema.oneOf:
-            entry_schema = Schema(schema.path, entry, schema._root)
-            if entry_schema.properties is None:
-                continue
-
-            properties.update(dict(entry_schema.properties))
+    properties = _aggregate_schema_properties(schema)
 
     if properties is None:
         return attrs

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -19,12 +19,16 @@ def _aggregate_schema_properties(
     :return: The aggregated properties and a set containing the keys of required properties.
     """
 
+    schema_count = 0
     properties = {}
     required = defaultdict(lambda: 0)
 
     def _handle_schema(_schema: Schema):
         if _schema.properties is None:
             return
+
+        nonlocal schema_count
+        schema_count += 1
 
         properties.update(dict(_schema.properties))
 
@@ -41,10 +45,6 @@ def _aggregate_schema_properties(
     for entry in one_of + any_of:
         # pylint: disable=protected-access
         _handle_schema(Schema(schema.path, entry, schema._root))
-
-    schema_count = (
-        (1 if schema.properties is not None else 0) + len(one_of) + len(any_of)
-    )
 
     return (
         properties,

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+from openapi3.schemas import Schema
+
+
+def _aggregate_schema_properties(schema: Schema) -> Dict[str, Any]:
+    """
+    Aggregates all properties in the given schema, accounting properties
+    nested in oneOf and anyOf blocks.
+
+    :param schema: The schema to aggregate properties from.
+    :return: The aggregated properties.
+    """
+
+    result = {}
+
+    if schema.properties is not None:
+        result.update(dict(schema.properties))
+
+    if schema.oneOf is not None:
+        result.update(dict(schema.oneOf))
+
+    if schema.anyOf is not None:
+        result.update(dict(schema.anyOf))
+
+    return result

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -1,3 +1,7 @@
+"""
+Provides various utility functions for use in baking logic.
+"""
+
 from typing import Any, Dict
 
 from openapi3.schemas import Schema
@@ -20,7 +24,9 @@ def _aggregate_schema_properties(schema: Schema) -> Dict[str, Any]:
     nested_schema = (schema.oneOf or []) + (schema.anyOf or [])
 
     for entry in nested_schema:
-        entry_schema = Schema(schema.path, entry, schema._root)
+        entry_schema = Schema(
+            schema.path, entry, schema._root
+        )  # pylint: disable=protected-access
         if entry_schema.properties is None:
             continue
 

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -24,9 +24,8 @@ def _aggregate_schema_properties(schema: Schema) -> Dict[str, Any]:
     nested_schema = (schema.oneOf or []) + (schema.anyOf or [])
 
     for entry in nested_schema:
-        entry_schema = Schema(
-            schema.path, entry, schema._root
-        )  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        entry_schema = Schema(schema.path, entry, schema._root)
         if entry_schema.properties is None:
             continue
 

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -2,33 +2,52 @@
 Provides various utility functions for use in baking logic.
 """
 
-from typing import Any, Dict
+from collections import defaultdict
+from typing import Any, Dict, Set, Tuple
 
 from openapi3.schemas import Schema
 
 
-def _aggregate_schema_properties(schema: Schema) -> Dict[str, Any]:
+def _aggregate_schema_properties(
+    schema: Schema,
+) -> Tuple[Dict[str, Any], Set[str]]:
     """
     Aggregates all properties in the given schema, accounting properties
     nested in oneOf and anyOf blocks.
 
     :param schema: The schema to aggregate properties from.
-    :return: The aggregated properties.
+    :return: The aggregated properties and a set containing the keys of required properties.
     """
 
-    result = {}
+    properties = {}
+    required = defaultdict(lambda: 0)
 
-    if schema.properties is not None:
-        result.update(dict(schema.properties))
+    def _handle_schema(_schema: Schema):
+        if _schema.properties is None:
+            return
 
-    nested_schema = (schema.oneOf or []) + (schema.anyOf or [])
+        properties.update(dict(_schema.properties))
 
-    for entry in nested_schema:
+        # Aggregate required keys and their number of usages.
+        if _schema.required is not None:
+            for key in _schema.required:
+                required[key] += 1
+
+    _handle_schema(schema)
+
+    one_of = schema.oneOf or []
+    any_of = schema.anyOf or []
+
+    for entry in one_of + any_of:
         # pylint: disable=protected-access
-        entry_schema = Schema(schema.path, entry, schema._root)
-        if entry_schema.properties is None:
-            continue
+        _handle_schema(Schema(schema.path, entry, schema._root))
 
-        result.update(dict(entry_schema.properties))
+    schema_count = (
+        (1 if schema.properties is not None else 0) + len(one_of) + len(any_of)
+    )
 
-    return result
+    return (
+        properties,
+        # We only want to mark fields that are required by ALL subschema as required
+        set(key for key, count in required.items() if count == schema_count),
+    )

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -17,10 +17,13 @@ def _aggregate_schema_properties(schema: Schema) -> Dict[str, Any]:
     if schema.properties is not None:
         result.update(dict(schema.properties))
 
-    if schema.oneOf is not None:
-        result.update(dict(schema.oneOf))
+    nested_schema = (schema.oneOf or []) + (schema.anyOf or [])
 
-    if schema.anyOf is not None:
-        result.update(dict(schema.anyOf))
+    for entry in nested_schema:
+        entry_schema = Schema(schema.path, entry, schema._root)
+        if entry_schema.properties is None:
+            continue
+
+        result.update(dict(entry_schema.properties))
 
     return result

--- a/linodecli/help_pages.py
+++ b/linodecli/help_pages.py
@@ -224,8 +224,13 @@ def print_help_action(
         _help_action_print_filter_args(console, op)
         return
 
-    if op.args:
-        _help_action_print_body_args(console, op)
+    if len(op.arg_routes) > 0:
+        # This operation uses oneOf so we need to render routes
+        # instead of the operation-level argument list.
+        for title, option in op.arg_routes.items():
+            _help_action_print_body_args(console, op, option, title=title)
+    elif op.args:
+        _help_action_print_body_args(console, op, op.args)
 
 
 def _help_action_print_filter_args(console: Console, op: OpenAPIOperation):
@@ -250,13 +255,15 @@ def _help_action_print_filter_args(console: Console, op: OpenAPIOperation):
 def _help_action_print_body_args(
     console: Console,
     op: OpenAPIOperation,
+    args: List[OpenAPIRequestArg],
+    title: Optional[str] = None,
 ):
     """
     Pretty-prints all the body (POST/PUT) arguments for this operation.
     """
-    console.print("[bold]Arguments:[/]")
+    console.print(f"[bold]Arguments{f' ({title})' if title else ''}:[/]")
 
-    for group in _help_group_arguments(op.args):
+    for group in _help_group_arguments(args):
         for arg in group:
             metadata = []
 

--- a/tests/fixtures/operation_with_one_ofs.yaml
+++ b/tests/fixtures/operation_with_one_ofs.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.1
+info:
+  title: API Specification
+  version: 1.0.0
+servers:
+  - url: http://localhost/v4
+
+paths:
+  /foo/bar:
+    x-linode-cli-command: foo
+    post:
+      summary: Do something.
+      operationId: fooBarPost
+      description: This is description
+      requestBody:
+        description: Some description.
+        required: True
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Foo'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Foo'
+
+components:
+  schemas:
+    Foo:
+      oneOf:
+        - type: object
+          required:
+            - foobar
+            - barfoo
+          properties:
+            foobar:
+              type: string
+              description: Some foobar.
+            barfoo:
+              type: integer
+              description: Some barfoo.
+        - type: object
+          required:
+            - foobar
+            - foofoo
+          properties:
+            foobar:
+              type: string
+              description: Some foobar.
+            foofoo:
+              type: boolean
+              description: Some foofoo.
+            barbar:
+              description: Some barbar.
+              anyOf:
+                - type: object
+                  properties:
+                    foo:
+                      type: string
+                      description: Some foo.
+                    bar:
+                      type: integer
+                      description: Some bar.
+                - type: object
+                  properties:
+                    baz:
+                      type: boolean
+                      description: Some baz.

--- a/tests/fixtures/operation_with_one_ofs.yaml
+++ b/tests/fixtures/operation_with_one_ofs.yaml
@@ -31,7 +31,8 @@ components:
   schemas:
     Foo:
       oneOf:
-        - type: object
+        - title: Usage 1
+          type: object
           required:
             - foobar
             - barfoo
@@ -42,7 +43,8 @@ components:
             barfoo:
               type: integer
               description: Some barfoo.
-        - type: object
+        - title: Usage 2
+          type: object
           required:
             - foobar
             - foofoo

--- a/tests/fixtures/operation_with_one_ofs.yaml
+++ b/tests/fixtures/operation_with_one_ofs.yaml
@@ -55,6 +55,7 @@ components:
               description: Some foofoo.
             barbar:
               description: Some barbar.
+              type: object
               anyOf:
                 - type: object
                   properties:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -343,6 +343,25 @@ def get_operation_for_subtable_test():
 
 
 @pytest.fixture
+def post_operation_with_one_ofs() -> OpenAPIOperation:
+    """
+    Creates a new OpenAPI operation that makes heavy use of oneOfs and anyOfs.
+    """
+
+    spec = _get_parsed_spec("operation_with_one_ofs.yaml")
+
+    # Get parameters for OpenAPIOperation() from yaml fixture
+    path = list(spec.paths.values())[0]
+
+    return make_test_operation(
+        path.extensions.get("linode-cli-command", "default"),
+        getattr(path, "post"),
+        "post",
+        path.parameters,
+    )
+
+
+@pytest.fixture
 def get_openapi_for_api_components_tests() -> OpenAPI:
     """
     Creates a set of OpenAPI operations with various apiVersion and

--- a/tests/unit/test_help_pages.py
+++ b/tests/unit/test_help_pages.py
@@ -263,5 +263,3 @@ class TestHelpPages:
         assert "--barbar.bar: Some bar." in captured
         assert "--barbar.baz: Some baz." in captured
         assert "--barbar.foo: Some foo." in captured
-
-        assert False

--- a/tests/unit/test_help_pages.py
+++ b/tests/unit/test_help_pages.py
@@ -236,3 +236,32 @@ class TestHelpPages:
                 "Test summary 2.",
             ],
         )
+
+    def test_action_help_post_method_routed(
+        self, capsys, mocker, mock_cli, post_operation_with_one_ofs
+    ):
+        mock_cli.find_operation = mocker.Mock(
+            return_value=post_operation_with_one_ofs
+        )
+
+        help_pages.print_help_action(mock_cli, "command", "action")
+        captured = capsys.readouterr().out
+
+        print(captured)
+
+        assert "linode-cli command action" in captured
+        assert "Do something." in captured
+
+        assert "Arguments (Usage 1):" in captured
+        assert "--foobar (required): Some foobar." in captured
+        assert "--foofoo (required): Some foofoo." in captured
+
+        assert "Arguments (Usage 2):" in captured
+        assert "--foobar (required): Some foobar." in captured
+        assert "--foofoo (required): Some foofoo." in captured
+
+        assert "--barbar.bar: Some bar." in captured
+        assert "--barbar.baz: Some baz." in captured
+        assert "--barbar.foo: Some foo." in captured
+
+        assert False

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -8,16 +8,16 @@ class TestRequest:
 
         arg_map = {arg.path: arg for arg in args}
 
-        print(arg_map.keys())
         expected = {
             "foobar": ("string", "Some foobar.", True),
             "barfoo": ("integer", "Some barfoo.", False),
             "foofoo": ("boolean", "Some foofoo.", False),
-            "barbar": ("string", "Some barbar.", False),
+            "barbar.foo": ("string", "Some foo.", False),
+            "barbar.bar": ("integer", "Some bar.", False),
+            "barbar.baz": ("boolean", "Some baz.", False),
         }
 
         for k, v in expected.items():
-            print(k)
             assert arg_map[k].datatype == v[0]
             assert arg_map[k].description == v[1]
             assert arg_map[k].required == v[2]

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -1,0 +1,23 @@
+class TestRequest:
+    """
+    Unit tests for baked requests.
+    """
+
+    def test_handle_one_ofs(self, post_operation_with_one_ofs):
+        args = post_operation_with_one_ofs.args
+
+        arg_map = {arg.path: arg for arg in args}
+
+        print(arg_map.keys())
+        expected = {
+            "foobar": ("string", "Some foobar.", True),
+            "barfoo": ("integer", "Some barfoo.", False),
+            "foofoo": ("boolean", "Some foofoo.", False),
+            "barbar": ("string", "Some barbar.", False),
+        }
+
+        for k, v in expected.items():
+            print(k)
+            assert arg_map[k].datatype == v[0]
+            assert arg_map[k].description == v[1]
+            assert arg_map[k].required == v[2]

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -1,6 +1,6 @@
-class TestOutputHandler:
+class TestResponse:
     """
-    Unit tests for linodecli.response
+    Unit tests for baked responses.
     """
 
     def test_model_fix_json_rows(self, list_operation_for_response_test):
@@ -45,3 +45,19 @@ class TestOutputHandler:
         result = attr.render_value(model)
 
         assert result == "[yellow]cool1, cool2[/]"
+
+    def test_handle_one_ofs(self, post_operation_with_one_ofs):
+        model = post_operation_with_one_ofs.response_model
+
+        attr_map = {attr.path: attr for attr in model.attrs}
+
+        expected = {
+            "foobar": ("string", "Some foobar"),
+            "barfoo": ("integer", "Some barfoo"),
+            "foofoo": ("boolean", "Some foofoo"),
+            "barbar": ("string", "Some barbar"),
+        }
+
+        for k, v in expected.items():
+            assert attr_map[k].datatype == v[0]
+            assert attr_map[k].description == v[1]

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -55,7 +55,9 @@ class TestResponse:
             "foobar": ("string", "Some foobar"),
             "barfoo": ("integer", "Some barfoo"),
             "foofoo": ("boolean", "Some foofoo"),
-            "barbar": ("string", "Some barbar"),
+            "barbar.foo": ("string", "Some foo"),
+            "barbar.bar": ("integer", "Some bar"),
+            "barbar.baz": ("boolean", "Some baz"),
         }
 
         for k, v in expected.items():


### PR DESCRIPTION
## 📝 Description

This pull request adds support for parsing [OpenAPI oneOfs and anyOfs](https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/) in both the request and response schema for operations. 

Additionally, this PR adds support for rendering each root-level request oneOf separate section in the generated command help pages.

## ✔️ How to Test

The following test steps assume you have pulled down this pull request locally and run the following command:

```shell
make SPEC='https://gist.githubusercontent.com/lgarber-akamai/07485a643e8329a5c16bec775e8066c4/raw/56f4491ba6e239c9cad736f05ff2d1ab0608098c/openapi.json' install
```

**NOTE: The overridden specification is necessary because the currently published OpenAPI specification does not yet make use of oneOfs.**

### Unit Testing

```
make testunit
```

### Integration Testing

```
make testint
```

### Manual Testing

1. Run the following command the view the help page of the `nodebalancers config-create` command:

```shell
linode-cli nodebalancers config-create --help
```

2. Ensure the output contains separate categories for each configuration protocol.
3. Create a NodeBalancer using the following command:

```shell
linode-cli nodebalancers create \
  --region us-mia \
  --label my-nodebalancer
``` 

4. Create a NodeBalancer configuration using the following command, replacing the `MYIDHERE` with the ID of the newly created NodeBalancer:

```shell
linode-cli nodebalancers config-create MYIDHERE \
  --port 440 \
  --protocol http \
  --algorithm roundrobin \
  --stickiness http_cookie \
  --check http_body \
  --check_interval 90 \
  --check_timeout 10 \
  --check_attempts 3 \
  --check_path "/test" \
  --check_body "it works"
```

5. Ensure the NodeBalancer configuration has been created successfully.

## 📷 Preview

### Improved Help Page

![Improved Help Page](https://github.com/user-attachments/assets/4e6d12b2-b9e6-4b3a-b26d-04da1b4a1a17)
