### PR TITLE
Requiring boto3>=1.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-obj = ["boto3"]
+obj = ["boto3>=1.36.0"]
 dev = [
     "pylint>=2.17.4",
     "pytest>=7.3.1",


### PR DESCRIPTION
## 📝 Description

The [latest code change](https://github.com/linode/linode-cli/pull/718) in the CLI for supporting boto3 >= 1.36 is not compatible with boto3 <= 1.35.

## ✔️ How to Test

```bash
make install && pytest tests/integration/obj/test_obj_plugin.py
```