### PR TITLE
Remove deprecated warning and update license format to latest format

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -234,7 +234,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    if: always() # && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 
@@ -291,8 +291,8 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [integration_tests]
-    if: ${{ (success() || failure()) && github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
+    needs: [integration_tests, process-upload-report]
+    if: ${{ (success() || failure()) }} #&& github.repository == 'linode/linode-cli' }} # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Akamai Technologies Inc.", email = "developers@linode.com" 
 description = "The official command-line interface for interacting with the Linode API."
 readme = "README.md"
 requires-python = ">=3.9"
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 classifiers = []
 dependencies = [
     "openapi3",


### PR DESCRIPTION
## 📝 Description

Deprecation warning is coming from setuptools, on how license variable is defined in pyproject.toml file defines the project.license field. Detailed build warnings below during `make install`:

/private/var/folders/g4/6nz043hs45qbblr441jmsq0c0000gq/T/build-env-ivsf1fb6/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: project.license as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for project.license. You can also use project.license-files.

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!

## ✔️ How to Test

1. Check out this branch
2. `make install` and verify deprecation warnings is removed

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**