### PR TITLE
Adding external plugin for ACLP-MR service

### DIFF
--- a/linodecli/plugins/aclp_mr.py
+++ b/linodecli/plugins/aclp_mr.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from linodecli.help_formatter import SortingHelpFormatter
+import requests
+from linodecli.helpers import register_debug_arg
+import json
+import sys
+
+PLUGIN_BASE = "linode-cli aclp_mr"
+MANDATORY_HEADER = ["Authorization"]
+MANDATORY_DATA = ["metrics","time_granularity"]
+
+def get_metadata_parser():
+    """
+    Builds argparser for Metadata plug-in
+    """
+    parser = ArgumentParser(
+        PLUGIN_BASE, add_help=False, formatter_class=SortingHelpFormatter, description="Python CLI to make HTTP GET requests to ACLP Metric Read Service"
+    )
+
+    register_debug_arg(parser)
+
+    parser.add_argument("--url", "-u", required=True, help="URL to send GET request to")
+    parser.add_argument(
+        "--header", "-H",
+        action="append",
+        required=True,
+        help="Add custom headers (format: Key:Value)",
+        default=[]
+    )
+
+    parser.add_argument(
+        "--cacert", "-c",
+        type=str,
+        help="Add ca certificate to validate server",
+        default=False
+    )
+
+    parser.add_argument(
+        "--data", "-d",
+        type=json.loads, 
+        required=True,
+        help="payload for MR requests"
+    )
+
+    parser.add_argument(
+        "--timeout", "-t",
+        type=int,
+        default=10, 
+        help="Request timeout in seconds (default: 10)"
+    )
+
+    return parser
+
+def header_parser(args):
+    headers = {}
+    print(args.header)
+    for h in args.header:
+        if ":" in h:
+            key, value = h.split(":", 1)
+            headers[key.strip()] = value.strip()
+
+    
+    return headers
+
+def data_parser(args):
+    return args.data
+
+def call(args, context):
+    """
+    The entrypoint for this plugin
+    """
+    parser = get_metadata_parser()
+    parsed, args = parser.parse_known_args(args)
+
+    # parse headers
+    headers = header_parser(parsed)
+    data = data_parser(parsed)
+    print(data)
+
+    try:
+        response = requests.post(parsed.url, headers=headers, json=data, timeout=parsed.timeout, verify=parsed.cacert)
+        #for k, v in response.headers.items():
+        #    print(f"  {k}: {v}")
+
+        print(response.text)
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+

--- a/linodecli/plugins/monitor-metrics-get.py
+++ b/linodecli/plugins/monitor-metrics-get.py
@@ -6,7 +6,7 @@ from linodecli.helpers import register_debug_arg
 import json
 import sys
 
-PLUGIN_BASE = "linode-cli aclp_mr"
+PLUGIN_BASE = "linode-cli monitor-metrics-get"
 MANDATORY_HEADER = ["Authorization"]
 MANDATORY_DATA = ["metrics","time_granularity"]
 
@@ -20,7 +20,7 @@ def get_metadata_parser():
 
     register_debug_arg(parser)
 
-    parser.add_argument("--url", "-u", required=True, help="URL to send GET request to")
+    parser.add_argument("--url", "-u", required=True, help="URL to request")
     parser.add_argument(
         "--header", "-H",
         action="append",
@@ -72,7 +72,7 @@ def call(args, context):
     """
     parser = get_metadata_parser()
     parsed, args = parser.parse_known_args(args)
-
+  
     # parse headers
     headers = header_parser(parsed)
     data = data_parser(parsed)

--- a/linodecli/plugins/monitor-metrics-get.py
+++ b/linodecli/plugins/monitor-metrics-get.py
@@ -7,8 +7,6 @@ import json
 import sys
 
 PLUGIN_BASE = "linode-cli monitor-metrics-get"
-MANDATORY_HEADER = ["Authorization"]
-MANDATORY_DATA = ["metrics","time_granularity"]
 
 def get_metadata_parser():
     """
@@ -25,7 +23,7 @@ def get_metadata_parser():
         "--header", "-H",
         action="append",
         required=True,
-        help="Add custom headers (format: Key:Value)",
+        help="Add custom headers (format: Key: Value)",
         default=[]
     )
 
@@ -54,7 +52,8 @@ def get_metadata_parser():
 
 def header_parser(args):
     headers = {}
-    print(args.header)
+    if hasattr(args, "debug") and args.debug:
+        print(f"[DEBUG] Headers argument: {args.header}")
     for h in args.header:
         if ":" in h:
             key, value = h.split(":", 1)
@@ -80,8 +79,6 @@ def call(args, context):
 
     try:
         response = requests.post(parsed.url, headers=headers, json=data, timeout=parsed.timeout, verify=parsed.cacert)
-        #for k, v in response.headers.items():
-        #    print(f"  {k}: {v}")
 
         print(response.text)
 


### PR DESCRIPTION
## 📝 Description
This is linode CLI external plugin for ACLP-MR services. Here is how this requests going to looks like

**Sample Command**
linode-cli monitor-metrics-get --url 'https://mr-devcloud.cloud-observability-dev.akadns.net/v2beta/monitor/services/firewall/metrics' \
--header 'Authorization: \<redacted\>' \
--header 'Authentication-type: jwe' \
--header 'Pragma: akamai-x-get-extracted-values' \
--header 'Userid: 10001' \
--header 'Content-Type: application/json' \
--data  '{"entity_ids":[1001], "relative_time_duration":{"unit":"min","value":60}, "metrics":[{"aggregate_function":"sum","name":"fw_ingress_bytes_accepted"}],"filters": [],
 "associated_entity_region": "us-east", "time_granularity": {"value": 1, "unit": "days"}}'
['Authorization: Bearer \<redacted\>', 'Authentication-type: jwe', 'Pragma: akamai-x-get-extracted-values', 'Userid: 10001', 'Content-Type: application/json']
{'entity_ids': [1001], 'relative_time_duration': {'unit': 'min', 'value': 60}, 'metrics': [{'aggregate_function': 'sum', 'name': 'fw_ingress_bytes_accepted'}], 'filters': [], 'associated_entity_region': 'us-east', 'time_granularity': {'value': 1, 'unit': 'days'}}


**Response**
{
  "data": {
    "result": [],
    "resultType": "matrix"
  },
  "isPartial": false,
  "stats": {
    "executionTimeMsec": 1,
    "seriesFetched": "0"
  },
  "status": "success"
}

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**