### PR TITLE
Parse OBJ endpoint domain dynamically

### DIFF
--- a/linodecli/plugins/obj/config.py
+++ b/linodecli/plugins/obj/config.py
@@ -2,9 +2,9 @@
 The config of the object storage plugin.
 """
 
-import shutil
 import os
 import re
+import shutil
 
 ENV_ACCESS_KEY_NAME = "LINODE_CLI_OBJ_ACCESS_KEY"
 ENV_SECRET_KEY_NAME = "LINODE_CLI_OBJ_SECRET_KEY"

--- a/linodecli/plugins/obj/config.py
+++ b/linodecli/plugins/obj/config.py
@@ -3,12 +3,24 @@ The config of the object storage plugin.
 """
 
 import shutil
+import os
+import re
 
 ENV_ACCESS_KEY_NAME = "LINODE_CLI_OBJ_ACCESS_KEY"
 ENV_SECRET_KEY_NAME = "LINODE_CLI_OBJ_SECRET_KEY"
-# replace {} with the cluster name
-BASE_URL_TEMPLATE = "https://{}.linodeobjects.com"
-BASE_WEBSITE_TEMPLATE = "{bucket}.website-{cluster}.linodeobjects.com"
+
+API_HOST = os.getenv("LINODE_CLI_API_HOST", "")
+
+match = re.match(r"api\.([^.]+)\.linode\.com", API_HOST)
+
+OBJ_DOMAIN = (
+    "linodeobjects.com"
+    if not match or match.group(1) == "linode"
+    else f"{match.group(1)}.linodeobjects.com"
+)
+
+BASE_URL_TEMPLATE = f"https://{{}}.{OBJ_DOMAIN}"
+BASE_WEBSITE_TEMPLATE = f"{{bucket}}.website-{{cluster}}.{OBJ_DOMAIN}"
 
 # for all date output
 DATE_FORMAT = "%Y-%m-%d %H:%M"

--- a/linodecli/plugins/obj/config.py
+++ b/linodecli/plugins/obj/config.py
@@ -11,13 +11,12 @@ ENV_SECRET_KEY_NAME = "LINODE_CLI_OBJ_SECRET_KEY"
 
 API_HOST = os.getenv("LINODE_CLI_API_HOST", "")
 
-match = re.match(r"api\.([^.]+)\.linode\.com", API_HOST)
+OBJ_DOMAIN = "linodeobjects.com"
 
-OBJ_DOMAIN = (
-    "linodeobjects.com"
-    if not match or match.group(1) == "linode"
-    else f"{match.group(1)}.linodeobjects.com"
-)
+if API_HOST:
+    match = re.match(r"api\.([^.]+)\.linode\.com", API_HOST)
+    if match:
+        OBJ_DOMAIN = f"{match.group(1)}.linodeobjects.com"
 
 BASE_URL_TEMPLATE = f"https://{{}}.{OBJ_DOMAIN}"
 BASE_WEBSITE_TEMPLATE = f"{{bucket}}.website-{{cluster}}.{OBJ_DOMAIN}"


### PR DESCRIPTION
## 📝 Description

Enables using OBJ plugin with non-production environments by resolving OBJ endpoints dynamically from the `LINODE_CLI_API_HOST` environment variable, which configures the environment that the CLI is pointing at.

## ✔️ How to Test

Pointing at a non-production environment (i.e. DevCloud), attempt to run various OBJ plugin CLI commands
