### PR TITLE
Uninstall Document

### DIFF
--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,4 +1,5 @@
 - [Installation](./Installation)
+- [Uninstallation](./Uninstallation)
 - [Configuration](./Configuration)
 - [Usage](./Usage)
 - [Output](./Output)


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Adds a basic uninstallation document to remind users to remove the config file.
