### PR TITLE
Update disk encryption node pool test

### DIFF
--- a/tests/integration/lke/test_clusters.py
+++ b/tests/integration/lke/test_clusters.py
@@ -407,7 +407,7 @@ def test_list_lke_types():
     assert "LKE High Availability" in types
 
 
-def test_create_node_pool_default_to_disk_encryption_disabled(test_lke_cluster):
+def test_create_node_pool_has_disk_encryption_field_set(test_lke_cluster):
     cluster_id = test_lke_cluster
 
     result = (
@@ -437,7 +437,7 @@ def test_create_node_pool_default_to_disk_encryption_disabled(test_lke_cluster):
 
     disk_encryption_status = pool_info.get("disk_encryption")
 
-    assert "disabled" in result
+    assert disk_encryption_status in ("enabled", "disabled")
     assert "g6-standard-4" in result
 
 


### PR DESCRIPTION
## 📝 Description

Test is made more flexible to check if disk encryption value is set instead of seeing the default value always equal to disabled

## ✔️ How to Test

`make test-int TEST_CASE=test_create_node_pool_has_disk_encryption_field `

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**