### PR TITLE
Align GHA workflows in the scope of report uploads

### DIFF
--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -126,7 +126,7 @@ jobs:
           LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
 
       - name: Upload Test Report as Artifact
-        if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: test-report-file
@@ -231,7 +231,7 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() && github.repository == 'linode/linode-cli' # Run even if integration tests fail and only on main repository
+    if: always() && github.repository == 'linode/linode-cli' && github.event_name == 'push' # Run even if integration tests fail and only on main repository and push event
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 
@@ -257,7 +257,6 @@ jobs:
 
       - name: Set release version env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
 
       - name: Add variables and upload test results
         if: always()

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -126,7 +126,7 @@ jobs:
           LINODE_CLI_TOKEN: ${{ env.LINODE_CLI_TOKEN }}
 
       - name: Upload Test Report as Artifact
-        if: always()
+        if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
         uses: actions/upload-artifact@v6
         with:
           name: test-report-file

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -40,6 +40,14 @@ on:
         options:
           - 'true'
           - 'false'
+      test_report_upload:
+        description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
   push:
     branches:
@@ -231,7 +239,8 @@ jobs:
   process-upload-report:
     runs-on: ubuntu-latest
     needs: [integration_tests]
-    if: always() && github.repository == 'linode/linode-cli' && github.event_name == 'push' # Run even if integration tests fail and only on main repository and push event
+    # Run even if integration tests fail on main repository AND (push event OR (manually triggered and test_report_upload is true))
+    if: always() && github.repository == 'linode/linode-cli' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -42,13 +42,9 @@ on:
           - 'false'
       test_report_upload:
         description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
+        type: boolean
         required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
-
+        default: false
   push:
     branches:
       - main
@@ -240,7 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration_tests]
     # Run even if integration tests fail on main repository AND (push event OR (manually triggered and test_report_upload is true))
-    if: always() && github.repository == 'linode/linode-cli' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))
+    if: always() && github.repository == 'linode/linode-cli' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload))
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 

--- a/.github/workflows/e2e-suite.yml
+++ b/.github/workflows/e2e-suite.yml
@@ -42,9 +42,13 @@ on:
           - 'false'
       test_report_upload:
         description: 'Indicates whether to upload the test report to object storage. Defaults to "false"'
-        type: boolean
         required: false
-        default: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
   push:
     branches:
       - main
@@ -236,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration_tests]
     # Run even if integration tests fail on main repository AND (push event OR (manually triggered and test_report_upload is true))
-    if: always() && github.repository == 'linode/linode-cli' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload))
+    if: always() && github.repository == 'linode/linode-cli' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.test_report_upload == 'true'))
     outputs:
       summary: ${{ steps.set-test-summary.outputs.summary }}
 


### PR DESCRIPTION
## 📝 Description

GHA workflows upload test results to TOD on push, PR and manual (workflow_dispatch) runs. PR covers aligning integration test workflows to upload results automatically on push/PR and on demand for manual runs.

https://track.akamai.com/jira/browse/TPT-4190

## ✔️ How to Test

Manual run of the workflow should not upload test results to TOD by default.
