### PR TITLE
Alphabetize config

### DIFF
--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -423,9 +423,9 @@ class CLIConfig:
             )
 
             if "data" in users:
-                auth_users = [
-                    u["username"] for u in users["data"] if "ssh_keys" in u
-                ]
+                auth_users = sorted(
+                    [u["username"] for u in users["data"] if "ssh_keys" in u]
+                )
 
         # get the preferred things
         config["region"] = _default_thing_input(

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -397,9 +397,12 @@ class CLIConfig:
         print(f"\nConfiguring {username}\n")
 
         # Configuring Defaults
-        regions = [
-            r["id"] for r in _do_get_request(self.base_url, "/regions")["data"]
-        ]
+        regions = sorted(
+            [
+                r["id"]
+                for r in _do_get_request(self.base_url, "/regions")["data"]
+            ]
+        )
         types = [
             t["id"]
             for t in _do_get_request(self.base_url, "/linode/types")["data"]

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -403,10 +403,12 @@ class CLIConfig:
                 for r in _do_get_request(self.base_url, "/regions")["data"]
             ]
         )
-        types = [
-            t["id"]
-            for t in _do_get_request(self.base_url, "/linode/types")["data"]
-        ]
+        types = sorted(
+            [
+                t["id"]
+                for t in _do_get_request(self.base_url, "/linode/types")["data"]
+            ]
+        )
         images = [
             i["id"] for i in _do_get_request(self.base_url, "/images")["data"]
         ]

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -409,9 +409,9 @@ class CLIConfig:
                 for t in _do_get_request(self.base_url, "/linode/types")["data"]
             ]
         )
-        images = [
-            i["id"] for i in _do_get_request(self.base_url, "/images")["data"]
-        ]
+        images = sorted(
+            [i["id"] for i in _do_get_request(self.base_url, "/images")["data"]]
+        )
 
         is_full_access = _check_full_access(self.base_url, token)
 


### PR DESCRIPTION
## 📝 Description

When configuring linode-cli, options are presented to the user in a random order. For example:
```
Select the user that should be given default SSH access to new Linodes.  Choices are:
1 - dour
2 - shiff
3 - retardment
4 - linotype
5 - subak
6 - frothy
7 - heptateuch
8 - sapp
9 - magisterial
10 - anglin
11 - fancied
12 - mercola
13 - naked
14 - aftershock
15 - spleen
16 - cuda
17 - carlinecarling
18 - natalienatalina
19 - whitehead
20 - rutherfordium
21 - sterrett
22 - integrated
23 - metacenter
24 - galegalea
25 - monachism
26 - turkish
27 - fabricate
28 - orvil
29 - rooker
30 - mintun
31 - prove

Default Option (Optional):
```

Have fun finding the user you're looking for!

This PR sorts the usernames to improve UX. It also sorts the regions, linode types, and images for the same reason.

## ✔️ How to Test

I tested by running `linode-cli configure` and verifying that the selected options appeared in the config file.

Since this PR does not introduce any new functionality, I did not add any tests. I did verify that these changes do not introduce failures when running unit tests.

## 📷 Preview
![1](https://github.com/user-attachments/assets/51ccaf17-b62d-4b83-acfd-0aec519d67ea)
![2](https://github.com/user-attachments/assets/5dc4490c-1e46-46ba-b4bc-a06bfa4412d6)
![3](https://github.com/user-attachments/assets/74fa57c2-081f-4e40-a9b2-394c6b72cca7)
![4](https://github.com/user-attachments/assets/453f1020-6398-4fc2-a9bf-9eb8124f30d0)

## Note

I wasn't sure if the linode types had some strategic order. I did sort them, however, that commit (or any other) can easily be dropped if this isn't desirable.