### PR TITLE
Fix minor grammar error

### DIFF
--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -364,7 +364,7 @@ class CLIConfig:
             if _check_browsers() and not self.configure_with_pat:
                 print(
                     "The CLI will use its web-based authentication to log you in.\n"
-                    "If you prefer to supply a Personal Access Token,"
+                    "If you prefer to supply a Personal Access Token, "
                     "use `linode-cli configure --token`."
                 )
                 input(


### PR DESCRIPTION
When the text is outputted to terminal, there's no space between the words. Based on other strings, it seems like the convention is to add the space to the end of a string.