### PR TITLE
Point to linode-api-openapi repo instead of linode-api-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Visit the [Wiki](../../wiki/Installation) for more information.
 
 ## Contributing
 
-This CLI is generated from the [OpenAPI specification for Linode's API](https://github.com/linode/linode-api-docs).  As
+This CLI is generated from the [OpenAPI specification for Linode's API](https://github.com/linode/linode-api-openapi).  As
 such, many changes are made directly to the spec.
 
 Please follow the [Contributing Guidelines](https://github.com/linode/linode-cli/blob/main/CONTRIBUTING.md) when making a contribution.

--- a/linodecli/arg_helpers.py
+++ b/linodecli/arg_helpers.py
@@ -4,6 +4,7 @@ Argument parser for the linode CLI.
 This module defines argument parsing, plugin registration, and plugin removal
 functionalities for the Linode CLI.
 """
+
 import sys
 from argparse import ArgumentParser
 from configparser import ConfigParser

--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -286,7 +286,7 @@ class CLI:  # pylint: disable=too-many-instance-attributes
         """
         return (
             f"linode-cli/{self.version} "
-            f"linode-api-docs/{self.spec_version} "
+            f"linode-api-openapi/{self.spec_version} "
             f"python/{version_info[0]}.{version_info[1]}.{version_info[2]}"
         )
 

--- a/linodecli/completion.py
+++ b/linodecli/completion.py
@@ -2,6 +2,7 @@
 """
 Contains any code relevant to generating/updating shell completions for linode-cli
 """
+
 from string import Template
 
 from openapi3 import OpenAPI
@@ -93,12 +94,10 @@ complete -F _linode_cli linode
 complete -F _linode_cli lin"""
     )
 
-    command_template = Template(
-        """$command)
+    command_template = Template("""$command)
         COMPREPLY=( $(compgen -W "$actions --help" -- ${cur}) )
         return 0
-        ;;"""
-    )
+        ;;""")
 
     command_blocks = [
         command_template.safe_substitute(

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -214,13 +214,11 @@ def _get_token_terminal(base_url: str) -> Tuple[str, str]:
     :returns: A tuple containing the user's username and token.
     :rtype: Tuple[str, str]
     """
-    print(
-        f"""
+    print(f"""
 First, we need a Personal Access Token.  To get one, please visit
 {TOKEN_GENERATION_URL} and click
 "Create a Personal Access Token".  The CLI needs access to everything
-on your account to work correctly."""
-    )
+on your account to work correctly.""")
 
     while True:
         token = input("Personal Access Token: ")
@@ -329,15 +327,13 @@ def _handle_oauth_callback() -> str:
     # figure out the URL to direct the user to and print out the prompt
     # pylint: disable-next=line-too-long
     url = f"https://login.linode.com/oauth/authorize?client_id={OAUTH_CLIENT_ID}&response_type=token&scopes=*&redirect_uri=http://localhost:{serv.server_address[1]}"
-    print(
-        f"""A browser should open directing you to this URL to authenticate:
+    print(f"""A browser should open directing you to this URL to authenticate:
 
 {url}
 
 If you are not automatically directed there, please copy/paste the link into your browser
 to continue..
-"""
-    )
+""")
 
     webbrowser.open(url)
 

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -97,11 +97,9 @@ def _check_browsers() -> bool:
 
     # pylint: disable-next=protected-access
     if not KNOWN_GOOD_BROWSERS.intersection(webbrowser._tryorder):
-        print(
-            """
+        print("""
 This tool defaults to web-based authentication,
-however no known-working browsers were found."""
-        )
+however no known-working browsers were found.""")
         while True:
             r = input("Try it anyway? [y/N]: ")
             if r.lower() in "yn ":

--- a/linodecli/plugins/obj/__init__.py
+++ b/linodecli/plugins/obj/__init__.py
@@ -2,6 +2,7 @@
 """
 CLI Plugin for handling OBJ
 """
+
 import getpass
 import os
 import re

--- a/resolve_spec_url
+++ b/resolve_spec_url
@@ -7,7 +7,7 @@ import sys
 
 import requests
 
-LINODE_DOCS_REPO = "linode/linode-api-docs"
+LINODE_DOCS_REPO = "linode/linode-api-openapi"
 
 
 def get_latest_tag():

--- a/tests/unit/test_api_request.py
+++ b/tests/unit/test_api_request.py
@@ -2,6 +2,7 @@
 """
 Unit tests for linodecli.api_request
 """
+
 import contextlib
 import io
 import json

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -79,7 +79,7 @@ class TestCLI:
 
     def test_user_agent(self, mock_cli: CLI):
         assert re.compile(
-            r"linode-cli/[0-9]+\.[0-9]+\.[0-9]+ linode-api-docs/[0-9]+\.[0-9]+\.[0-9]+ python/[0-9]+\.[0-9]+\.[0-9]+"
+            r"linode-cli/[0-9]+\.[0-9]+\.[0-9]+ linode-api-openapi/[0-9]+\.[0-9]+\.[0-9]+ python/[0-9]+\.[0-9]+\.[0-9]+"
         ).match(mock_cli.user_agent)
 
     def test_load_openapi_spec_json(self):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,6 +2,7 @@
 """
 Unit tests for linodecli.configuration
 """
+
 import argparse
 import contextlib
 import io

--- a/wiki/development/Development - Overview.md
+++ b/wiki/development/Development - Overview.md
@@ -3,7 +3,7 @@ The following section outlines the core functions of the Linode CLI.
 ## OpenAPI Specification Parsing
 
 Most Linode CLI commands (excluding [plugin commands](https://github.com/linode/linode-cli/tree/dev/linodecli/plugins)) 
-are generated dynamically at build-time from the [Linode OpenAPI Specification](https://github.com/linode/linode-api-docs),
+are generated dynamically at build-time from the [Linode OpenAPI Specification](https://github.com/linode/linode-api-openapi),
 which is also used to generate the [official Linode API documentation](https://www.linode.com/docs/api/). 
 
 Each OpenAPI spec endpoint method is parsed into an `OpenAPIOperation` object. 

--- a/wiki/development/Development - Setup.md
+++ b/wiki/development/Development - Setup.md
@@ -73,7 +73,7 @@ This can be achieved using the `SPEC` Makefile argument, for example:
 
 ```bash
 # Download the OpenAPI spec
-curl -o openapi.yaml https://raw.githubusercontent.com/linode/linode-api-docs/development/openapi.yaml
+curl -o openapi.json https://raw.githubusercontent.com/linode/linode-api-openapi/main/openapi.json
 
 # Many arbitrary changes to the spec
 


### PR DESCRIPTION
## 📝 Description

Change the CLI from pointing to the [linode-api-docs](https://github.com/linode/linode-api-docs) repository to the new [linode-api-openapi](https://github.com/linode/linode-api-openapi) repository for fetching the Open API spec file.

> **_NOTE:_**: Future Open API spec releases will be titled by date rather than matching the API version, i.e. `2026-01-23` instead of `Release 4.215.0-patch.1`, so we will need to reference them accordingly in future release notes.

## ✔️ How to Test

Pull down this PR locally and run `make install`. Ensure that the project builds and installs properly.