### PR TITLE
Add fallback value to replace explicitly option checking for config gets

### DIFF
--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -294,7 +294,7 @@ class CLIConfig:
             if key.startswith("plugin-"):
                 continue
 
-            value = self.config.get(username, key, fallback=ns_dict[key])
+            value = self.config.get(username, key, fallback=ns_dict.get(key))
 
             if not value:
                 continue

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -82,10 +82,7 @@ class CLIConfig:
         :returns: The `default-user` username or an empty string.
         :rtype: str
         """
-        if self.config.has_option("DEFAULT", "default-user"):
-            return self.config.get("DEFAULT", "default-user")
-
-        return ""
+        return self.config.get("DEFAULT", "default-user", fallback="")
 
     def set_user(self, username: str):
         """
@@ -153,15 +150,11 @@ class CLIConfig:
         :rtype: str
         """
         if self.used_env_token:
-            return os.environ.get(ENV_TOKEN_NAME, None)
+            return os.getenv(ENV_TOKEN_NAME, None)
 
-        if self.config.has_option(
-            self.username or self.default_username(), "token"
-        ):
-            return self.config.get(
-                self.username or self.default_username(), "token"
-            )
-        return ""
+        return self.config.get(
+            self.username or self.default_username(), "token", fallback=""
+        )
 
     def get_value(self, key: str) -> Optional[Any]:
         """
@@ -180,12 +173,9 @@ class CLIConfig:
                   current user.
         :rtype: any
         """
-        username = self.username or self.default_username()
-
-        if not self.config.has_option(username, key):
-            return None
-
-        return self.config.get(username, key)
+        return self.config.get(
+            self.username or self.default_username(), key, fallback=None
+        )
 
     def get_bool(self, key: str) -> bool:
         """
@@ -204,12 +194,10 @@ class CLIConfig:
                   current user.
         :rtype: any
         """
-        username = self.username or self.default_username()
 
-        if not self.config.has_option(username, key):
-            return False
-
-        return self.config.getboolean(username, key)
+        return self.config.getboolean(
+            self.username or self.default_username(), key, fallback=False
+        )
 
     # plugin methods - these are intended for plugins to utilize to store their
     # own persistent config information
@@ -258,10 +246,7 @@ class CLIConfig:
         username = self.username or self.default_username()
         full_key = f"plugin-{self.running_plugin}-{key}"
 
-        if not self.config.has_option(username, full_key):
-            return None
-
-        return self.config.get(username, full_key)
+        return self.config.get(username, full_key, fallback=None)
 
     # TODO: this is more of an argparsing function than it is a config function
     # might be better to move this to argparsing during refactor and just have
@@ -308,11 +293,8 @@ class CLIConfig:
             # these don't get included in the updated namespace
             if key.startswith("plugin-"):
                 continue
-            value = None
-            if self.config.has_option(username, key):
-                value = self.config.get(username, key)
-            else:
-                value = ns_dict[key]
+
+            value = self.config.get(username, key, fallback=ns_dict[key])
 
             if not value:
                 continue

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -299,6 +299,4 @@ def _config_get_with_default(
     :returns: The value pulled from the config or the default value.
     :rtype: Any
     """
-    return (
-        config.get(user, field) if config.has_option(user, field) else default
-    )
+    return config.get(user, field, fallback=default)


### PR DESCRIPTION
## Description

Refactor the logic for handling absent of the config values by providing a fallback value in the `get` function call to replace the explicit checking with if statement.

## Testing

There should not be any functionality change in this PR, but you can try various stuff with the CLI, for example:
1. `linode configure`
2. `linode linodes list`
3. ...