### PR TITLE
Error on missing x-linode-cli-command extension; log when operationId is used for action

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -110,7 +110,8 @@ class CLI:  # pylint: disable=too-many-instance-attributes
                 if action is None:
                     action = operation.operationId
                     logger.info(
-                        "%s: Using operationId (%s) as action because %s extension is not specified",
+                        "%s: Using operationId (%s) as action because "
+                        "%s extension is not specified",
                         operation_log_fmt,
                         action,
                         ext["action"],

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -112,6 +112,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
                     logger.info(
                         "%s: Using operationId (%s) as action because %s extension is not specified",
                         operation_log_fmt,
+                        action,
                         ext["action"],
                     )
 

--- a/tests/fixtures/cli_test_bake_missing_cmd_ext.yaml
+++ b/tests/fixtures/cli_test_bake_missing_cmd_ext.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.1
+info:
+  title: API Specification
+  version: 1.0.0
+servers:
+  - url: http://localhost/v4
+paths:
+  /foo/bar:
+    get:
+      summary: get info
+      operationId: fooBarGet
+      description: This is description
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OpenAPIResponseAttr'
+                  page:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/page'
+                  pages:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/pages'
+                  results:
+                    $ref: '#/components/schemas/PaginationEnvelope/properties/results'
+
+components:
+  schemas:
+    OpenAPIResponseAttr:
+      type: object
+      properties:
+        filterable_result:
+          x-linode-filterable: true
+          type: string
+          description: Filterable result value
+        filterable_list_result:
+          x-linode-filterable: true
+          type: array
+          items:
+            type: string
+          description: Filterable result value
+    PaginationEnvelope:
+      type: object
+      properties:
+        pages:
+          type: integer
+          readOnly: true
+          description: The total number of pages.
+          example: 1
+        page:
+          type: integer
+          readOnly: true
+          description: The current page.
+          example: 1
+        results:
+          type: integer
+          readOnly: true
+          description: The total number of results.
+          example: 1

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -122,6 +122,24 @@ class TestCLI:
             assert m.call_count == 1
             assert parsed_json_http.raw_element == parsed_json_local.raw_element
 
+    def test_bake_missing_cmd_ext(self, mock_cli: CLI):
+        try:
+            mock_cli.bake(
+                str(
+                    os.path.join(
+                        FIXTURES_PATH, "cli_test_bake_missing_cmd_ext.yaml"
+                    )
+                ),
+                save=False,
+            )
+        except KeyError as err:
+            assert (
+                str(err)
+                == "'GET /foo/bar: Missing x-linode-cli-command extension'"
+            )
+        else:
+            raise AssertionError("Expected a KeyError exception")
+
 
 def test_get_all_pages(
     mock_cli: CLI, list_operation: OpenAPIOperation, monkeypatch: MonkeyPatch


### PR DESCRIPTION
## 📝 Description

This pull request adds logic to raise an error if an OpenAPI path has CLI-enabled actions but does _not_ specify an `x-linode-cli-command` extension. This is necessary because we've recently had OpenAPI specification release candidates make it very far down the pipeline before commands misgrouped under `default` are discovered, which is not intentionally used by any existing commands. 

This pull request also adds a new log entry that occurs when the `x-linode-cli-action` extension is not specified and the operationId is used as a failover.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```