### PR TITLE
Update README install instructions to use pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ pipx install linode-cli
 To upgrade:
 ```
 pipx upgrade linode-cli
+```
 We recommend using `pipx` to install `linode-cli`, as it installs Python CLI tools in isolated environments and avoids conflicts with system-managed Python packages (PEP 668).
 Visit the [Wiki](../../wiki/Installation) for more information.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To upgrade:
 ```
 pipx upgrade linode-cli
 ```
+```
 We recommend using `pipx` to install `linode-cli`, as it installs Python CLI tools in isolated environments and avoids conflicts with system-managed Python packages (PEP 668).
 Visit the [Wiki](../../wiki/Installation) for more information.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Visit the [Wiki](../../wiki) for more information.
 
 Install via PyPI:
 ```bash
-pip3 install linode-cli
+pipx install linode-cli
 ```
-
+To upgrade:
+```
+pipx upgrade linode-cli
+We recommend using `pipx` to install `linode-cli`, as it installs Python CLI tools in isolated environments and avoids conflicts with system-managed Python packages (PEP 668).
 Visit the [Wiki](../../wiki/Installation) for more information.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ To upgrade:
 ```
 pipx upgrade linode-cli
 ```
-```
 We recommend using `pipx` to install `linode-cli`, as it installs Python CLI tools in isolated environments and avoids conflicts with system-managed Python packages (PEP 668).
 Visit the [Wiki](../../wiki/Installation) for more information.
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,21 @@ Visit the [Wiki](../../wiki) for more information.
 
 ## Install
 
-Install via PyPI:
+We recommend installing `linode-cli` with `pipx`, which installs each Python CLI tool into its own isolated environment and works on distributions where `pip install` fails because the system Python is marked as externally managed ([PEP 668](https://peps.python.org/pep-0668/)). If pipx isn't installed yet, follow the [pipx installation guide](https://pipx.pypa.io/latest/how-to/install-pipx.html).
+
+To install:
+
 ```bash
 pipx install linode-cli
 ```
+
 To upgrade:
-```
+
+```bash
 pipx upgrade linode-cli
 ```
-We recommend using `pipx` to install `linode-cli`, as it installs Python CLI tools in isolated environments and avoids conflicts with system-managed Python packages (PEP 668).
-Visit the [Wiki](../../wiki/Installation) for more information.
+
+The [Wiki](https://github.com/linode/linode-cli/wiki/Installation) covers other installation methods, including the Docker image, the GitHub Action, and building from source.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
This PR updates the installation instructions in README.md to recommend `pipx` instead of `pip3`.

## Changes
- Replaced `pip3 install linode-cli` with `pipx install linode-cli`
- Added `pipx upgrade linode-cli` command
- Added explanation about why pipx is recommended (PEP 668)

## Why
Using pipx avoids conflicts with system-managed Python environments and follows modern Python best practices.

## How to Test
- Follow updated install instructions using `pipx`
- Verify CLI installs and runs correctly