### PR TITLE
fix: Incomplete URL substring sanitization Unvalidated Redirects and Forwards

### DIFF
--- a/tests/integration/domains/test_slave_domains.py
+++ b/tests/integration/domains/test_slave_domains.py
@@ -70,7 +70,9 @@ def test_list_slave_domain(slave_domain):
     result = exec_test_command(
         BASE_CMD + ["list", "--text", "--no-header"]
     ).stdout.decode()
-    assert "-example.com" in result
+    from urllib.parse import urlparse
+    parsed_url = urlparse(result)
+    assert parsed_url.hostname and parsed_url.hostname.endswith("-example.com")
 
 
 @pytest.mark.skip(reason="BUG 872")


### PR DESCRIPTION
## 📝 Description
patched(fix) for #735

To fix the problem, we should parse the URL and check the hostname to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. We will extract the hostname from the URL and check if it ends with the expected domain.

- Replace the substring check `"-example.com" in result` with a more robust check that parses the URL and verifies the hostname.
- Update the test to use the `urlparse` function to extract the hostname and check if it ends with the expected domain.


