### PR TITLE
Support baking different scenarios of oneOf usage in openapi spec

### DIFF
--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -249,9 +249,11 @@ class OpenAPIResponse:
         elif self.is_paginated:
             # for paginated responses, the model we're parsing is the item in the paginated
             # response, not the pagination envelope
-            self.attrs = _parse_response_model(
-                response.schema.properties["data"].items
+            data_schema = response.schema.properties["data"]
+            target_schema = (
+                data_schema.items if data_schema.items else data_schema
             )
+            self.attrs = _parse_response_model(target_schema)
         else:
             self.attrs = _parse_response_model(response.schema)
 


### PR DESCRIPTION
## 📝 Description

Previously, the schema expected oneOf to be defined strictly within the properties block of the YAML file, limiting flexibility in structuring the schema. This update allows oneOf to be defined outside of properties in yaml files, e.g. schema definitions like below:

```
type: object
description: |
  One of the following interface types: VPC, public, or VLAN.
oneOf:
- $ref: linode-interface-public.yaml
- $ref: linode-interface-vlan.yaml
- $ref: linode-interface-vpc.yaml
```

## ✔️ How to Test

Download `openapi.json` file from Akamai git source v4.199.0

`SPEC=/path/to/openapi.json make test-int`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**