### PR TITLE
feat: use generic cli args for get-kubeconfig plugin

### DIFF
--- a/linodecli/plugins/get-kubeconfig.py
+++ b/linodecli/plugins/get-kubeconfig.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import yaml
 
 from linodecli.exit_codes import ExitCodes
+from linodecli.plugins import inherit_plugin_args
 
 PLUGIN_BASE = "linode-cli get-kubeconfig"
 
@@ -22,8 +23,9 @@ def call(args, context):
     """
     The entrypoint for this plugin
     """
-    parser = argparse.ArgumentParser(PLUGIN_BASE, add_help=True)
-
+    parser = inherit_plugin_args(
+        argparse.ArgumentParser(PLUGIN_BASE, add_help=True)
+    )
     group = parser.add_mutually_exclusive_group()
 
     parser.add_argument(


### PR DESCRIPTION
## 📝 Description

When working with different accounts from the CLI, it is useful to set one specific account on-demand using the `--as-user` argument. The `get-kubeconfig` plugin did not pass such global CLI arguments through, making it necessary having to make an extra call with `set-user`, and switching back after.

## ✔️ How to Test

There was no extra unit test written for this, as all other plugins use the same functionality.

Manual testing can be performed by adding two accounts to the Linode CLI config where each account has at least one LKE cluster. 
Given that `account1` has `cluster1` and `account2` has `cluster2`, making a call such as `linode-cli get-kubeconfig --as-user account1 cluster1` and `linode-cli get-kubeconfig --as-user account2 cluster2` will download and add two contexts to the local `kubectl` configuration.

Without this change, the commands return `unrecognized arguments: --as-user account[1 or 2]`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**