### PR TITLE
Consume linode-api-docs/openapi.json rather than openapi.yaml

### DIFF
--- a/resolve_spec_url
+++ b/resolve_spec_url
@@ -39,5 +39,5 @@ if __name__ == "__main__":
         desired_version = get_latest_tag()
 
     print(
-        f"https://raw.githubusercontent.com/{LINODE_DOCS_REPO}/{desired_version}/openapi.yaml"
+        f"https://raw.githubusercontent.com/{LINODE_DOCS_REPO}/{desired_version}/openapi.json"
     )


### PR DESCRIPTION
## 📝 Description

This pull request re-points the default OpenAPI specification URL from

```
https://raw.githubusercontent.com/linode/linode-api-docs/.../openapi.yaml
``` 

to

```
https://raw.githubusercontent.com/linode/linode-api-docs/.../openapi.json
```

in response to the corresponding change in the linode-api-docs repository.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Manual Testing

1. Run an arbitrary command using the new Linode CLI install.

### Integration Testing

```
make test-int
```
