### PR TITLE
Configure Python `logging` level when debug flag is specified; add debug logs to bake command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ VERSION_FILE := ./linodecli/version.py
 VERSION_MODULE_DOCSTRING ?= \"\"\"\nThe version of the Linode CLI.\n\"\"\"\n\n
 LINODE_CLI_VERSION ?= "0.0.0.dev"
 
+BAKE_FLAGS := --debug
+
 .PHONY: install
 install: check-prerequisites requirements build
 	pip3 install --force dist/*.whl
@@ -21,7 +23,7 @@ bake: clean
 ifeq ($(SKIP_BAKE), 1)
 	@echo Skipping bake stage
 else
-	python3 -m linodecli bake ${SPEC} --skip-config
+	python3 -m linodecli bake ${SPEC} --skip-config $(BAKE_FLAGS)
 	cp data-3 linodecli/
 endif
 

--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -4,6 +4,7 @@ Argument parser for the linode CLI
 """
 
 import argparse
+import logging
 import os
 import sys
 from importlib.metadata import version
@@ -37,6 +38,11 @@ VERSION = __version__
 BASE_URL = "https://api.linode.com/v4"
 
 TEST_MODE = os.getenv("LINODE_CLI_TEST_MODE") == "1"
+
+# Configure the `logging` package log level depending on the --debug flag.
+logging.basicConfig(
+    level=logging.DEBUG if "--debug" in argv else logging.WARNING,
+)
 
 # if any of these arguments are given, we don't need to prompt for configuration
 skip_config = (

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -109,15 +109,15 @@ def do_request(
         # Multiline log entries aren't ideal, we should consider
         # using single-line structured logging in the future.
         logger.debug(
-            "\n"
-            + "\n".join(_format_request_for_log(method, url, headers, body))
+            "\n%s",
+            "\n".join(_format_request_for_log(method, url, headers, body)),
         )
 
     result = method(url, headers=headers, data=body, verify=API_CA_PATH)
 
     # Print response debug info is requested
     if ctx.debug_request:
-        logger.debug("\n" + "\n".join(_format_response_for_log(result)))
+        logger.debug("\n%s", "\n".join(_format_response_for_log(result)))
 
     # Retry the request if necessary
     while _check_retry(result) and not ctx.no_retry and ctx.retry_count < 3:
@@ -395,7 +395,7 @@ def _format_request_for_log(
 
         result.append(f"> {k}: {v}")
 
-    result.extend(["> Body:", f">   {body or ''}", f"> "])
+    result.extend(["> Body:", f">   {body or ''}", "> "])
 
     return result
 

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -404,7 +404,7 @@ def _format_response_for_log(
     response: requests.Response,
 ):
     """
-    Builds a debug output for the given request.
+    Builds a debug output for the given response.
 
     :param response: The HTTP response to format.
 

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -18,7 +18,6 @@ from urllib.parse import urlparse
 import openapi3.paths
 from openapi3.paths import Operation, Parameter
 
-from linodecli import logging
 from linodecli.baked.parsing import simplify_description
 from linodecli.baked.request import (
     OpenAPIFilteringRequest,

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -5,6 +5,7 @@ CLI Operation logic
 import argparse
 import glob
 import json
+import logging
 import platform
 import re
 import sys
@@ -17,6 +18,7 @@ from urllib.parse import urlparse
 import openapi3.paths
 from openapi3.paths import Operation, Parameter
 
+from linodecli import logging
 from linodecli.baked.parsing import simplify_description
 from linodecli.baked.request import (
     OpenAPIFilteringRequest,
@@ -400,9 +402,10 @@ class OpenAPIOperation:
         self.docs_url = self._resolve_operation_docs_url(operation)
 
         if self.docs_url is None:
-            print(
-                f"INFO: Could not resolve docs URL for {operation}",
-                file=sys.stderr,
+            logging.warning(
+                "%s %s Could not resolve docs URL for operation",
+                self.method.upper(),
+                self.url_path,
             )
 
         code_samples_ext = operation.extensions.get("code-samples")
@@ -425,6 +428,13 @@ class OpenAPIOperation:
         Return a list of attributes from the request schema
         """
         return self.request.attr_routes if self.request else []
+
+    @property
+    def attrs(self):
+        """
+        Return a list of attributes from the request schema
+        """
+        return self.response_model.attrs if self.response_model else []
 
     @staticmethod
     def _flatten_url_path(tag: str) -> str:

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -8,6 +8,7 @@ import os
 import pickle
 import sys
 from json import JSONDecodeError
+from logging import getLogger
 from sys import version_info
 from typing import IO, Any, ContextManager, Dict
 
@@ -22,8 +23,6 @@ from linodecli.exit_codes import ExitCodes
 from linodecli.output.output_handler import OutputHandler, OutputMode
 
 METHODS = ("get", "post", "put", "delete")
-
-from logging import getLogger
 
 logger = getLogger(__name__)
 

--- a/linodecli/helpers.py
+++ b/linodecli/helpers.py
@@ -106,7 +106,10 @@ def register_debug_arg(parser: ArgumentParser):
     ArgumentParser that may be shared across the CLI and plugins.
     """
     parser.add_argument(
-        "--debug", action="store_true", help="Enable verbose HTTP debug output."
+        "--debug",
+        action="store_true",
+        help="Enable verbose debug logging, including displaying HTTP debug output and "
+        "configuring the Python logging package level to DEBUG.",
     )
 
 

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -21,8 +21,6 @@ class TestAPIRequest:
     """
 
     def test_response_debug_info(self):
-        stderr_buf = io.StringIO()
-
         mock_response = SimpleNamespace(
             raw=SimpleNamespace(version=11.1),
             status_code=200,
@@ -31,34 +29,32 @@ class TestAPIRequest:
             content=b"cool body",
         )
 
-        with contextlib.redirect_stderr(stderr_buf):
-            api_request._print_response_debug_info(mock_response)
+        result = api_request._format_response_for_log(mock_response)
 
-        output = stderr_buf.getvalue()
-        assert "< HTTP/1.1 200 OK" in output
-        assert "< cool: test" in output
-        assert "< Body:" in output
-        assert "<   cool body" in output
-        assert "< " in output
+        assert result == [
+            "< HTTP/1.1 200 OK",
+            "< cool: test",
+            "< Body:",
+            "<   cool body",
+            "< ",
+        ]
 
     def test_request_debug_info(self):
-        stderr_buf = io.StringIO()
+        result = api_request._format_request_for_log(
+            SimpleNamespace(__name__="get"),
+            "https://definitely.linode.com/",
+            {"cool": "test", "Authorization": "sensitiveinfo"},
+            "cool body",
+        )
 
-        with contextlib.redirect_stderr(stderr_buf):
-            api_request._print_request_debug_info(
-                SimpleNamespace(__name__="get"),
-                "https://definitely.linode.com/",
-                {"cool": "test", "Authorization": "sensitiveinfo"},
-                "cool body",
-            )
-
-        output = stderr_buf.getvalue()
-        assert "> GET https://definitely.linode.com/" in output
-        assert "> cool: test" in output
-        assert f"> Authorization: Bearer {'*' * 64}" in output
-        assert "> Body:" in output
-        assert ">   cool body" in output
-        assert "> " in output
+        assert result == [
+            "> GET https://definitely.linode.com/",
+            "> cool: test",
+            f"> Authorization: Bearer {'*' * 64}",
+            "> Body:",
+            ">   cool body",
+            "> ",
+        ]
 
     def test_build_request_body(self, mock_cli, create_operation):
         create_operation.allowed_defaults = ["region", "image"]


### PR DESCRIPTION
## 📝 Description

This pull request updates the `--debug` flag to additionally set the Python `logging` package's log level to `DEBUG`. This allows users to more easily diagnose issues with underlying dependencies (e.g. urllib3) and introduces a standardized logging format we can use for debugging.

This pull request also introduces various log statements to the `linode-cli bake` command, which should make build issues easier to diagnose in CI.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Manual Testing

1. Attempt to re-bake the OpenAPI spec:

```shell
make bake
```

2. Ensure the output contains debug lines similar to the following:

```
DEBUG:linodecli.cli:GET /{apiVersion}/vpcs/{vpcId}/subnets/{vpcSubnetId}: Attempting to generate command for operation
DEBUG:linodecli.cli:GET /{apiVersion}/vpcs/{vpcId}/subnets/{vpcSubnetId}: Successfully built command for operation: command='vpcs subnet-view'; summary='Get a VPC subnet'; paginated=False; num_args=0; num_attrs=8
```

3. Run an arbitrary command using the `--debug` flag:

```shell
linode-cli linodes create --debug --type g6-nanode-1 --region us-mia --label test
```

4. Ensure urllib3 debug information is displayed alongside the API request/response data.