### PR TITLE
Adds integration tests for node balancer with UDP configuration

### DIFF
--- a/tests/integration/nodebalancers/fixtures.py
+++ b/tests/integration/nodebalancers/fixtures.py
@@ -165,3 +165,161 @@ def nodebalancer_with_default_conf(linode_cloud_firewall):
     res_arr = result.split(",")
     nodebalancer_id = res_arr[0]
     delete_target_id(target="nodebalancers", id=nodebalancer_id)
+
+
+@pytest.fixture(scope="module")
+def nodebalancer_with_udp_config_and_node(linode_cloud_firewall):
+    nodebalancer_id = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "create",
+            "--region",
+            "us-ord",
+            "--client_conn_throttle",
+            "20",
+            "--firewall_id",
+            linode_cloud_firewall,
+            "--text",
+            "--delimiter",
+            ",",
+            "--format",
+            "id",
+            "--no-headers",
+        ]
+    )
+    config_id = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "config-create",
+            nodebalancer_id,
+            "--port",
+            "80",
+            "--protocol",
+            "udp",
+            "--algorithm",
+            "roundrobin",
+            "--check_interval",
+            "90",
+            "--check_timeout",
+            "10",
+            "--check_attempts",
+            "3",
+            "--check_path",
+            "/test",
+            "--check_body",
+            "it works",
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+            "--format",
+            "id",
+        ]
+    )
+
+    linode_create = exec_test_command(
+        BASE_CMDS["linodes"]
+        + [
+            "create",
+            "--root_pass",
+            "aComplex@Password",
+            "--booted",
+            "true",
+            "--region",
+            "us-ord",
+            "--type",
+            "g6-nanode-1",
+            "--private_ip",
+            "true",
+            "--image",
+            DEFAULT_TEST_IMAGE,
+            "--firewall_id",
+            linode_cloud_firewall,
+            "--text",
+            "--delimiter",
+            ",",
+            "--format",
+            "id,ipv4",
+            "--no-header",
+            "--suppress-warnings",
+        ]
+    )
+    linode_arr = linode_create.split(",")
+    linode_id = linode_arr[0]
+    ip_arr = linode_arr[1].split(" ")
+    node_ip = ip_arr[1]
+    node_label = "defaultnode1"
+    node_id = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "node-create",
+            nodebalancer_id,
+            config_id,
+            "--address",
+            node_ip + ":80",
+            "--label",
+            node_label,
+            "--weight",
+            "100",
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+            "--format",
+            "id",
+        ]
+    )
+
+    yield nodebalancer_id, config_id, node_id, node_ip
+
+    delete_target_id(target="nodebalancers", id=nodebalancer_id)
+    delete_target_id(target="linodes", id=linode_id)
+
+
+@pytest.fixture(scope="module")
+def simple_nodebalancer_with_config(linode_cloud_firewall):
+    nodebalancer_id = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "create",
+            "--region",
+            "us-ord",
+            "--client_conn_throttle",
+            "20",
+            "--firewall_id",
+            linode_cloud_firewall,
+            "--text",
+            "--delimiter",
+            ",",
+            "--format",
+            "id",
+            "--no-headers",
+        ]
+    )
+    config_id = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "config-create",
+            nodebalancer_id,
+            "--port",
+            "81",
+            "--protocol",
+            "http",
+            "--algorithm",
+            "leastconn",
+            "--check_path",
+            "/test",
+            "--check_body",
+            "it works",
+            "--text",
+            "--no-headers",
+            "--delimiter",
+            ",",
+            "--format",
+            "id",
+        ]
+    )
+
+    yield nodebalancer_id, config_id
+
+    delete_target_id(target="nodebalancers", id=nodebalancer_id)

--- a/tests/integration/nodebalancers/test_node_balancers.py
+++ b/tests/integration/nodebalancers/test_node_balancers.py
@@ -12,6 +12,8 @@ from tests.integration.nodebalancers.fixtures import (  # noqa: F401
     linode_to_add,
     nodebalancer_w_config_and_node,
     nodebalancer_with_default_conf,
+    nodebalancer_with_udp_config_and_node,
+    simple_nodebalancer_with_config,
 )
 
 
@@ -337,6 +339,207 @@ def test_list_multiple_configuration_profile(nodebalancer_w_config_and_node):
     )
     assert re.search(
         "[0-9]+,83,http,roundrobin,none,True,recommended,,", result
+    )
+
+
+def test_update_node_balancer_udp_configuration(
+    simple_nodebalancer_with_config,
+):
+    nodebalancer_id = simple_nodebalancer_with_config[0]
+    config_id = simple_nodebalancer_with_config[1]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "config-update",
+            nodebalancer_id,
+            config_id,
+            "--port",
+            "80",
+            "--protocol",
+            "udp",
+            "--algorithm",
+            "roundrobin",
+            "--check_interval",
+            "80",
+            "--check_timeout",
+            "15",
+            "--check_attempts",
+            "2",
+            "--check_path",
+            "/testUpdate",
+            "--check_body",
+            "OK",
+            "--check_passive",
+            "False",
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert result == config_id + ",80,udp,roundrobin,none,False,none,,"
+
+
+def test_rebuild_node_balancer_udp_configuration(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "config-rebuild",
+            nodebalancer_id,
+            config_id,
+            "--port",
+            "80",
+            "--protocol",
+            "udp",
+            "--algorithm",
+            "ring_hash",
+            "--nodes.label",
+            "defaultnode1",
+            "--nodes.address",
+            nodebalancer_with_udp_config_and_node[3] + ":80",
+            "--nodes.weight",
+            "50",
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert result == config_id + ",80,udp,ring_hash,session,False,none,,"
+
+
+def test_list_node_balancer_configurations_with_udp_type(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "configs-list",
+            nodebalancer_id,
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert result == config_id + ",80,udp,roundrobin,session,False,none,,"
+
+
+def test_view_node_balancer_udp_configuration(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "config-view",
+            nodebalancer_id,
+            config_id,
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert result == config_id + ",80,udp,roundrobin,session,False,none,,"
+
+
+def test_update_node_for_node_balancer_udp_configuration(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+    node_id = nodebalancer_with_udp_config_and_node[2]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "node-update",
+            nodebalancer_id,
+            config_id,
+            node_id,
+            "--weight",
+            "30",
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert (
+        result
+        == node_id
+        + ",defaultnode1,"
+        + nodebalancer_with_udp_config_and_node[3]
+        + ":80,Unknown,30,none"
+    )
+
+
+def test_list_nodes_for_node_balancer_udp_configuration(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+    node_id = nodebalancer_with_udp_config_and_node[2]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "nodes-list",
+            nodebalancer_id,
+            config_id,
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert (
+        result
+        == node_id
+        + ",defaultnode1,"
+        + nodebalancer_with_udp_config_and_node[3]
+        + ":80,Unknown,100,none"
+    )
+
+
+def test_view_node_for_node_balancer_udp_configuration(
+    nodebalancer_with_udp_config_and_node,
+):
+    nodebalancer_id = nodebalancer_with_udp_config_and_node[0]
+    config_id = nodebalancer_with_udp_config_and_node[1]
+    node_id = nodebalancer_with_udp_config_and_node[2]
+
+    result = exec_test_command(
+        BASE_CMDS["nodebalancers"]
+        + [
+            "node-view",
+            nodebalancer_id,
+            config_id,
+            node_id,
+            "--delimiter",
+            ",",
+            "--text",
+            "--no-headers",
+        ]
+    )
+    assert (
+        result
+        == node_id
+        + ",defaultnode1,"
+        + nodebalancer_with_udp_config_and_node[3]
+        + ":80,Unknown,100,none"
     )
 
 


### PR DESCRIPTION
## 📝 Description

Add Integration test to NodeBalancer with UDP configuration
Test Against Devcloud - api.devcloud.linode.com

## ✔️ How to Test

make test-int TEST_CASE=test_update_node_balancer_udp_configuration
make test-int TEST_CASE=test_rebuild_node_balancer_udp_configuration
make test-int TEST_CASE=test_list_node_balancer_configurations_with_udp_type
make test-int TEST_CASE=test_view_node_balancer_udp_configuration
make test-int TEST_CASE=test_update_node_for_node_balancer_udp_configuration
make test-int TEST_CASE=test_list_nodes_for_node_balancer_udp_configuration
make test-int TEST_CASE=test_view_node_for_node_balancer_udp_configuration