### PR TITLE
Fix failure on OBJ plugin when CLI is not configured

### DIFF
--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -255,7 +255,7 @@ class CLIConfig:
                 "No running plugin to retrieve configuration for!"
             )
 
-        username = self.username or self.default_username()
+        username = self.username or self.default_username() or "DEFAULT"
         full_key = f"plugin-{self.running_plugin}-{key}"
 
         if not self.config.has_option(username, full_key):
@@ -553,7 +553,7 @@ class CLIConfig:
 
         if len(users) == 0:
             # config is new or _really_ old
-            token = self.config.get("DEFAULT", "token")
+            token = self.config.get("DEFAULT", "token", fallback=None)
 
             if token is not None:
                 # there's a token in the config - configure that user


### PR DESCRIPTION
## 📝 Description

This is to fix an issue that prevent OBJ plugin to work when no default user has been configured to the CLI.

## ✔️ How to Test

1. Remove existing CLI configuration file: `rm ~/.config/linode-cli` (if you have important stuff in the config, please back it up rather than remove)
2. Configure CLI via environmental variables.
```bash
export LINODE_CLI_TOKEN=[YOUR_API_TOKEN]
export LINODE_CLI_OBJ_ACCESS_KEY=[YOUR_OBJ_ACCESS_KEY]
export LINODE_CLI_OBJ_SECRET_KEY=[YOUR_OBJ_SECRET_KEY]
```
3. Verify the OBJ plugin is still working: `linode obj la`

