### PR TITLE
Add --raw-body argument for POST and PUT requests

### DIFF
--- a/linodecli/__init__.py
+++ b/linodecli/__init__.py
@@ -80,6 +80,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     cli.page = parsed.page
     cli.page_size = parsed.page_size
     cli.debug_request = parsed.debug
+    cli.raw_body = parsed.raw_body
 
     if parsed.as_user and not skip_config:
         cli.config.set_user(parsed.as_user)

--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -378,9 +378,8 @@ def _build_request_body(
     if ctx.raw_body is not None:
         if len(body_args) > 0:
             print(
-                "--raw-body cannot be specified with action arguments: {}".format(
-                    ", ".join(sorted(f"--{key}" for key, _ in body_args)),
-                ),
+                "--raw-body cannot be specified with action arguments: "
+                + ", ".join(sorted(f"--{key}" for key, _ in body_args)),
                 file=sys.stderr,
             )
             sys.exit(ExitCodes.ARGUMENT_ERROR)

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -81,6 +81,13 @@ def register_args(parser: ArgumentParser) -> ArgumentParser:
         help="The alias to set or remove.",
     )
 
+    parser.add_argument(
+        "--raw-body",
+        type=str,
+        help="The raw body to use for the request body. "
+        + "This can only be used if action-specific arguments are not specified.",
+    )
+
     # Register shared argument groups
     register_output_args_shared(parser)
     register_pagination_args_shared(parser)

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -85,7 +85,8 @@ def register_args(parser: ArgumentParser) -> ArgumentParser:
         "--raw-body",
         type=str,
         help="The raw body to use for the request body. "
-        + "This can only be used if action-specific arguments are not specified.",
+        + "This argument cannot be used if action-specific arguments are specified. "
+        + "Additionally, this argument can only be used with POST and PUT actions.",
     )
 
     # Register shared argument groups

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -84,7 +84,7 @@ def register_args(parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument(
         "--raw-body",
         type=str,
-        help="The raw body to use for the request body. "
+        help="The raw JSON to use as the request body of an action. "
         + "This argument cannot be used if action-specific arguments are specified. "
         + "Additionally, this argument can only be used with POST and PUT actions.",
     )

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -44,6 +44,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
         self.base_url = base_url
         self.spec_version = "None"
         self.suppress_warnings = False
+        self.raw_body = None
 
         self.output_handler = OutputHandler()
         self.config = CLIConfig(self.base_url, skip_config=skip_config)

--- a/tests/integration/cli/test_args.py
+++ b/tests/integration/cli/test_args.py
@@ -1,0 +1,85 @@
+import json
+
+from linodecli.exit_codes import ExitCodes
+from tests.integration.helpers import (
+    exec_failing_test_command,
+    exec_test_command,
+    get_random_region_with_caps,
+    get_random_text,
+)
+
+
+def test_arg_raw_body():
+    label = get_random_text(12)
+    region = get_random_region_with_caps(["VPCs"])
+
+    res = json.loads(
+        exec_test_command(
+            [
+                "linode-cli",
+                "vpcs",
+                "create",
+                "--json",
+                "--raw-body",
+                json.dumps(
+                    {
+                        "label": label,
+                        "region": region,
+                    }
+                ),
+            ],
+        )
+    )
+
+    exec_test_command(["linode-cli", "vpcs", "delete", str(res[0]["id"])])
+
+    assert res[0]["id"] > 0
+    assert res[0]["label"] == label
+    assert res[0]["region"] == region
+
+
+def test_arg_raw_body_conflict():
+    label = get_random_text(12)
+    region = get_random_region_with_caps(["VPCs"])
+
+    res = exec_failing_test_command(
+        [
+            "linode-cli",
+            "vpcs",
+            "create",
+            "--json",
+            "--label",
+            label,
+            "--region",
+            region,
+            "--raw-body",
+            json.dumps(
+                {
+                    "label": label,
+                    "region": region,
+                }
+            ),
+        ],
+        expected_code=ExitCodes.ARGUMENT_ERROR,
+    )
+
+    assert (
+        "--raw-body cannot be specified with action arguments: --label, --region"
+        in res
+    )
+
+
+def test_arg_raw_body_get():
+    res = exec_failing_test_command(
+        [
+            "linode-cli",
+            "vpcs",
+            "list",
+            "--json",
+            "--raw-body",
+            json.dumps({"label": "test"}),
+        ],
+        expected_code=ExitCodes.ARGUMENT_ERROR,
+    )
+
+    assert "--raw-body cannot be specified for actions with method get" in res

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -164,7 +164,7 @@ class TestAPIRequest:
             == result
         )
 
-    def test_build_request_body(self, mock_cli, create_operation):
+    def test_build_request_body_raw(self, mock_cli, create_operation):
         body = {"foo": "bar"}
 
         mock_cli.raw_body = json.dumps(body)
@@ -176,7 +176,24 @@ class TestAPIRequest:
         )
         assert json.loads(result) == body
 
-    def test_build_request_body_conflict(
+    def test_build_request_body_raw_with_defaults(
+        self, mock_cli, create_operation
+    ):
+        body = {"foo": "bar"}
+        mock_cli.raw_body = json.dumps(body)
+
+        mock_cli.defaults = True
+        mock_cli.config.get = lambda user, key, **kwargs: {"foo": "baz"}
+        create_operation.allowed_defaults = ["foo"]
+
+        result = api_request._build_request_body(
+            mock_cli,
+            create_operation,
+            SimpleNamespace(),
+        )
+        assert json.loads(result) == body
+
+    def test_build_request_body_raw_conflict(
         self, mock_cli, create_operation, capsys: CaptureFixture
     ):
         mock_cli.raw_body = json.dumps({"foo": "bar"})
@@ -194,7 +211,7 @@ class TestAPIRequest:
             in capsys.readouterr().err
         )
 
-    def test_build_request_body_get(
+    def test_build_request_body_raw_get(
         self, mock_cli, list_operation, capsys: CaptureFixture
     ):
         mock_cli.raw_body = json.dumps({"foo": "bar"})


### PR DESCRIPTION
## 📝 Description

This pull request adds a new `--raw-body` argument that can be used to manually specify the body used for a command's API request. This is useful when using fields that aren't yet documented in the OpenAPI specification, or to more easily use the CLI with programmatically generated request bodies. 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and run `make install`.

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make test-int
```

### Manual Testing

1. Run the following command to create a Linode using a raw request body:

```shell
linode-cli linodes create --raw-body '{"label": "test-linode", "region": "us-mia", "type": "g6-nanode-1"}'
```

2. Ensure the command runs successfully and the Linode is visible in Cloud Manager.