### PR TITLE
feat: support "help" as a subcommand synonymous with "--help" #868

### DIFF
--- a/linodecli/cli.py
+++ b/linodecli/cli.py
@@ -25,7 +25,13 @@ from linodecli.output.output_handler import OutputHandler, OutputMode
 METHODS = ("get", "post", "put", "delete")
 
 logger = getLogger(__name__)
+args = sys.argv[1:]
 
+if len(args) > 0 and args[-1] == "help":
+    sys.argv = [sys.argv[0]] + args[:-1] + ["--help"]
+
+elif len(args) > 0 and args[0] == "help":
+    sys.argv = [sys.argv[0]] + args[1:] + ["--help"]
 
 class CLI:  # pylint: disable=too-many-instance-attributes
     """

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "linode-cli",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/test_help_alias.py
+++ b/tests/test_help_alias.py
@@ -1,0 +1,18 @@
+import subprocess
+import os
+def test_help_alias():
+    env = os.environ.copy()
+    env["LINODE_CLI_CONFIG"] = "/dev/null"
+    env["HOME"] = "/tmp"
+
+    result = subprocess.run(
+        ["python3", "-m", "linodecli", "instance", "help"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env=env,
+        input="\n"
+    )
+
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
Added support for using `help` as a subcommand in the CLI.

Closes #868 

What this does
Now the following commands work:

linode-cli instance help
linode-cli help instance

Both behave the same as using `--help`.

Why
While using different CLIs, I often find myself typing `help` as a subcommand instead of `--help`. Many tools like git and aws support this pattern, so adding it here makes the CLI a bit more intuitive and user-friendly.

Implementation
This is handled by checking for `help` in the arguments early and mapping it to `--help`. The change is minimal and doesn’t affect existing functionality.

Notes
If there’s a preferred way to handle this at the parser level instead of rewriting argv, I’m happy to update the implementation.