### PR TITLE
Fix integration tests

### DIFF
--- a/tests/integration/account/test_account.py
+++ b/tests/integration/account/test_account.py
@@ -86,20 +86,6 @@ def test_event_view(get_event_id):
     assert_headers_in_lines(headers, lines)
 
 
-def test_event_read(get_event_id):
-    event_id = get_event_id
-    process = exec_test_command(
-        [
-            "linode-cli",
-            "events",
-            "mark-read",
-            event_id,
-            "--text",
-            "--delimiter=,",
-        ]
-    )
-
-
 def test_event_seen(get_event_id):
     event_id = get_event_id
     process = exec_test_command(

--- a/tests/integration/events/test_events.py
+++ b/tests/integration/events/test_events.py
@@ -14,9 +14,6 @@ def test_print_events_usage_information():
     assert "linode-cli events [ACTION]" in output
 
     assert re.search(
-        "mark-read.*(Event Mark as Read|Mark an event as read)", output
-    )
-    assert re.search(
         "mark-seen.*(Event Mark as Seen|Mark an event as seen)", output
     )
     assert re.search("list.*(Events List|List events)", output)
@@ -68,34 +65,6 @@ def test_mark_event_seen():
     exec_test_command(
         BASE_CMDS["events"]
         + ["mark-seen", event_id, "--text", "--no-headers", "--delimiter", ","]
-    )
-
-    # view event
-    result = exec_test_command(
-        BASE_CMDS["events"]
-        + ["view", event_id, "--text", "--no-headers", "--delimiter", ","]
-    )
-    assert re.search("[0-9]+,.*,.*,[0-9]+-[0-9][0-9]-.*,.*,[a-z]+.*", result)
-
-
-@pytest.mark.smoke
-def test_mark_event_read():
-    event_id = exec_test_command(
-        [
-            "linode-cli",
-            "events",
-            "list",
-            "--format",
-            "id",
-            "--no-headers",
-            "--text",
-        ]
-    ).split()[0]
-
-    # mark event as read
-    exec_test_command(
-        BASE_CMDS["events"]
-        + ["mark-read", event_id, "--text", "--no-headers", "--delimiter", ","]
     )
 
     # view event

--- a/tests/integration/lke/test_lke_enterprise.py
+++ b/tests/integration/lke/test_lke_enterprise.py
@@ -138,7 +138,7 @@ def test_lke_tiered_versions_view():
         + [
             "tiered-version-view",
             "standard",
-            "1.31",
+            "1.33",
             "--json",
         ]
     )


### PR DESCRIPTION
## 📝 Description

Remove integration tests related to `mark-account-read`, which is deprecated. Also fixed old LKE version causing test to fail.

## ✔️ How to Test

`make test-int`