### PR TITLE
Fixed domain test failures caused by `--target-command` argument

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -108,14 +108,14 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         sys.exit(ExitCodes.ARGUMENT_ERROR)
 
     if parsed.command in ("set-custom-alias", "remove-custom-alias"):
-        if not parsed.target_command or not parsed.alias:
+        if not parsed.alias_command or not parsed.alias:
             print(
-                "Both --target-command and --alias must be provided.",
+                "Both --alias-command and --alias must be provided.",
                 file=sys.stderr,
             )
             sys.exit(ExitCodes.ARGUMENT_ERROR)
 
-        command = parsed.target_command
+        command = parsed.alias_command
         alias = parsed.alias
 
         if command not in cli.ops:

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -68,8 +68,7 @@ def register_args(parser: ArgumentParser) -> ArgumentParser:
     )
 
     parser.add_argument(
-        "--target-command",
-        "-t",
+        "--alias-command",
         nargs="?",
         type=str,
         help="The command to set or remove an alias for.",
@@ -77,7 +76,6 @@ def register_args(parser: ArgumentParser) -> ArgumentParser:
 
     parser.add_argument(
         "--alias",
-        "-a",
         nargs="?",
         type=str,
         help="The alias to set or remove.",


### PR DESCRIPTION
## 📝 Description

Renamed `--target-command` to `--alias-command` to address domain test failures.

## ✔️ How to Test

The following steps assume you have pulled down this PR locally and ran `make install`.

### Integration Testing
`make test-int TEST_CASE= test_create_domain_srv_record `
`make test-int TEST_CASE= test_list_srv_record `
`make test-int TEST_CASE= test_view_domain_record `
`make test-int TEST_CASE= test_update_domain_record `
`make test-int TEST_CASE= test_delete_a_domain_record `
`make test-int TEST_CASE= test_help_records_list `

### Manual Testing
Ensure that custom alias functionality introduced in #755 still works by running the following commands:

`linode-cli set-custom-alias --alias-command nodebalancers --alias nbs1`
`linode-cli set-custom-alias --alias nbs2 --alias-command nodebalancers`
`linode-cli remove-custom-alias --alias-command nodebalancers --alias nbs1`
`linode-cli remove-custom-alias --alias nbs2 --alias-command nodebalancers`

Feel free to test it out with other commands as well.
