### PR TITLE
Trusted publisher for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,11 @@ jobs:
             github_token=${{ secrets.GITHUB_TOKEN }}
 
   pypi-release:
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     runs-on: ubuntu-latest
+    environment: pypi-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -103,5 +107,3 @@ jobs:
 
       - name: Publish the release artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # pin@release/v1.12.4
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## 📝 Description

Migrate to trusted publisher to avoid token usage.

Sample release: https://github.com/zliang-akamai/linode-cli/actions/runs/14677674503/job/41196302382

Do we want to configure [some protection rules for the `pypi-release` environment](https://github.com/linode/linode-cli/settings/environments/6488209563/edit)?