### PR TITLE
Fix various integration test issues

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -215,8 +215,8 @@ def create_vpc_w_subnet():
                 vpc_label,
                 "--region",
                 region,
-                "--ipv6.range",
-                "auto",
+                # "--ipv6.range",    TODO: Uncomment after VPC Dual Stack is ready to ship
+                # "auto",
                 "--subnets.ipv4",
                 "10.0.0.0/24",
                 "--subnets.label",

--- a/tests/integration/database/test_database_engine_config.py
+++ b/tests/integration/database/test_database_engine_config.py
@@ -497,7 +497,7 @@ def test_mysql_engine_config_view():
     binlog_retention = mysql_config[0]["binlog_retention_period"]
     assert binlog_retention["type"] == "integer"
     assert binlog_retention["minimum"] == 600
-    assert binlog_retention["maximum"] == 604800
+    assert binlog_retention["maximum"] == 9007199254740991
     assert binlog_retention["requires_restart"] is False
 
     mysql_settings = mysql_config[0]["mysql"]

--- a/tests/integration/monitor/test_alerts.py
+++ b/tests/integration/monitor/test_alerts.py
@@ -104,7 +104,7 @@ def test_list_alert_definitions_for_service_type(get_service_type):
     output = exec_test_command(
         BASE_CMDS["alerts"]
         + [
-            "service-definition-view",
+            "service-definitions-list",
             service_type,
             "--text",
             "--delimiter=,",

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -34,8 +34,8 @@ def test_vpc_wo_subnet():
             label,
             "--region",
             region,
-            "--ipv6.range",
-            "auto",
+            # "--ipv6.range",    TODO: Uncomment after VPC Dual Stack is ready to ship
+            # "auto",
             "--no-headers",
             "--text",
             "--format=id",

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -228,7 +228,9 @@ def test_fails_to_update_vpc_subenet_w_invalid_label(test_vpc_w_subnet):
     assert "Label must include only ASCII" in res
 
 
-@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_vpc_with_ipv6_auto():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-vpc"
@@ -259,7 +261,9 @@ def test_create_vpc_with_ipv6_auto():
 
 
 @pytest.mark.parametrize("prefix_len", ["52"])
-@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + f"-vpc{prefix_len}"
@@ -287,7 +291,9 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     assert ipv6_range.endswith(f"/{prefix_len}")
 
 
-@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_subnet_with_ipv6_auto(test_vpc_wo_subnet):
     vpc_id = test_vpc_wo_subnet
     subnet_label = get_random_text(5) + "-ipv6subnet"
@@ -324,7 +330,9 @@ def test_create_subnet_with_ipv6_auto(test_vpc_wo_subnet):
     assert "/" in ipv6_range, f"Unexpected IPv6 CIDR format: {ipv6_range}"
 
 
-@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_fails_to_create_vpc_with_invalid_ipv6_range():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-invalidvpc"
@@ -360,7 +368,9 @@ def test_list_vpc_ip_address():
         assert header in lines[0]
 
 
-@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_list_vpc_ipv6s_address():
 
     res = exec_test_command(

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -15,6 +15,10 @@ from tests.integration.helpers import (
 BASE_CMD = ["linode-cli", "vpcs"]
 
 
+# TODO: Remove this variable and @pytest.mark.skipif once VPC Dual Stack is ready to ship
+disable_vpc_dual_stack_tests = True
+
+
 def test_list_vpcs(test_vpc_wo_subnet):
     vpc_id = test_vpc_wo_subnet
     res = exec_test_command(BASE_CMDS["vpcs"] + ["ls", "--text"])
@@ -224,6 +228,7 @@ def test_fails_to_update_vpc_subenet_w_invalid_label(test_vpc_w_subnet):
     assert "Label must include only ASCII" in res
 
 
+@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
 def test_create_vpc_with_ipv6_auto():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-vpc"
@@ -254,6 +259,7 @@ def test_create_vpc_with_ipv6_auto():
 
 
 @pytest.mark.parametrize("prefix_len", ["52"])
+@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
 def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + f"-vpc{prefix_len}"
@@ -281,6 +287,7 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     assert ipv6_range.endswith(f"/{prefix_len}")
 
 
+@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
 def test_create_subnet_with_ipv6_auto(test_vpc_wo_subnet):
     vpc_id = test_vpc_wo_subnet
     subnet_label = get_random_text(5) + "-ipv6subnet"
@@ -317,6 +324,7 @@ def test_create_subnet_with_ipv6_auto(test_vpc_wo_subnet):
     assert "/" in ipv6_range, f"Unexpected IPv6 CIDR format: {ipv6_range}"
 
 
+@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
 def test_fails_to_create_vpc_with_invalid_ipv6_range():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-invalidvpc"
@@ -352,6 +360,7 @@ def test_list_vpc_ip_address():
         assert header in lines[0]
 
 
+@pytest.mark.skipif(disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled")
 def test_list_vpc_ipv6s_address():
 
     res = exec_test_command(


### PR DESCRIPTION
## 📝 Description

Fixes integration tests that were failing.

## ✔️ How to Test

`make test-int TEST_CASE=vpc`
`make test-int TEST_CASE=test_list_alert_definitions_for_service_type`
`make test-int TEST_CASE=test_mysql_engine_config_view`