### PR TITLE
Pass JSON value parameter as is to the API call

### DIFF
--- a/linodecli/api_request.py
+++ b/linodecli/api_request.py
@@ -20,6 +20,7 @@ from linodecli.helpers import API_CA_PATH, API_VERSION_OVERRIDE
 from .baked.operation import (
     ExplicitEmptyDictValue,
     ExplicitEmptyListValue,
+    ExplicitJsonValue,
     ExplicitNullValue,
     OpenAPIOperation,
 )
@@ -320,6 +321,10 @@ def _traverse_request_body(o: Any) -> Any:
 
             if isinstance(v, ExplicitNullValue):
                 result[k] = None
+                continue
+
+            if isinstance(v, ExplicitJsonValue):
+                result[k] = v.json_value
                 continue
 
             value = _traverse_request_body(v)

--- a/linodecli/baked/operation.py
+++ b/linodecli/baked/operation.py
@@ -10,9 +10,11 @@ import platform
 import re
 import sys
 from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
 from getpass import getpass
 from os import environ, path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import openapi3.paths
@@ -49,46 +51,12 @@ def parse_boolean(value: str) -> bool:
     raise argparse.ArgumentTypeError("Expected a boolean value")
 
 
-def parse_dict(
-    value: str,
-) -> Union[Dict[str, Any], "ExplicitEmptyDictValue", "ExplicitEmptyListValue"]:
-    """
-    A helper function to decode incoming JSON data as python dicts.  This is
-    intended to be passed to the `type=` kwarg for ArgumentParaser.add_argument.
-
-    :param value: The json string to be parsed into dict.
-    :type value: str
-
-    :returns: The dict value of the input.
-    :rtype: dict, ExplicitEmptyDictValue, or ExplicitEmptyListValue
-    """
-    if not isinstance(value, str):
-        raise argparse.ArgumentTypeError("Expected a JSON string")
-
-    try:
-        result = json.loads(value)
-    except Exception as e:
-        raise argparse.ArgumentTypeError("Expected a JSON string") from e
-
-    # This is necessary because empty dicts and lists are excluded from requests
-    # by default, but we still want to support user-defined empty dict
-    # strings. This is particularly helpful when updating LKE node pool
-    # labels and taints.
-    if isinstance(result, dict) and result == {}:
-        return ExplicitEmptyDictValue()
-
-    if isinstance(result, list) and result == []:
-        return ExplicitEmptyListValue()
-
-    return result
-
-
 TYPES = {
     "string": str,
     "integer": int,
     "boolean": parse_boolean,
     "array": list,
-    "object": parse_dict,
+    "object": lambda value: ExplicitJsonValue(json_value=json.loads(value)),
     "number": float,
 }
 
@@ -112,7 +80,16 @@ class ExplicitEmptyDictValue:
     """
 
 
-def wrap_parse_nullable_value(arg_type: str) -> TYPES:
+@dataclass
+class ExplicitJsonValue:
+    """
+    A special type used to explicitly pass raw JSON from user input as is.
+    """
+
+    json_value: Any
+
+
+def wrap_parse_nullable_value(arg_type: str) -> Callable[[Any], Any]:
     """
     A helper function to parse `null` as None for nullable CLI args.
     This is intended to be called and passed to the `type=` kwarg for ArgumentParser.add_argument.


### PR DESCRIPTION
## 📝 Description

Previously the value of a JSON parameter passed in by the user had to go through `_traverse_request_body` function to have null or empty list/dict values remove. We did have a way to allow explicit empty dict/list but that won't work if the empty dict/list is nested in the JSON object.

Here is an example:
```bash
linode-cli linodes create \
  --image 'linode/ubuntu24.04' \
  --interface_generation linode \
  --interfaces '[{"firewall_id":123456,"public":{}}]' \
  --private_ip false \
  --region us-mia \
  --type g6-nanode-1 \
  --label test-cli-create-linode-public \
  --root_pass 'this-is-an-unsafe-password' \
  --disk_encryption enabled --debug
```

The JSON value parameter `interfaces` with user input JSON string `'[{"firewall_id":123456,"public":{}}]'` would be translated into an invalid API call request body attribute, which had `{}` removed:

```json
{
    "interfaces": [{"firewall_id": 2431805}]
}
```
(irrelevant attributes in the body are ignored)

This change will let the CLI to pass whatever user input as-is into the request body to resolve this issue.

This is a potential breaking change because if user passed in some JSON like `{"a": {}, b: {"key": "value"}}` and expected key `a` would be dropped, this change will break their code. But I believe this change is necessary to make CLI behaviors correct and there isn't another easy way to fix the bug.

## ✔️ How to Test
```bash
make install && linode-cli linodes create \
  --image 'linode/ubuntu24.04' \
  --interface_generation linode \
  --interfaces '[{"firewall_id":1629606,"public":{}}]' \
  --private_ip false \
  --region us-ord \
  --type g6-nanode-1 \
  --label test-cli-create-linode-public \
  --root_pass 'this-is-an-unsafe-password' \
  --disk_encryption enabled --debug
```