### PR TITLE
Fixed `get_pool_nodesid` helper

### DIFF
--- a/tests/integration/lke/helpers.py
+++ b/tests/integration/lke/helpers.py
@@ -45,22 +45,20 @@ def get_node_pool_id(cluster_id):
 
 
 def get_pool_nodesid(cluster_id):
-    cluster_id
-    nodepool_id = exec_test_command(
+    response = exec_test_command(
         BASE_CMDS["lke"]
         + [
             "pools-list",
             cluster_id,
-            "--text",
-            "--no-headers",
-            "--format",
-            "nodes.id",
+            "--json",
         ]
-    ).splitlines()
+    )
 
-    first_id = nodepool_id[0]
+    nodepools = json.loads(response)
 
-    return first_id
+    first_node_id = nodepools[0]["nodes"][0]["id"]
+
+    return first_node_id
 
 
 def get_lke_enterprise_id():

--- a/tests/integration/lke/helpers.py
+++ b/tests/integration/lke/helpers.py
@@ -56,9 +56,7 @@ def get_pool_nodesid(cluster_id):
 
     nodepools = json.loads(response)
 
-    first_node_id = nodepools[0]["nodes"][0]["id"]
-
-    return first_node_id
+    return nodepools[0]["nodes"][0]["id"]
 
 
 def get_lke_enterprise_id():


### PR DESCRIPTION
## 📝 Description

`get_pool_nodesid` was improperly accessing data from `pools-list` causing an error in `test_view_node`

## ✔️ How to Test

`make test-int TEST_CASE=test_view_node`