### PR TITLE
Add test summary to slack notification

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Generate test summary and save to output
         id: set-test-summary
         run: |
-          filename=$(ls | grep -E '^[0-9]{12}_sdk_test_report\.xml$') 
+          filename=$(ls | grep -E '^[0-9]{12}_cli_test_report\.xml$')
           test_output=$(python3 e2e_scripts/tod_scripts/generate_test_summary.py "${filename}")
           {
             echo 'summary<<EOF'

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -235,6 +235,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration_tests]
     if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    outputs:
+      summary: ${{ steps.set-test-summary.outputs.summary }}
 
     steps:
       - name: Checkout code
@@ -275,6 +277,17 @@ jobs:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
 
+      - name: Generate test summary and save to output
+        id: set-test-summary
+        run: |
+          filename=$(ls | grep -E '^[0-9]{12}_sdk_test_report\.xml$') 
+          test_output=$(python3 e2e_scripts/tod_scripts/generate_test_summary.py "${filename}")
+          {
+            echo 'summary<<EOF'
+            echo "$test_output"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
 
   notify-slack:
     runs-on: ubuntu-latest
@@ -283,6 +296,7 @@ jobs:
 
     steps:
       - name: Notify Slack
+        id: main_message
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -293,7 +307,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
+                  text: ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* ${{ needs.integration_tests.result == 'success' && ':white_check_mark:' || ':failed:' }}"
               - type: divider
               - type: section
                 fields:
@@ -312,3 +326,14 @@ jobs:
                 elements:
                   - type: mrkdwn
                     text: "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
+
+      - name: Test summary thread
+        if: success()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            thread_ts: "${{ steps.main_message.outputs.ts }}"
+            text: "${{ needs.process-upload-report.outputs.summary }}"


### PR DESCRIPTION
## 📝 Description

Improving slack test notifications

Overall Test Summary available
Now it is able to thread failures and errors in slack message
e.g.
![image](https://github.com/user-attachments/assets/45107d08-e1b2-4fa4-a58f-bd655e09c3bc)

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**