### PR TITLE
Add openapi.json to .gitignore; drop from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/.env
 MANIFEST
 venv
 openapi*.yaml
+openapi*.json


### PR DESCRIPTION
## 📝 Description

This pull request drops the `openapi.json` from this repository's tracked files and adds a corresponding entry to the `.gitignore` file