### PR TITLE
Allow specifying explicitly empty dicts and lists for object arguments

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -18,6 +18,7 @@ from linodecli.exit_codes import ExitCodes
 from linodecli.helpers import API_CA_PATH, API_VERSION_OVERRIDE
 
 from .baked.operation import (
+    ExplicitEmptyDictValue,
     ExplicitEmptyListValue,
     ExplicitNullValue,
     OpenAPIOperation,
@@ -303,13 +304,17 @@ def _traverse_request_body(o: Any) -> Any:
             if v is None:
                 continue
 
-            # Values that are expected to be serialized as empty lists
-            # and explicit None values are converted here.
+            # Values that are expected to be serialized as empty
+            # dicts, lists, and explicit None values are converted here.
             # See: operation.py
             # NOTE: These aren't handled at the top-level of this function
             # because we don't want them filtered out in the step below.
             if isinstance(v, ExplicitEmptyListValue):
                 result[k] = []
+                continue
+
+            if isinstance(v, ExplicitEmptyDictValue):
+                result[k] = {}
                 continue
 
             if isinstance(v, ExplicitNullValue):

--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -330,7 +330,7 @@ def test_update_node_pool(test_lke_cluster):
     node_pool_id = get_node_pool_id(cluster_id)
     new_value = get_random_text(8) + "updated_pool"
 
-    result = (
+    result = json.loads(
         exec_test_command(
             BASE_CMD
             + [
@@ -341,16 +341,42 @@ def test_update_node_pool(test_lke_cluster):
                 "5",
                 "--labels",
                 json.dumps({"label-key": new_value}),
-                "--text",
-                "--no-headers",
-                "--format=label",
+                "--taints",
+                '[{"key": "test-key", "value": "test-value", "effect": "NoSchedule"}]',
+                "--json",
             ]
-        )
-        .stdout.decode()
-        .rstrip()
+        ).stdout.decode()
     )
 
-    assert new_value in result
+    assert result[0]["labels"] == {"label-key": new_value}
+
+    assert result[0]["taints"] == [
+        {
+            "key": "test-key",
+            "value": "test-value",
+            "effect": "NoSchedule",
+        }
+    ]
+
+    # Reset the values for labels and taints (TPT-3665)
+    result = json.loads(
+        exec_test_command(
+            BASE_CMD
+            + [
+                "pool-update",
+                cluster_id,
+                node_pool_id,
+                "--labels",
+                "{}",
+                "--taints",
+                "[]",
+                "--json",
+            ]
+        ).stdout.decode()
+    )
+
+    assert result[0]["labels"] == {}
+    assert result[0]["taints"] == []
 
 
 def test_view_node(test_lke_cluster):

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -12,7 +12,11 @@ import pytest
 import requests
 
 from linodecli import api_request
-from linodecli.baked.operation import ExplicitEmptyListValue, ExplicitNullValue
+from linodecli.baked.operation import (
+    ExplicitEmptyDictValue,
+    ExplicitEmptyListValue,
+    ExplicitNullValue,
+)
 
 
 class TestAPIRequest:
@@ -597,6 +601,7 @@ class TestAPIRequest:
                     "baz": ExplicitNullValue(),
                 },
                 "cool": [],
+                "pretty_cool": ExplicitEmptyDictValue(),
                 "cooler": ExplicitEmptyListValue(),
                 "coolest": ExplicitNullValue(),
             }
@@ -614,6 +619,7 @@ class TestAPIRequest:
                 "foo": "bar",
                 "baz": None,
             },
+            "pretty_cool": {},
             "cooler": [],
             "coolest": None,
         }

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -5,6 +5,8 @@ import json
 
 from linodecli.baked import operation
 from linodecli.baked.operation import (
+    TYPES,
+    ExplicitEmptyDictValue,
     ExplicitEmptyListValue,
     ExplicitNullValue,
     OpenAPIOperation,
@@ -276,6 +278,41 @@ class TestOperation:
         # User specifies a normal value and an empty list value
         result = parser.parse_args(["--foo", "foo", "--foo", "[]"])
         assert getattr(result, "foo") == ["foo", "[]"]
+
+    def test_object_arg_action_basic(self):
+        """
+        Tests a basic array argument condition..
+        """
+
+        parser = argparse.ArgumentParser(
+            prog=f"foo",
+        )
+
+        parser.add_argument(
+            "--foo",
+            metavar="foo",
+            type=TYPES["object"],
+        )
+
+        # User specifies a normal object (dict)
+        result = parser.parse_args(["--foo", '{"test-key": "test-value"}'])
+        assert getattr(result, "foo") == {"test-key": "test-value"}
+
+        # User specifies a normal object (list)
+        result = parser.parse_args(["--foo", '[{"test-key": "test-value"}]'])
+        assert getattr(result, "foo") == [{"test-key": "test-value"}]
+
+        # User wants an explicitly empty object (dict)
+        result = parser.parse_args(["--foo", "{}"])
+        assert isinstance(getattr(result, "foo"), ExplicitEmptyDictValue)
+
+        # User wants an explicitly empty object (list)
+        result = parser.parse_args(["--foo", "[]"])
+        assert isinstance(getattr(result, "foo"), ExplicitEmptyListValue)
+
+        # User doesn't specify the list
+        result = parser.parse_args([])
+        assert getattr(result, "foo") is None
 
     def test_resolve_api_components(self, get_openapi_for_api_components_tests):
         root = get_openapi_for_api_components_tests


### PR DESCRIPTION
## 📝 Description

This pull request adds support for specifying explicitly empty lists and dicts when a specified in an object argument JSON string. This allows users to reset the labels and taints for an LKE node pool using the `linode-cli lke pool-update` command.

**Syntax for Explicit Empty Dict:**

```bash
linode-cli command action --some-object-arg '{}'
```

**Syntax for Explicit Empty List:**

```bash
linode-cli command action --some-object-arg '[]'
```

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int TEST_SUITE=lke/test_clusters.py::test_update_node_pool
```

### Manual Testing

1. Run the following command to create a new LKE cluster with explicit labels and taints:

```shell
linode-cli lke cluster-create \
  --label cli-test \
  --region us-mia \
  --k8s_version 1.32 \
  --node_pools.count 2 \
  --node_pools.type g6-standard-1 \
  --node_pools.labels '{"test-key": "test-value"}' \
  --node_pools.taints '[{"key": "test-key", "value": "test-value", "effect": "NoSchedule"}]'
```

2. Ensure the LKE cluster was created successfully and take note of its ID.
3. Run the following command to retrieve the ID of the cluster's pool:

```shell
linode-cli lke pools-list {your_lke_cluster_id} --format id
```

4. Run the following command to remove the labels and taints from the pool:

```shell
linode-cli lke pool-update {your_lke_cluster_id} {your_node_pool_id} --labels '{}' --taints '[]'
```

5. Ensure the command runs successfully and that the pool no longer has any labels or taints.