### PR TITLE
TPT-4175: cli: Update interactive config token access check

### DIFF
--- a/linodecli/configuration/__init__.py
+++ b/linodecli/configuration/__init__.py
@@ -5,7 +5,6 @@ Configuration helper package for the Linode CLI.
 # Private methods need to be imported explicitly
 from .auth import *
 from .auth import (
-    _check_full_access,
     _do_get_request,
     _get_token_terminal,
     _get_token_web,

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -176,7 +176,14 @@ def _check_full_access(base_url: str, token: str) -> bool:
         verify=API_CA_PATH,
     )
 
-    _handle_response_status(result, exit_on_error=True)
+    # IAM-enrolled users receive a 403 from /profile/grants since that
+    # endpoint is not accessible to them. Treat 403 as a valid response
+    # (i.e. not full access) rather than a fatal error.
+    _handle_response_status(
+        result,
+        exit_on_error=True,
+        status_validator=lambda status: status == 403,
+    )
 
     return result.status_code == 204
 

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -152,42 +152,6 @@ def _do_request(
     return result.json()
 
 
-def _check_full_access(base_url: str, token: str) -> bool:
-    """
-    Checks whether the given token has full-access permissions.
-
-    :param base_url: The base URL for the API.
-    :type base_url: str
-    :param token: The access token to use.
-    :type token :str
-
-    :returns: Whether the user has full access.
-    :rtype: bool
-    """
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-
-    result = requests.get(
-        base_url + "/profile/grants",
-        headers=headers,
-        timeout=120,
-        verify=API_CA_PATH,
-    )
-
-    # IAM-enrolled users receive a 403 from /profile/grants since that
-    # endpoint is not accessible to them. Treat 403 as a valid response
-    # (i.e. not full access) rather than a fatal error.
-    _handle_response_status(
-        result,
-        exit_on_error=True,
-        status_validator=lambda status: status == 403,
-    )
-
-    return result.status_code == 204
-
-
 def _username_for_token(base_url: str, token: str) -> str:
     """
     A helper function that returns the username associated with a token by

--- a/linodecli/configuration/config.py
+++ b/linodecli/configuration/config.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 from linodecli.exit_codes import ExitCodes
 
 from .auth import (
-    _check_full_access,
     _do_get_request,
     _get_token_terminal,
     _get_token_web,
@@ -430,18 +429,33 @@ class CLIConfig:
             [i["id"] for i in _do_get_request(self.base_url, "/images")["data"]]
         )
 
-        is_full_access = _check_full_access(self.base_url, token)
-
         auth_users = []
 
-        if is_full_access:
+        # Use /profile/sshkeys as a lightweight capability check. If the token
+        # lacks profile access (401) or the user is IAM-enrolled (403), skip
+        # the authorized_users prompt entirely. Capture the status code via a
+        # closure passed as status_validator so no new API surface is needed.
+        sshkeys_status_code = None
+
+        def _capture_sshkeys_status(status: int) -> bool:
+            nonlocal sshkeys_status_code
+            sshkeys_status_code = status
+            return True  # suppress _handle_response_status error output
+
+        _do_get_request(
+            self.base_url,
+            "/profile/sshkeys",
+            token=token,
+            exit_on_error=False,
+            status_validator=_capture_sshkeys_status,
+        )
+
+        if sshkeys_status_code == 200:
             users = _do_get_request(
                 self.base_url,
                 "/account/users",
                 token=token,
-                # Allow 401 responses so tokens without
-                # account perms can be configured
-                status_validator=lambda status: status == 401,
+                status_validator=lambda status: status in (401, 403),
             )
 
             if "data" in users:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -19,6 +19,7 @@ from linodecli.configuration import (
     _default_text_input,
     _default_thing_input,
 )
+from linodecli.configuration.auth import _check_full_access
 
 
 class TestConfiguration:
@@ -676,3 +677,41 @@ mysql_engine = mysql/8.0.26"""
 
             for i, _ in enumerate(expected_configs):
                 assert expected_configs[i] == configs[i]
+
+
+class TestCheckFullAccess:
+    """
+    Unit tests for _check_full_access
+    """
+
+    base_url = "https://linode-test.com"
+    test_token = "cli-dev-token"
+
+    def test_full_access_returns_true(self):
+        """
+        204 No Content means the token has full (unrestricted) access.
+        """
+        with requests_mock.Mocker() as m:
+            m.get(f"{self.base_url}/profile/grants", status_code=204)
+            assert _check_full_access(self.base_url, self.test_token) is True
+
+    def test_restricted_access_returns_false(self):
+        """
+        200 with a grants body means the token has restricted access.
+        """
+        with requests_mock.Mocker() as m:
+            m.get(
+                f"{self.base_url}/profile/grants",
+                status_code=200,
+                json={"linode": []},
+            )
+            assert _check_full_access(self.base_url, self.test_token) is False
+
+    def test_iam_user_403_returns_false(self):
+        """
+        IAM-enrolled users receive a 403 from /profile/grants.
+        This should be treated as "not full access" rather than a fatal error.
+        """
+        with requests_mock.Mocker() as m:
+            m.get(f"{self.base_url}/profile/grants", status_code=403)
+            assert _check_full_access(self.base_url, self.test_token) is False

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -16,10 +16,10 @@ import requests_mock
 from linodecli import configuration
 from linodecli.configuration import (
     _bool_input,
+    _check_full_access,
     _default_text_input,
     _default_thing_input,
 )
-from linodecli.configuration.auth import _check_full_access
 
 
 class TestConfiguration:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -16,7 +16,6 @@ import requests_mock
 from linodecli import configuration
 from linodecli.configuration import (
     _bool_input,
-    _check_full_access,
     _default_text_input,
     _default_thing_input,
 )
@@ -299,7 +298,7 @@ mysql_engine = mysql/8.0.26"""
             requests_mock.Mocker() as m,
         ):
             m.get(f"{self.base_url}/profile", json={"username": "cli-dev"})
-            m.get(f"{self.base_url}/profile/grants", status_code=204)
+            m.get(f"{self.base_url}/profile/sshkeys", json={"data": []})
             m.get(
                 f"{self.base_url}/regions",
                 json={"data": [{"id": "test-region"}]},
@@ -350,7 +349,7 @@ mysql_engine = mysql/8.0.26"""
             requests_mock.Mocker() as m,
         ):
             m.get(f"{self.base_url}/profile", json={"username": "cli-dev"})
-            m.get(f"{self.base_url}/profile/grants", status_code=204)
+            m.get(f"{self.base_url}/profile/sshkeys", json={"data": []})
             m.get(
                 f"{self.base_url}/regions",
                 json={"data": [{"id": "test-region"}]},
@@ -679,39 +678,103 @@ mysql_engine = mysql/8.0.26"""
                 assert expected_configs[i] == configs[i]
 
 
-class TestCheckFullAccess:
+class TestConfigureAuthorizedUsers:
     """
-    Unit tests for _check_full_access
+    Unit tests for the authorized_users gate in CLIConfig.configure(),
+    which uses GET /profile/sshkeys as a capability check instead of
+    GET /profile/grants (which is inaccessible to IAM-enrolled users).
     """
 
     base_url = "https://linode-test.com"
     test_token = "cli-dev-token"
 
-    def test_full_access_returns_true(self):
-        """
-        204 No Content means the token has full (unrestricted) access.
-        """
-        with requests_mock.Mocker() as m:
-            m.get(f"{self.base_url}/profile/grants", status_code=204)
-            assert _check_full_access(self.base_url, self.test_token) is True
+    def _base_mocks(self, m, *, sshkeys_status=200, users_json=None):
+        """Register the common mocks needed for a configure() call."""
+        m.get(f"{self.base_url}/profile", json={"username": "cli-dev"})
+        m.get(
+            f"{self.base_url}/profile/sshkeys",
+            status_code=sshkeys_status,
+            json={"data": []},
+        )
+        m.get(f"{self.base_url}/regions", json={"data": [{"id": "us-east"}]})
+        m.get(
+            f"{self.base_url}/linode/types",
+            json={"data": [{"id": "g6-nanode-1"}]},
+        )
+        m.get(
+            f"{self.base_url}/images",
+            json={"data": [{"id": "linode/debian12"}]},
+        )
+        if users_json is not None:
+            m.get(f"{self.base_url}/account/users", json=users_json)
 
-    def test_restricted_access_returns_false(self):
+    def test_sshkeys_success_populates_authorized_users(self):
         """
-        200 with a grants body means the token has restricted access.
+        When /profile/sshkeys succeeds, /account/users is fetched and
+        authorized_users is offered.
         """
-        with requests_mock.Mocker() as m:
-            m.get(
-                f"{self.base_url}/profile/grants",
-                status_code=200,
-                json={"linode": []},
+        conf = configuration.CLIConfig(self.base_url, skip_config=True)
+        answers = iter(["1", "1", "1", "1", "n", "n"])
+
+        with (
+            patch("linodecli.configuration.open", mock_open()),
+            patch("os.chmod", lambda a, b: None),
+            patch("builtins.input", lambda _: next(answers)),
+            contextlib.redirect_stdout(io.StringIO()),
+            patch("linodecli.configuration._check_browsers", lambda: False),
+            patch.dict(os.environ, {"LINODE_CLI_TOKEN": self.test_token}),
+            requests_mock.Mocker() as m,
+        ):
+            self._base_mocks(
+                m,
+                users_json={
+                    "data": [{"username": "cli-dev", "ssh_keys": ["key1"]}]
+                },
             )
-            assert _check_full_access(self.base_url, self.test_token) is False
+            conf.configure()
 
-    def test_iam_user_403_returns_false(self):
+        assert conf.get_value("authorized_users") == "cli-dev"
+
+    def test_sshkeys_401_skips_authorized_users(self):
         """
-        IAM-enrolled users receive a 403 from /profile/grants.
-        This should be treated as "not full access" rather than a fatal error.
+        When /profile/sshkeys returns 401 (restricted token), the
+        authorized_users prompt is skipped.
         """
-        with requests_mock.Mocker() as m:
-            m.get(f"{self.base_url}/profile/grants", status_code=403)
-            assert _check_full_access(self.base_url, self.test_token) is False
+        conf = configuration.CLIConfig(self.base_url, skip_config=True)
+        answers = iter(["1", "1", "1", "n", "n"])
+
+        with (
+            patch("linodecli.configuration.open", mock_open()),
+            patch("os.chmod", lambda a, b: None),
+            patch("builtins.input", lambda _: next(answers)),
+            contextlib.redirect_stdout(io.StringIO()),
+            patch("linodecli.configuration._check_browsers", lambda: False),
+            patch.dict(os.environ, {"LINODE_CLI_TOKEN": self.test_token}),
+            requests_mock.Mocker() as m,
+        ):
+            self._base_mocks(m, sshkeys_status=401)
+            conf.configure()
+
+        assert conf.get_value("authorized_users") is None
+
+    def test_sshkeys_403_iam_skips_authorized_users(self):
+        """
+        When /profile/sshkeys returns 403 (IAM-enrolled user), the
+        authorized_users prompt is skipped.
+        """
+        conf = configuration.CLIConfig(self.base_url, skip_config=True)
+        answers = iter(["1", "1", "1", "n", "n"])
+
+        with (
+            patch("linodecli.configuration.open", mock_open()),
+            patch("os.chmod", lambda a, b: None),
+            patch("builtins.input", lambda _: next(answers)),
+            contextlib.redirect_stdout(io.StringIO()),
+            patch("linodecli.configuration._check_browsers", lambda: False),
+            patch.dict(os.environ, {"LINODE_CLI_TOKEN": self.test_token}),
+            requests_mock.Mocker() as m,
+        ):
+            self._base_mocks(m, sshkeys_status=403)
+            conf.configure()
+
+        assert conf.get_value("authorized_users") is None


### PR DESCRIPTION
## 📝 Description

AM Users wont have access to /profile/grants so we need to come up with a new way to check the access level of an account so it can add auth users. 

## ✔️ How to Test

```
make test-unit
```
