### PR TITLE
Fixed improperly nested `engine_config` arguments in Postgres DB creation

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -23,6 +23,7 @@ from .baked.operation import (
     ExplicitNullValue,
     OpenAPIOperation,
 )
+from .baked.util import get_path_segments
 from .helpers import handle_url_overrides
 
 if TYPE_CHECKING:
@@ -364,13 +365,15 @@ def _build_request_body(
         if v is None or k in param_names:
             continue
 
+        path_segments = get_path_segments(k)
+
         cur = expanded_json
-        for part in k.split(".")[:-1]:
+        for part in path_segments[:-1]:
             if part not in cur:
                 cur[part] = {}
             cur = cur[part]
 
-        cur[k.split(".")[-1]] = v
+        cur[path_segments[-1]] = v
 
     return json.dumps(_traverse_request_body(expanded_json))
 

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -25,6 +25,7 @@ from linodecli.baked.request import (
     OpenAPIRequestArg,
 )
 from linodecli.baked.response import OpenAPIResponse
+from linodecli.baked.util import unescape_arg_segment
 from linodecli.exit_codes import ExitCodes
 from linodecli.output.output_handler import OutputHandler
 from linodecli.overrides import OUTPUT_OVERRIDES
@@ -649,6 +650,9 @@ class OpenAPIOperation:
             if arg.read_only:
                 continue
 
+            arg_name_unescaped = unescape_arg_segment(arg.name)
+            arg_path_unescaped = unescape_arg_segment(arg.path)
+
             arg_type = (
                 arg.item_type if arg.datatype == "array" else arg.datatype
             )
@@ -660,15 +664,17 @@ class OpenAPIOperation:
             if arg.datatype == "array":
                 # special handling for input arrays
                 parser.add_argument(
-                    "--" + arg.path,
-                    metavar=arg.name,
+                    "--" + arg_path_unescaped,
+                    dest=arg.path,
+                    metavar=arg_name_unescaped,
                     action=ArrayAction,
                     type=arg_type_handler,
                 )
             elif arg.is_child:
                 parser.add_argument(
-                    "--" + arg.path,
-                    metavar=arg.name,
+                    "--" + arg_path_unescaped,
+                    dest=arg.path,
+                    metavar=arg_name_unescaped,
                     action=ListArgumentAction,
                     type=arg_type_handler,
                 )
@@ -677,7 +683,7 @@ class OpenAPIOperation:
                 if arg.datatype == "string" and arg.format == "password":
                     # special case - password input
                     parser.add_argument(
-                        "--" + arg.path,
+                        "--" + arg_path_unescaped,
                         nargs="?",
                         action=PasswordPromptAction,
                     )
@@ -687,15 +693,17 @@ class OpenAPIOperation:
                     "ssl-key",
                 ):
                     parser.add_argument(
-                        "--" + arg.path,
-                        metavar=arg.name,
+                        "--" + arg_path_unescaped,
+                        dest=arg.path,
+                        metavar=arg_name_unescaped,
                         action=OptionalFromFileAction,
                         type=arg_type_handler,
                     )
                 else:
                     parser.add_argument(
-                        "--" + arg.path,
-                        metavar=arg.name,
+                        "--" + arg_path_unescaped,
+                        dest=arg.path,
+                        metavar=arg_name_unescaped,
                         type=arg_type_handler,
                     )
 

--- a/linodecli/baked/request.py
+++ b/linodecli/baked/request.py
@@ -9,7 +9,10 @@ from openapi3.schemas import Schema
 
 from linodecli.baked.parsing import simplify_description
 from linodecli.baked.response import OpenAPIResponse
-from linodecli.baked.util import _aggregate_schema_properties
+from linodecli.baked.util import (
+    _aggregate_schema_properties,
+    escape_arg_segment,
+)
 
 
 class OpenAPIRequestArg:
@@ -152,6 +155,8 @@ def _parse_request_model(
         return args
 
     for k, v in properties.items():
+        k = escape_arg_segment(k)
+
         # Handle nested objects which aren't read-only and have properties
         if (
             v.type == "object"

--- a/linodecli/baked/util.py
+++ b/linodecli/baked/util.py
@@ -2,8 +2,9 @@
 Provides various utility functions for use in baking logic.
 """
 
+import re
 from collections import defaultdict
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from openapi3.schemas import Schema
 
@@ -51,3 +52,58 @@ def _aggregate_schema_properties(
         # We only want to mark fields that are required by ALL subschema as required
         set(key for key, count in required.items() if count == schema_count),
     )
+
+
+ESCAPED_PATH_DELIMITER_PATTERN = re.compile(r"(?<!\\)\.")
+
+
+def escape_arg_segment(segment: str) -> str:
+    """
+    Escapes periods in a segment by prefixing them with a backslash.
+
+    :param segment: The input string segment to escape.
+    :return: The escaped segment with periods replaced by '\\.'.
+    """
+    return segment.replace(".", "\\.")
+
+
+def unescape_arg_segment(segment: str) -> str:
+    """
+    Reverses the escaping of periods in a segment, turning '\\.' back into '.'.
+
+    :param segment: The input string segment to unescape.
+    :return: The unescaped segment with '\\.' replaced by '.'.
+    """
+    return segment.replace("\\.", ".")
+
+
+def get_path_segments(path: str) -> List[str]:
+    """
+    Splits a path string into segments using a delimiter pattern,
+    and unescapes any escaped delimiters in the resulting segments.
+
+    :param path: The full path string to split and unescape.
+    :return: A list of unescaped path segments.
+    """
+    return [
+        unescape_arg_segment(seg)
+        for seg in ESCAPED_PATH_DELIMITER_PATTERN.split(path)
+    ]
+
+
+def get_terminal_keys(data: Dict[str, Any]) -> List[str]:
+    """
+    Recursively retrieves all terminal (non-dict) keys from a nested dictionary.
+
+    :param data: The input dictionary, possibly nested.
+    :return: A list of all terminal keys (keys whose values are not dictionaries).
+    """
+    ret = []
+
+    for k, v in data.items():
+        if isinstance(v, dict):
+            ret.extend(get_terminal_keys(v))  # recurse into nested dicts
+        else:
+            ret.append(k)  # terminal key
+
+    return ret

--- a/linodecli/output/output_handler.py
+++ b/linodecli/output/output_handler.py
@@ -331,27 +331,30 @@ class OutputHandler:  # pylint: disable=too-few-public-methods,too-many-instance
         # Special handling for JSON headers.
         # We're only interested in the last part of the column name, unless the last
         # part is a dotted key. If the last part is a dotted key, include the entire dotted key.
-        parsedHeader = []
-        terminal_keys = get_terminal_keys(data[0])
-
-        for v in header:
-            parts = v.split(".")
-            if (
-                len(parts) >= 2
-                and ".".join([parts[-2], parts[-1]]) in terminal_keys
-            ):
-                parsedHeader.append(".".join([parts[-2], parts[-1]]))
-            else:
-                parsedHeader.append(parts[-1])
 
         content = []
         if len(data) and isinstance(data[0], dict):  # we got delimited json in
+            parsed_header = []
+            terminal_keys = get_terminal_keys(data[0])
+
+            for v in header:
+                parts = v.split(".")
+                if (
+                    len(parts) >= 2
+                    and ".".join([parts[-2], parts[-1]]) in terminal_keys
+                ):
+                    parsed_header.append(".".join([parts[-2], parts[-1]]))
+                else:
+                    parsed_header.append(parts[-1])
+
             # parse down to the value we display
             for row in data:
-                content.append(self._select_json_elements(parsedHeader, row))
+                content.append(self._select_json_elements(parsed_header, row))
         else:  # this is a list
+            header = [v.split(".")[-1] for v in header]
+
             for row in data:
-                content.append(dict(zip(parsedHeader, row)))
+                content.append(dict(zip(header, row)))
 
         print(
             json.dumps(


### PR DESCRIPTION
## 📝 Description

Fixed the following improperly nested fields in Postgres Database Creation:
```
pg_partman_bgw.interval
pg_partman_bgw.role
pg_stat_monitor.pgsm_enable_query_plan
pg_stat_monitor.pgsm_max_buckets
pg_stat_statements.track
```

## ✔️ How to Test
The following test steps require that the CLI is build against the latest API spec.

### Integration Testing
Run the integration test suite to ensure that this fix did not break unrelated functionality:
`make test-int`

### Manual Testing
Run the following command and ensure that the database is properly created and json is properly printed:
```
linode-cli databases postgresql-create \
  --engine postgresql/16 \
  --label my-postgres-db \
  --region us-east \
  --type g6-standard-2 \
  --allow_list 172.232.164.239 \
  --cluster_size 3 \
  --ssl_connection true \
  --engine_config.pg.autovacuum_analyze_scale_factor 1 \
  --engine_config.pg.autovacuum_analyze_threshold 2147483647 \
  --engine_config.pg.autovacuum_max_workers 20 \
  --engine_config.pg.autovacuum_naptime 86400 \
  --engine_config.pg.autovacuum_vacuum_cost_delay 100 \
  --engine_config.pg.autovacuum_vacuum_cost_limit 10000 \
  --engine_config.pg.autovacuum_vacuum_scale_factor 1 \
  --engine_config.pg.autovacuum_vacuum_threshold 2147483647 \
  --engine_config.pg.bgwriter_delay 200 \
  --engine_config.pg.bgwriter_flush_after 512 \
  --engine_config.pg.bgwriter_lru_maxpages 100 \
  --engine_config.pg.bgwriter_lru_multiplier 2.5 \
  --engine_config.pg.deadlock_timeout 1000 \
  --engine_config.pg.default_toast_compression lz4 \
  --engine_config.pg.idle_in_transaction_session_timeout 604800000 \
  --engine_config.pg.jit true \
  --engine_config.pg.max_files_per_process 1024 \
  --engine_config.pg.max_locks_per_transaction 1024 \
  --engine_config.pg.max_logical_replication_workers 64 \
  --engine_config.pg.max_parallel_workers 96 \
  --engine_config.pg.max_parallel_workers_per_gather 96 \
  --engine_config.pg.max_pred_locks_per_transaction 5120 \
  --engine_config.pg.max_replication_slots 64 \
  --engine_config.pg.max_slot_wal_keep_size 1000000 \
  --engine_config.pg.max_stack_depth 2097152 \
  --engine_config.pg.max_standby_archive_delay 1 \
  --engine_config.pg.max_standby_streaming_delay 10 \
  --engine_config.pg.max_wal_senders 20 \
  --engine_config.pg.max_worker_processes 96 \
  --engine_config.pg.password_encryption scram-sha-256 \
  --engine_config.pg.pg_partman_bgw.interval 3600 \
  --engine_config.pg.pg_partman_bgw.role pg_partman_bgw \
  --engine_config.pg.pg_stat_monitor.pgsm_enable_query_plan true \
  --engine_config.pg.pg_stat_monitor.pgsm_max_buckets 10 \
  --engine_config.pg.pg_stat_statements.track top \
  --engine_config.pg.temp_file_limit 5000000 \
  --engine_config.pg.timezone Europe/Helsinki \
  --engine_config.pg.track_activity_query_size 1024 \
  --engine_config.pg.track_commit_timestamp on \
  --engine_config.pg.track_functions none \
  --engine_config.pg.track_io_timing off \
  --engine_config.pg.wal_sender_timeout 60000 \
  --engine_config.pg.wal_writer_delay 200 \
  --engine_config.pg_stat_monitor_enable true \
  --engine_config.pglookout.max_failover_replication_time_lag 10 \
  --debug --json
```