### PR TITLE
Add LKE tier integration tests

### DIFF
--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -407,7 +407,7 @@ def test_list_lke_types():
     assert "LKE High Availability" in types
 
 
-def test_create_node_pool_default_to_disk_encryption_enabled(test_lke_cluster):
+def test_create_node_pool_default_to_disk_encryption_disabled(test_lke_cluster):
     cluster_id = test_lke_cluster
 
     result = (
@@ -429,7 +429,7 @@ def test_create_node_pool_default_to_disk_encryption_enabled(test_lke_cluster):
         .rstrip()
     )
 
-    assert "enabled" in result
+    assert "disabled" in result
     assert "g6-standard-4" in result
 
 

--- a/tests/integration/lke/test_lke_enterprise.py
+++ b/tests/integration/lke/test_lke_enterprise.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest import MonkeyPatch
 
 from tests.integration.helpers import (
@@ -48,7 +50,7 @@ def test_create_lke_enterprise(monkeypatch: MonkeyPatch):
                 "--tier",
                 "enterprise",
                 "--k8s_version",
-                "v1.31.1+lke1",
+                "v1.31.1+lke4",
                 "--node_pools.type",
                 "g6-standard-6",
                 "--node_pools.count",
@@ -74,7 +76,7 @@ def test_create_lke_enterprise(monkeypatch: MonkeyPatch):
     assert_headers_in_lines(headers, output.splitlines())
 
     assert label in output
-    assert "v1.31.1+lke1" in output
+    assert "v1.31.1+lke4" in output
     assert "enterprise" in output
 
     delete_target_id(
@@ -82,3 +84,89 @@ def test_create_lke_enterprise(monkeypatch: MonkeyPatch):
         id=get_cluster_id(label=label),
         delete_command="cluster-delete",
     )
+
+
+def test_lke_tiered_versions_list():
+    enterprise_tier_info_list = (
+        exec_test_command(
+            BASE_CMD
+            + [
+                "tiered-versions-list",
+                "enterprise",
+                "--json",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )
+
+    parsed = json.loads(enterprise_tier_info_list)
+
+    enterprise_ti = parsed[0]
+
+    assert enterprise_ti.get("id") == "v1.31.1+lke4"
+    assert enterprise_ti.get("tier") == "enterprise"
+
+    standard_tier_info_list = (
+        exec_test_command(
+            BASE_CMD
+            + [
+                "tiered-versions-list",
+                "standard",
+                "--json",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )
+
+    s_ti_list = json.loads(standard_tier_info_list)
+
+    assert s_ti_list[0].get("id") == "1.32"
+    assert s_ti_list[0].get("tier") == "standard"
+    assert s_ti_list[1].get("id") == "1.31"
+    assert s_ti_list[1].get("tier") == "standard"
+
+
+def test_lke_tiered_versions_view():
+    enterprise_tier_info = (
+        exec_test_command(
+            BASE_CMD
+            + [
+                "tiered-version-view",
+                "enterprise",
+                "v1.31.1+lke4",
+                "--json",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )
+
+    parsed = json.loads(enterprise_tier_info)
+
+    enterprise_ti = parsed[0]
+
+    assert enterprise_ti.get("id") == "v1.31.1+lke4"
+    assert enterprise_ti.get("tier") == "enterprise"
+
+    standard_tier_info = (
+        exec_test_command(
+            BASE_CMD
+            + [
+                "tiered-version-view",
+                "standard",
+                "1.31",
+                "--json",
+            ]
+        )
+        .stdout.decode()
+        .rstrip()
+    )
+
+    parsed = json.loads(standard_tier_info)
+
+    stardard_ti = parsed[0]
+
+    assert stardard_ti.get("id") == "1.31"
+    assert stardard_ti.get("tier") == "standard"

--- a/tests/integration/lke/test_lke_enterprise.py
+++ b/tests/integration/lke/test_lke_enterprise.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from pytest import MonkeyPatch
 
 from tests.integration.helpers import (
@@ -86,6 +87,7 @@ def test_create_lke_enterprise(monkeypatch: MonkeyPatch):
     )
 
 
+@pytest.mark.skip(reason="Commnad not available in spec < v4.198.0")
 def test_lke_tiered_versions_list():
     enterprise_tier_info_list = (
         exec_test_command(
@@ -128,6 +130,7 @@ def test_lke_tiered_versions_list():
     assert s_ti_list[1].get("tier") == "standard"
 
 
+@pytest.mark.skip(reason="Commnad not available in spec < v4.198.0")
 def test_lke_tiered_versions_view():
     enterprise_tier_info = (
         exec_test_command(


### PR DESCRIPTION
## 📝 Description

```
+ lke tiered-version-view (/{apiVersion}/lke/tiers/{tier}/versions/{version})
+ lke tiered-versions-list (/{apiVersion}/lke/tiers/{tier}/versions)
```
Add integration test coverage for commands above for spec v4.198.0 release

## ✔️ How to Test

`make test-int TEST_SUITE=lke`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**