### PR TITLE
Add conditions to notification job in e2e workflow

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -234,7 +234,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    if: always() # && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 
@@ -291,8 +291,8 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [integration_tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
+    needs: [integration_tests, process-upload-report]
+    if: ${{ (success() || failure()) }} #&& github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -234,7 +234,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() # && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 
@@ -292,7 +292,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [integration_tests, process-upload-report]
-    if: ${{ (success() || failure()) }} #&& github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
+    if: ${{ (success() || failure()) && github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack


### PR DESCRIPTION
## 📝 Description

` needs: [integration_tests, process-upload-report]`
The condition above was missed which was causing the summary to be empty during notification job

## ✔️ How to Test

Tested on forked and private channel 
![image](https://github.com/user-attachments/assets/bdd7511d-1610-4b4d-b436-2d1774eb24a5)


## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**