### PR TITLE
Updated VPC error message in tests

### DIFF
--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -199,7 +199,7 @@ def test_fails_to_create_vpc_subnet_w_invalid_label(test_vpc_wo_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
-def test_fails_to_update_vpc_subenet_w_invalid_label(test_vpc_w_subnet):
+def test_fails_to_update_vpc_subnet_w_invalid_label(test_vpc_w_subnet):
     vpc_id = test_vpc_w_subnet
 
     invalid_label = "invalid_label"

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -147,7 +147,7 @@ def test_fails_to_create_vpc_invalid_label():
     )
 
     assert "Request failed: 400" in res
-    assert "Label must include only ASCII" in res
+    assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
 def test_fails_to_create_vpc_duplicate_label(test_vpc_wo_subnet):
@@ -175,7 +175,7 @@ def test_fails_to_update_vpc_invalid_label(test_vpc_wo_subnet):
     )
 
     assert "Request failed: 400" in res
-    assert "Label must include only ASCII" in res
+    assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
 def test_fails_to_create_vpc_subnet_w_invalid_label(test_vpc_wo_subnet):
@@ -196,7 +196,7 @@ def test_fails_to_create_vpc_subnet_w_invalid_label(test_vpc_wo_subnet):
     )
 
     assert "Request failed: 400" in res
-    assert "Label must include only ASCII" in res
+    assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
 def test_fails_to_update_vpc_subenet_w_invalid_label(test_vpc_w_subnet):
@@ -225,7 +225,7 @@ def test_fails_to_update_vpc_subenet_w_invalid_label(test_vpc_w_subnet):
     )
 
     assert "Request failed: 400" in res
-    assert "Label must include only ASCII" in res
+    assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## 📝 Description

Fixes failing VPC integration tests that were failing due to an error message that changed in the API.

## ✔️ How to Test

`make test-int TEST_SUITE=vpc`
