### PR TITLE
Remove workaround and fix public interface testing by creating linodes to be offline

### DIFF
--- a/tests/integration/linodes/fixtures.py
+++ b/tests/integration/linodes/fixtures.py
@@ -321,12 +321,8 @@ def linode_interface_public(linode_cloud_firewall):
         interfaces='[{"public": {"ipv4": {"addresses": [{"primary": true}]}}, "default_route": {"ipv4": true, "ipv6": true }, "firewall_id":'
         + linode_cloud_firewall
         + "}]",
+        booted=False,
     )
-
-    wait_until(linode_id=linode_id, timeout=300, status="running")
-
-    # TODO: add support of creating a offline linode in `create_linode` then remove this workaround
-    exec_test_command(BASE_CMDS["linodes"] + ["shutdown", linode_id])
 
     wait_until(linode_id=linode_id, timeout=60, status="offline")
 

--- a/tests/integration/linodes/helpers.py
+++ b/tests/integration/linodes/helpers.py
@@ -62,6 +62,7 @@ def create_linode(
     disk_encryption=False,
     interface_generation: str = None,
     interfaces: str = None,
+    booted: bool = True,
 ):
     # Base command
     command = BASE_CMDS["linodes"] + [
@@ -78,6 +79,8 @@ def create_linode(
         firewall_id,
         "--disk_encryption",
         "enabled" if disk_encryption else "disabled",
+        "--booted",
+        str(booted).lower(),
     ]
 
     if interface_generation:


### PR DESCRIPTION
## 📝 Description

Set `booted=false` during creation, to avoid need of shutting down after creation, for fixing the tests.

## ✔️ How to Test

```bash
pytest tests/integration/linodes/test_linode_interfaces.py -k test_interface_update
```

```bash
pytest tests/integration/linodes/test_linode_interfaces.py -k test_interface_firewalls_list
```


```bash
pytest tests/integration/linodes/test_linode_interfaces.py -k test_interface_settings_update
```