### PR TITLE
Fix usage of `yaml.load` in getkubeconfig plugin

### DIFF
--- a/linodecli/plugins/get-kubeconfig.py
+++ b/linodecli/plugins/get-kubeconfig.py
@@ -130,7 +130,7 @@ def _get_kubeconfig_by_label(cluster_label, client):
 # Loads a yaml file
 def _load_config(filepath):
     with open(filepath, "r", encoding="utf-8") as file_descriptor:
-        data = yaml.load(file_descriptor, Loader=yaml.Loader)
+        data = yaml.safe_load(file_descriptor)
 
     if not data:
         print(f"Could not load file at {filepath}", file=sys.stderr)


### PR DESCRIPTION
## 📝 Description

Replace usage of `yaml.load` with `yaml.safe_load` in get-kubeconfig plugin.

## ✔️ How to Test

`make test-unit`