### PR TITLE
TPT-4280: Add integration tests for Reserved IP for IPv4

### DIFF
--- a/tests/integration/linodes/helpers.py
+++ b/tests/integration/linodes/helpers.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 
 from tests.integration.helpers import (
@@ -7,7 +8,7 @@ from tests.integration.helpers import (
 )
 
 DEFAULT_RANDOM_PASS = exec_test_command(["openssl", "rand", "-base64", "32"])
-DEFAULT_REGION = "us-ord"
+DEFAULT_REGION = "pl-labkrk-2" if "devcloud" in os.getenv('LINODE_CLI_API_HOST') else "us-ord"
 
 DEFAULT_TEST_IMAGE = exec_test_command(
     [

--- a/tests/integration/linodes/helpers.py
+++ b/tests/integration/linodes/helpers.py
@@ -8,7 +8,11 @@ from tests.integration.helpers import (
 )
 
 DEFAULT_RANDOM_PASS = exec_test_command(["openssl", "rand", "-base64", "32"])
-DEFAULT_REGION = "pl-labkrk-2" if "devcloud" in os.getenv('LINODE_CLI_API_HOST') else "us-ord"
+DEFAULT_REGION = (
+    "pl-labkrk-2"
+    if "devcloud" in os.getenv("LINODE_CLI_API_HOST")
+    else "us-ord"
+)
 
 DEFAULT_TEST_IMAGE = exec_test_command(
     [

--- a/tests/integration/linodes/helpers.py
+++ b/tests/integration/linodes/helpers.py
@@ -10,7 +10,7 @@ from tests.integration.helpers import (
 DEFAULT_RANDOM_PASS = exec_test_command(["openssl", "rand", "-base64", "32"])
 DEFAULT_REGION = (
     "pl-labkrk-2"
-    if "devcloud" in os.getenv("LINODE_CLI_API_HOST")
+    if "devcloud" in os.getenv("LINODE_CLI_API_HOST", "")
     else "us-ord"
 )
 

--- a/tests/integration/networking/fixtures.py
+++ b/tests/integration/networking/fixtures.py
@@ -21,7 +21,7 @@ def create_reserved_ip(request):
         DEFAULT_REGION,
         "--text",
         "--delimiter",
-        ","
+        ",",
     ]
 
     if tags:

--- a/tests/integration/networking/fixtures.py
+++ b/tests/integration/networking/fixtures.py
@@ -6,9 +6,9 @@ from tests.integration.helpers import (
     exec_test_command,
 )
 from tests.integration.linodes.helpers import (
+    DEFAULT_REGION,
     create_linode,
     create_linode_and_wait,
-    DEFAULT_REGION
 )
 
 

--- a/tests/integration/networking/fixtures.py
+++ b/tests/integration/networking/fixtures.py
@@ -1,0 +1,69 @@
+import pytest
+
+from tests.integration.helpers import (
+    BASE_CMDS,
+    delete_target_id,
+    exec_test_command,
+)
+from tests.integration.linodes.helpers import (
+    create_linode,
+    create_linode_and_wait,
+    DEFAULT_REGION
+)
+
+
+@pytest.fixture
+def create_reserved_ip(request):
+    tags = getattr(request, "param", None)
+    command = BASE_CMDS["networking"] + [
+        "reserved-ip-add",
+        "--region",
+        DEFAULT_REGION,
+        "--text",
+        "--delimiter",
+        ","
+    ]
+
+    if tags:
+        command += ["--tags", tags]
+
+    headers, values = get_command_heads_and_vals(command)
+    yield headers, values
+
+    delete_target_id("networking", values[0], "reserved-ip-delete")
+
+
+@pytest.fixture(scope="package")
+def test_linode_id(linode_cloud_firewall):
+    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
+
+    yield linode_id
+
+    delete_target_id(target="linodes", id=linode_id)
+
+
+@pytest.fixture(scope="package")
+def test_linode_id_shared_ipv4(linode_cloud_firewall):
+    target_region = "us-mia"
+
+    linode_ids = (
+        create_linode(
+            test_region=target_region, firewall_id=linode_cloud_firewall
+        ),
+        create_linode(
+            test_region=target_region, firewall_id=linode_cloud_firewall
+        ),
+    )
+
+    yield linode_ids
+
+    for id_num in linode_ids:
+        delete_target_id(target="linodes", id=id_num)
+
+
+def get_command_heads_and_vals(command):
+    result = exec_test_command(command).splitlines()
+    headers = [item for item in result[0].split(",")]
+    values = [item for item in result[1].split(",")]
+
+    return headers, values

--- a/tests/integration/networking/fixtures.py
+++ b/tests/integration/networking/fixtures.py
@@ -35,7 +35,7 @@ def create_reserved_ip(request):
 
 
 @pytest.fixture(scope="package")
-def test_linode_id(linode_cloud_firewall):
+def get_linode_id(linode_cloud_firewall):
     linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
 
     yield linode_id
@@ -44,7 +44,7 @@ def test_linode_id(linode_cloud_firewall):
 
 
 @pytest.fixture(scope="package")
-def test_linode_id_shared_ipv4(linode_cloud_firewall):
+def get_linode_ids_shared_ipv4(linode_cloud_firewall):
     target_region = "us-mia"
 
     linode_ids = (

--- a/tests/integration/networking/fixtures.py
+++ b/tests/integration/networking/fixtures.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from tests.integration.helpers import (
@@ -19,18 +21,17 @@ def create_reserved_ip(request):
         "reserved-ip-add",
         "--region",
         DEFAULT_REGION,
-        "--text",
-        "--delimiter",
-        ",",
+        "--json",
     ]
 
     if tags:
         command += ["--tags", tags]
 
-    headers, values = get_command_heads_and_vals(command)
-    yield headers, values
+    result = json.loads(exec_test_command(command))[0]
 
-    delete_target_id("networking", values[0], "reserved-ip-delete")
+    yield result
+
+    delete_target_id("networking", result["address"], "reserved-ip-delete")
 
 
 @pytest.fixture(scope="package")

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -63,7 +63,7 @@ def test_display_ips_for_available_linodes(test_linode_id):
 
     assert re.search(r"^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}", result)
     assert re.search(
-        r"ipv4,True,[0-9]{1,3}\-[0-9]{1,3}\-[0-9]{1,3}\-[0-9]{1,3}\.ip.linodeusercontent.com,.*,[0-9][0-9][0-9][0-9][0-9][0-9][0-9]*",
+        r"ipv4,True,(False|True),[0-9]{1,3}\-[0-9]{1,3}\-[0-9]{1,3}\-[0-9]{1,3}\.ip\.linodeusercontent\.com,[0-9]*",
         result,
     )
     assert re.search("ipv6,True,,.*,[0-9][0-9][0-9][0-9][0-9][0-9]*", result)
@@ -253,6 +253,43 @@ def test_get_reserved_ips_list(create_reserved_ip):
     ).splitlines()
 
     assert all(item == "True" for item in result)
+
+
+def test_update_ephemeral_to_reserved(test_linode_id):
+    linode_id = test_linode_id
+
+    ephemeral_ip = exec_test_command(
+        BASE_CMDS["linodes"] + [
+            "view",
+            linode_id,
+            "--text",
+            "--no-headers",
+            "--format",
+            "ipv4",
+        ]
+    ).split(" ")[0]
+
+    exec_test_command(
+        BASE_CMDS["networking"] + [
+            "ip-update",
+            ephemeral_ip,
+            "--reserved",
+            "true",
+        ]
+    )
+
+    is_reserved = exec_test_command(
+        BASE_CMDS["networking"] + [
+            "reserved-ip-view",
+            ephemeral_ip,
+            "--text",
+            "--no-headers",
+            "--format",
+            "reserved",
+        ]
+    )
+
+    assert is_reserved == "True"
 
 
 def test_share_ipv4_address(

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -8,77 +8,20 @@ from _pytest.monkeypatch import MonkeyPatch
 from tests.integration.helpers import (
     BASE_CMDS,
     assert_headers_in_lines,
-    delete_target_id,
     exec_test_command,
 )
-from tests.integration.linodes.helpers import (
-    create_linode,
-    create_linode_and_wait,
-    DEFAULT_REGION
+from tests.integration.linodes.helpers import DEFAULT_REGION
+from tests.integration.networking.fixtures import (
+    create_reserved_ip,
+    get_command_heads_and_vals,
+    test_linode_id,
+    test_linode_id_shared_ipv4
 )
-from tests.integration.sharegroups.fixtures import get_region  # noqa: F401
 
 
 RESERVED_IP_HEADERS = [
     "address", "type", "public", "rdns", "linode_id", "reserved", "tags"
 ]
-
-
-@pytest.fixture
-def create_reserved_ip(request):
-    tags = getattr(request, "param", None)
-    command = BASE_CMDS["networking"] + [
-        "reserved-ip-add",
-        "--region",
-        DEFAULT_REGION,
-        "--text",
-        "--delimiter",
-        ","
-    ]
-
-    if tags:
-        command += ["--tags", tags]
-
-    headers, values = get_command_heads_and_vals(command)
-    yield headers, values
-
-    delete_target_id("networking", values[0], "reserved-ip-delete")
-
-
-@pytest.fixture(scope="package")
-def test_linode_id(linode_cloud_firewall):
-    linode_id = create_linode_and_wait(firewall_id=linode_cloud_firewall)
-
-    yield linode_id
-
-    delete_target_id(target="linodes", id=linode_id)
-
-
-@pytest.fixture(scope="package")
-def test_linode_id_shared_ipv4(linode_cloud_firewall):
-    target_region = "us-mia"
-
-    linode_ids = (
-        create_linode(
-            test_region=target_region, firewall_id=linode_cloud_firewall
-        ),
-        create_linode(
-            test_region=target_region, firewall_id=linode_cloud_firewall
-        ),
-    )
-
-    yield linode_ids
-
-    for id in linode_ids:
-        delete_target_id(target="linodes", id=id)
-
-
-def get_command_heads_and_vals(command):
-    result = exec_test_command(command).splitlines()
-    headers = [item for item in result[0].split(",")]
-    values = [item for item in result[1].split(",")]
-
-    return headers, values
 
 
 def has_shared_ip(linode_id: int, ip: str) -> bool:

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -15,9 +15,8 @@ from tests.integration.networking.fixtures import (
     create_reserved_ip,
     get_command_heads_and_vals,
     test_linode_id,
-    test_linode_id_shared_ipv4
+    test_linode_id_shared_ipv4,
 )
-
 
 RESERVED_IP_HEADERS = [
     "address", "type", "public", "rdns", "linode_id", "reserved", "tags"

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -7,9 +7,9 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from tests.integration.helpers import (
     BASE_CMDS,
+    assert_headers_in_lines,
     delete_target_id,
     exec_test_command,
-    get_random_region_with_caps,
 )
 from tests.integration.linodes.helpers import (
     create_linode,
@@ -19,6 +19,11 @@ from tests.integration.linodes.helpers import (
 from tests.integration.sharegroups.fixtures import get_region  # noqa: F401
 
 
+RESERVED_IP_HEADERS = [
+    "address", "type", "public", "rdns", "linode_id", "reserved", "tags"
+]
+
+
 @pytest.fixture
 def create_reserved_ip(request):
     tags = getattr(request, "param", None)
@@ -26,17 +31,18 @@ def create_reserved_ip(request):
         "reserved-ip-add",
         "--region",
         DEFAULT_REGION,
-        "--json",
+        "--text",
+        "--delimiter",
+        ","
     ]
 
     if tags:
         command += ["--tags", tags]
 
-    result = json.loads(exec_test_command(command))[0]
+    headers, values = get_command_heads_and_vals(command)
+    yield headers, values
 
-    yield result
-
-    delete_target_id("networking", result["address"], "reserved-ip-delete")
+    delete_target_id("networking", values[0], "reserved-ip-delete")
 
 
 @pytest.fixture(scope="package")
@@ -67,6 +73,14 @@ def test_linode_id_shared_ipv4(linode_cloud_firewall):
         delete_target_id(target="linodes", id=id)
 
 
+def get_command_heads_and_vals(command):
+    result = exec_test_command(command).splitlines()
+    headers = [item for item in result[0].split(",")]
+    values = [item for item in result[1].split(",")]
+
+    return headers, values
+
+
 def has_shared_ip(linode_id: int, ip: str) -> bool:
     shared_ips = json.loads(
         exec_test_command(
@@ -87,12 +101,13 @@ def has_shared_ip(linode_id: int, ip: str) -> bool:
 
 def verify_reserved_ip(reserved_ip):
     assert isinstance(
-        ipaddress.ip_address(reserved_ip["address"]), ipaddress.IPv4Address
+        ipaddress.ip_address(reserved_ip[0]), ipaddress.IPv4Address
     )
-    assert reserved_ip["type"] == "ipv4"
-    assert reserved_ip["public"] == True
-    assert reserved_ip["reserved"] == True
-    assert reserved_ip["linode_id"] is None
+    assert reserved_ip[1] == "ipv4"
+    assert reserved_ip[2] == "True"
+    assert reserved_ip[4] == DEFAULT_REGION
+    assert not reserved_ip[5]
+    assert reserved_ip[7] == "True"
     # TODO: To be clarified if it should be returned in CLI
     # assert reserved_ip["assigned_entity"] is None
 
@@ -180,48 +195,47 @@ def test_allocate_additional_private_ipv4_address(test_linode_id):
         "ipv4,False,.*,[0-9][0-9][0-9][0-9][0-9][0-9][0-9]*", result
     )
 
-
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "create_reserved_ip", ["test", None], indirect=True
 )
 def test_create_reserved_ip(create_reserved_ip):
-    reserved_ip = create_reserved_ip
+    headers, reserved_ip = create_reserved_ip
+    assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
     verify_reserved_ip(reserved_ip)
 
-    tags = reserved_ip["tags"]
-    assert tags == ["test"] if tags else tags == []
+    tags = reserved_ip[-1]
+    assert tags == "test" if tags else tags == ''
 
 
 @pytest.mark.parametrize(
     "create_reserved_ip", ["test"], indirect=True
 )
 def test_update_reserved_ip_tags(create_reserved_ip):
-    reserved_ip = create_reserved_ip
-    verify_reserved_ip(reserved_ip)
-    assert reserved_ip["tags"] == ["test"]
+    _, reserved_ip = create_reserved_ip
+    assert reserved_ip[-1] == "test"
 
-    result =  json.loads(
-        exec_test_command(
-            BASE_CMDS["networking"] + [
-                "reserved-ip-update",
-                "--tags",
-                "updated",
-                reserved_ip["address"],
-                "--json",
-            ]
-        )
-    )[0]
+    result =  exec_test_command(
+        BASE_CMDS["networking"] + [
+            "reserved-ip-update",
+            "--tags",
+            "updated",
+            "--tags",
+            "updated2",
+            reserved_ip[0],
+            "--text",
+            "--no-headers",
+            "--delimiter",
+            ","
+        ]
+    ).split(",")
     verify_reserved_ip(result)
-    assert result["tags"] == ["updated"]
+    assert result[-1] == "updated updated2"
 
 
-# @pytest.mark.parametrize(
-#     "create_reserved_ip", ["test"], indirect=True
-# )
-def test_create_reserved_ip_assigned(test_linode_id, create_reserved_ip):
+def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
+    _, reserved_ip = create_reserved_ip
     linode_id = test_linode_id
-    reserved_ip = create_reserved_ip
-    verify_reserved_ip(reserved_ip)
 
     exec_test_command(
         BASE_CMDS["networking"] + [
@@ -229,43 +243,73 @@ def test_create_reserved_ip_assigned(test_linode_id, create_reserved_ip):
             "--assignments.linode_id",
             linode_id,
             "--assignments.address",
-            reserved_ip["address"],
+            reserved_ip[0],
             "--region",
             DEFAULT_REGION,
         ]
     )
 
-    result = json.loads(
-        exec_test_command(
-            BASE_CMDS["linodes"] + [
-                "ip-view",
-                linode_id,
-                reserved_ip["address"],
-                "--json"
-            ]
-        )
-    )[0]
-    assert result["address"] == reserved_ip["address"]
-    assert str(result["linode_id"]) == linode_id
-    assert result["reserved"] == True
-    # TODO: To be clarified if it should be returned in CLI
-    # assert result["tags"] == reserved_ip["tags"]
+    command = BASE_CMDS["linodes"] + [
+        "ip-view",
+        linode_id,
+        reserved_ip[0],
+        "--text",
+        "--delimiter",
+        ","
+    ]
+    headers, values = get_command_heads_and_vals(command)
+
+    assert_headers_in_lines(RESERVED_IP_HEADERS[:-1], [headers])
+    # TODO: To be clarified if tags should be returned in CLI (currently it is)
+    # assert "tags" not in headers
+    assert values[0] == reserved_ip[0]
+    assert str(values[5]) == linode_id
+    assert values[7] == "True"
 
 
 def test_get_reserved_ip_types():
-    result = json.loads(
-        exec_test_command(
-            BASE_CMDS["networking"] + [
-                "reserved-ip-types-list",
-                "--json"
-            ]
-        )
-    )[0]
-    assert result["id"] == "reserved-ipv4"
-    assert result["label"] == "Reserved IPv4"
-    assert "hourly" in result["price"]
-    assert "monthly" in result["price"]
-    assert any(price != 0 for price in list(result["price"].values()))
+    headers_exp = ["id", "label", "price.hourly", "price.monthly"]
+    command = BASE_CMDS["networking"] + [
+        "reserved-ip-types-list",
+        "--text",
+        "--delimiter",
+        ","
+    ]
+    headers, values = get_command_heads_and_vals(command)
+
+    assert_headers_in_lines(headers_exp, [headers])
+    assert values[0] == "reserved-ipv4"
+    assert values[1] == "Reserved IPv4"
+    assert any(price != 0 for price in values[2:4])
+
+
+def test_get_reserved_ip_view(create_reserved_ip):
+    _, reserved_ip = create_reserved_ip
+    command = BASE_CMDS["networking"] + [
+        "reserved-ip-view",
+        reserved_ip[0],
+        "--text",
+        "--delimiter",
+        ","
+    ]
+    headers, values = get_command_heads_and_vals(command)
+
+    assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
+    verify_reserved_ip(values)
+
+
+def test_get_reserved_ips_list(create_reserved_ip):
+    result = exec_test_command(
+        BASE_CMDS["networking"] + [
+            "reserved-ips-list",
+            "--text",
+            "--no-headers",
+            "--format",
+            "reserved"
+        ]
+    ).splitlines()
+
+    assert all(item == "True" for item in result)
 
 
 def test_share_ipv4_address(

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -11,7 +11,7 @@ from tests.integration.helpers import (
     exec_test_command,
 )
 from tests.integration.linodes.helpers import DEFAULT_REGION
-from tests.integration.networking.fixtures import (
+from tests.integration.networking.fixtures import (  # noqa: F401
     create_reserved_ip,
     get_command_heads_and_vals,
     test_linode_id,

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import re
 
@@ -13,6 +14,28 @@ from tests.integration.linodes.helpers import (
     create_linode,
     create_linode_and_wait,
 )
+from tests.integration.sharegroups.fixtures import get_region  # noqa: F401
+
+
+@pytest.fixture
+def create_reserved_ip(request, get_region):
+    tags = getattr(request, "param", None)
+    region = get_region
+    command = BASE_CMDS["networking"] + [
+        "reserved-ip-add",
+        "--region",
+        region,
+        "--json",
+    ]
+
+    if tags:
+        command += ["--tags", tags]
+
+    result = json.loads(exec_test_command(command))[0]
+
+    yield result
+
+    delete_target_id("networking", result["address"], "reserved-ip-delete")
 
 
 @pytest.fixture(scope="package")
@@ -59,6 +82,18 @@ def has_shared_ip(linode_id: int, ip: str) -> bool:
             return True
 
     return False
+
+
+def verify_reserved_ip(reserved_ip):
+    assert isinstance(
+        ipaddress.ip_address(reserved_ip["address"]), ipaddress.IPv4Address
+    )
+    assert reserved_ip["type"] == "ipv4"
+    assert reserved_ip["public"] == True
+    assert reserved_ip["reserved"] == True
+    assert reserved_ip["linode_id"] is None
+    # TODO: To be clarified if it should be returned in CLI
+    # assert reserved_ip["assigned_entity"] is None
 
 
 def test_display_ips_for_available_linodes(test_linode_id):
@@ -143,6 +178,53 @@ def test_allocate_additional_private_ipv4_address(test_linode_id):
     assert re.search(
         "ipv4,False,.*,[0-9][0-9][0-9][0-9][0-9][0-9][0-9]*", result
     )
+
+
+@pytest.mark.parametrize(
+    "create_reserved_ip", ["test", None], indirect=True
+)
+def test_create_reserved_ip(create_reserved_ip):
+    reserved_ip = create_reserved_ip
+    verify_reserved_ip(reserved_ip)
+
+    tags = reserved_ip["tags"]
+    assert tags == ["test"] if tags else tags == []
+
+
+def test_create_reserved_ip_wo_region_fail():
+    with pytest.raises(RuntimeError) as exc_info:
+        exec_test_command(
+            BASE_CMDS["networking"] + [
+                "reserved-ip-add",
+                "--json",
+            ]
+        )
+
+    assert "Request failed: 400" in exc_info.value.args[0]
+    assert "region is required" in exc_info.value.args[0]
+
+
+@pytest.mark.parametrize(
+    "create_reserved_ip", ["test"], indirect=True
+)
+def test_update_reserved_ip_tags(create_reserved_ip):
+    reserved_ip = create_reserved_ip
+    verify_reserved_ip(reserved_ip)
+    assert reserved_ip["tags"] == ["test"]
+
+    result =  json.loads(
+        exec_test_command(
+            BASE_CMDS["networking"] + [
+                "reserved-ip-update",
+                "--tags",
+                "updated",
+                reserved_ip["address"],
+                "--json",
+            ]
+        )
+    )[0]
+    verify_reserved_ip(result)
+    assert result["tags"] == ["updated"]
 
 
 def test_share_ipv4_address(

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -19,7 +19,13 @@ from tests.integration.networking.fixtures import (  # noqa: F401
 )
 
 RESERVED_IP_HEADERS = [
-    "address", "type", "public", "rdns", "linode_id", "reserved", "tags"
+    "address",
+    "type",
+    "public",
+    "rdns",
+    "linode_id",
+    "reserved",
+    "tags",
 ]
 
 
@@ -137,28 +143,26 @@ def test_allocate_additional_private_ipv4_address(test_linode_id):
         "ipv4,False,.*,[0-9][0-9][0-9][0-9][0-9][0-9][0-9]*", result
     )
 
+
 @pytest.mark.smoke
-@pytest.mark.parametrize(
-    "create_reserved_ip", ["test", None], indirect=True
-)
+@pytest.mark.parametrize("create_reserved_ip", ["test", None], indirect=True)
 def test_create_reserved_ip(create_reserved_ip):
     headers, reserved_ip = create_reserved_ip
     assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
     verify_reserved_ip(reserved_ip)
 
     tags = reserved_ip[-1]
-    assert tags == "test" if tags else tags == ''
+    assert tags == "test" if tags else tags == ""
 
 
-@pytest.mark.parametrize(
-    "create_reserved_ip", ["test"], indirect=True
-)
+@pytest.mark.parametrize("create_reserved_ip", ["test"], indirect=True)
 def test_update_reserved_ip_tags(create_reserved_ip):
     _, reserved_ip = create_reserved_ip
     assert reserved_ip[-1] == "test"
 
-    result =  exec_test_command(
-        BASE_CMDS["networking"] + [
+    result = exec_test_command(
+        BASE_CMDS["networking"]
+        + [
             "reserved-ip-update",
             "--tags",
             "updated",
@@ -168,7 +172,7 @@ def test_update_reserved_ip_tags(create_reserved_ip):
             "--text",
             "--no-headers",
             "--delimiter",
-            ","
+            ",",
         ]
     ).split(",")
     verify_reserved_ip(result)
@@ -180,7 +184,8 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
     linode_id = test_linode_id
 
     exec_test_command(
-        BASE_CMDS["networking"] + [
+        BASE_CMDS["networking"]
+        + [
             "ip-assign",
             "--assignments.linode_id",
             linode_id,
@@ -197,7 +202,7 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
         reserved_ip[0],
         "--text",
         "--delimiter",
-        ","
+        ",",
     ]
     headers, values = get_command_heads_and_vals(command)
 
@@ -215,7 +220,7 @@ def test_get_reserved_ip_types():
         "reserved-ip-types-list",
         "--text",
         "--delimiter",
-        ","
+        ",",
     ]
     headers, values = get_command_heads_and_vals(command)
 
@@ -232,7 +237,7 @@ def test_get_reserved_ip_view(create_reserved_ip):
         reserved_ip[0],
         "--text",
         "--delimiter",
-        ","
+        ",",
     ]
     headers, values = get_command_heads_and_vals(command)
 
@@ -242,12 +247,13 @@ def test_get_reserved_ip_view(create_reserved_ip):
 
 def test_get_reserved_ips_list(create_reserved_ip):
     result = exec_test_command(
-        BASE_CMDS["networking"] + [
+        BASE_CMDS["networking"]
+        + [
             "reserved-ips-list",
             "--text",
             "--no-headers",
             "--format",
-            "reserved"
+            "reserved",
         ]
     ).splitlines()
 
@@ -258,7 +264,8 @@ def test_update_ephemeral_to_reserved(test_linode_id):
     linode_id = test_linode_id
 
     ephemeral_ip = exec_test_command(
-        BASE_CMDS["linodes"] + [
+        BASE_CMDS["linodes"]
+        + [
             "view",
             linode_id,
             "--text",
@@ -269,7 +276,8 @@ def test_update_ephemeral_to_reserved(test_linode_id):
     ).split(" ")[0]
 
     exec_test_command(
-        BASE_CMDS["networking"] + [
+        BASE_CMDS["networking"]
+        + [
             "ip-update",
             ephemeral_ip,
             "--reserved",
@@ -278,7 +286,8 @@ def test_update_ephemeral_to_reserved(test_linode_id):
     )
 
     is_reserved = exec_test_command(
-        BASE_CMDS["networking"] + [
+        BASE_CMDS["networking"]
+        + [
             "reserved-ip-view",
             ephemeral_ip,
             "--text",

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -9,22 +9,23 @@ from tests.integration.helpers import (
     BASE_CMDS,
     delete_target_id,
     exec_test_command,
+    get_random_region_with_caps,
 )
 from tests.integration.linodes.helpers import (
     create_linode,
     create_linode_and_wait,
+    DEFAULT_REGION
 )
 from tests.integration.sharegroups.fixtures import get_region  # noqa: F401
 
 
 @pytest.fixture
-def create_reserved_ip(request, get_region):
+def create_reserved_ip(request):
     tags = getattr(request, "param", None)
-    region = get_region
     command = BASE_CMDS["networking"] + [
         "reserved-ip-add",
         "--region",
-        region,
+        DEFAULT_REGION,
         "--json",
     ]
 
@@ -191,19 +192,6 @@ def test_create_reserved_ip(create_reserved_ip):
     assert tags == ["test"] if tags else tags == []
 
 
-def test_create_reserved_ip_wo_region_fail():
-    with pytest.raises(RuntimeError) as exc_info:
-        exec_test_command(
-            BASE_CMDS["networking"] + [
-                "reserved-ip-add",
-                "--json",
-            ]
-        )
-
-    assert "Request failed: 400" in exc_info.value.args[0]
-    assert "region is required" in exc_info.value.args[0]
-
-
 @pytest.mark.parametrize(
     "create_reserved_ip", ["test"], indirect=True
 )
@@ -225,6 +213,59 @@ def test_update_reserved_ip_tags(create_reserved_ip):
     )[0]
     verify_reserved_ip(result)
     assert result["tags"] == ["updated"]
+
+
+# @pytest.mark.parametrize(
+#     "create_reserved_ip", ["test"], indirect=True
+# )
+def test_create_reserved_ip_assigned(test_linode_id, create_reserved_ip):
+    linode_id = test_linode_id
+    reserved_ip = create_reserved_ip
+    verify_reserved_ip(reserved_ip)
+
+    exec_test_command(
+        BASE_CMDS["networking"] + [
+            "ip-assign",
+            "--assignments.linode_id",
+            linode_id,
+            "--assignments.address",
+            reserved_ip["address"],
+            "--region",
+            DEFAULT_REGION,
+        ]
+    )
+
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["linodes"] + [
+                "ip-view",
+                linode_id,
+                reserved_ip["address"],
+                "--json"
+            ]
+        )
+    )[0]
+    assert result["address"] == reserved_ip["address"]
+    assert str(result["linode_id"]) == linode_id
+    assert result["reserved"] == True
+    # TODO: To be clarified if it should be returned in CLI
+    # assert result["tags"] == reserved_ip["tags"]
+
+
+def test_get_reserved_ip_types():
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["networking"] + [
+                "reserved-ip-types-list",
+                "--json"
+            ]
+        )
+    )[0]
+    assert result["id"] == "reserved-ipv4"
+    assert result["label"] == "Reserved IPv4"
+    assert "hourly" in result["price"]
+    assert "monthly" in result["price"]
+    assert any(price != 0 for price in list(result["price"].values()))
 
 
 def test_share_ipv4_address(

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -23,9 +23,15 @@ RESERVED_IP_HEADERS = [
     "type",
     "public",
     "rdns",
+    "region",
     "linode_id",
+    "interface_id",
     "reserved",
     "tags",
+    # "gateway",
+    # "prefix",
+    # "subnet_mask",
+    # "vpc_nat_1_1",
 ]
 
 
@@ -47,17 +53,16 @@ def has_shared_ip(linode_id: int, ip: str) -> bool:
     return False
 
 
-def verify_reserved_ip(reserved_ip):
+def verify_reserved_ip(result):
     assert isinstance(
-        ipaddress.ip_address(reserved_ip[0]), ipaddress.IPv4Address
+        ipaddress.ip_address(result["address"]), ipaddress.IPv4Address
     )
-    assert reserved_ip[1] == "ipv4"
-    assert reserved_ip[2] == "True"
-    assert reserved_ip[4] == DEFAULT_REGION
-    assert not reserved_ip[5]
-    assert reserved_ip[7] == "True"
-    # TODO: To be clarified if it should be returned in CLI
-    # assert reserved_ip["assigned_entity"] is None
+    assert result["type"] == "ipv4"
+    assert result["public"] == True
+    assert result["region"] == DEFAULT_REGION
+    assert not result["linode_id"]
+    assert result["reserved"] == True
+    # assert not result["assigned_entity.label"]
 
 
 def test_display_ips_for_available_linodes(test_linode_id):
@@ -145,42 +150,47 @@ def test_allocate_additional_private_ipv4_address(test_linode_id):
 
 
 @pytest.mark.smoke
-@pytest.mark.parametrize("create_reserved_ip", ["test", None], indirect=True)
-def test_create_reserved_ip(create_reserved_ip):
-    headers, reserved_ip = create_reserved_ip
-    assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
-    verify_reserved_ip(reserved_ip)
+@pytest.mark.parametrize(
+    "create_reserved_ip, expected",
+    [
+        ("test", ["test"]),
+        (None, [])
+    ],
+    indirect=["create_reserved_ip"])
+def test_create_reserved_ip(create_reserved_ip, expected):
+    res_ip_data = create_reserved_ip
+    headers = list(res_ip_data.keys())
 
-    tags = reserved_ip[-1]
-    assert tags == "test" if tags else tags == ""
+    assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
+    verify_reserved_ip(res_ip_data)
+    assert res_ip_data["tags"] == expected
 
 
 @pytest.mark.parametrize("create_reserved_ip", ["test"], indirect=True)
 def test_update_reserved_ip_tags(create_reserved_ip):
-    _, reserved_ip = create_reserved_ip
-    assert reserved_ip[-1] == "test"
+    res_ip_data = create_reserved_ip
+    assert res_ip_data["tags"] == ["test"]
 
-    result = exec_test_command(
-        BASE_CMDS["networking"]
-        + [
-            "reserved-ip-update",
-            "--tags",
-            "updated",
-            "--tags",
-            "updated2",
-            reserved_ip[0],
-            "--text",
-            "--no-headers",
-            "--delimiter",
-            ",",
-        ]
-    ).split(",")
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["networking"] + [
+                "reserved-ip-update",
+                "--tags",
+                "updated",
+                "--tags",
+                "updated2",
+                res_ip_data["address"],
+                "--json",
+            ]
+        )
+    )[0]
+
     verify_reserved_ip(result)
-    assert result[-1] == "updated updated2"
+    assert result["tags"] == ["updated", "updated2"]
 
 
 def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
-    _, reserved_ip = create_reserved_ip
+    res_ip_data = create_reserved_ip
     linode_id = test_linode_id
 
     exec_test_command(
@@ -190,32 +200,33 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
             "--assignments.linode_id",
             linode_id,
             "--assignments.address",
-            reserved_ip[0],
+            res_ip_data["address"],
             "--region",
             DEFAULT_REGION,
         ]
     )
 
-    command = BASE_CMDS["linodes"] + [
-        "ip-view",
-        linode_id,
-        reserved_ip[0],
-        "--text",
-        "--delimiter",
-        ",",
-    ]
-    headers, values = get_command_heads_and_vals(command)
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["linodes"] + [
+                "ip-view",
+                linode_id,
+                res_ip_data["address"],
+                "--json",
+            ]
+        )
+    )[0]
+    headers = list(result.keys())
 
     assert_headers_in_lines(RESERVED_IP_HEADERS[:-1], [headers])
-    # TODO: To be clarified if tags should be returned in CLI (currently it is)
-    # assert "tags" not in headers
-    assert values[0] == reserved_ip[0]
-    assert str(values[5]) == linode_id
-    assert values[7] == "True"
+    assert result["address"] == res_ip_data["address"]
+    assert result["linode_id"] == int(linode_id)
+    assert result["reserved"] == True
+    assert "tags" not in headers
 
 
 def test_get_reserved_ip_types():
-    headers_exp = ["id", "label", "price.hourly", "price.monthly"]
+    headers_exp = ["id", "label", "price.hourly", "price.monthly"] # , "region_prices"]
     command = BASE_CMDS["networking"] + [
         "reserved-ip-types-list",
         "--text",
@@ -231,18 +242,20 @@ def test_get_reserved_ip_types():
 
 
 def test_get_reserved_ip_view(create_reserved_ip):
-    _, reserved_ip = create_reserved_ip
-    command = BASE_CMDS["networking"] + [
-        "reserved-ip-view",
-        reserved_ip[0],
-        "--text",
-        "--delimiter",
-        ",",
-    ]
-    headers, values = get_command_heads_and_vals(command)
+    res_ip_data = create_reserved_ip
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["networking"] + [
+                "reserved-ip-view",
+                res_ip_data["address"],
+                "--json",
+            ]
+        )
+    )[0]
+    headers = list(result.keys())
 
     assert_headers_in_lines(RESERVED_IP_HEADERS, [headers])
-    verify_reserved_ip(values)
+    verify_reserved_ip(result)
 
 
 def test_get_reserved_ips_list(create_reserved_ip):

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -323,7 +323,7 @@ def test_update_ephemeral_to_reserved(get_linode_id):
 
 
 def test_share_ipv4_address(
-        get_linode_ids_shared_ipv4, monkeypatch: MonkeyPatch
+    get_linode_ids_shared_ipv4, monkeypatch: MonkeyPatch
 ):
     target_linode, parent_linode = get_linode_ids_shared_ipv4
     monkeypatch.setenv("LINODE_CLI_API_VERSION", "v4beta")

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -14,8 +14,8 @@ from tests.integration.linodes.helpers import DEFAULT_REGION
 from tests.integration.networking.fixtures import (  # noqa: F401
     create_reserved_ip,
     get_command_heads_and_vals,
-    test_linode_id,
-    test_linode_id_shared_ipv4,
+    get_linode_id,
+    get_linode_ids_shared_ipv4,
 )
 
 RESERVED_IP_HEADERS = [
@@ -63,7 +63,7 @@ def verify_reserved_ip(result):
     assert result["reserved"] == True
 
 
-def test_display_ips_for_available_linodes(test_linode_id):
+def test_display_ips_for_available_linodes(get_linode_id):
     result = exec_test_command(
         BASE_CMDS["networking"]
         + ["ips-list", "--text", "--no-headers", "--delimiter", ","]
@@ -82,8 +82,8 @@ def test_display_ips_for_available_linodes(test_linode_id):
 
 
 @pytest.mark.smoke
-def test_view_an_ip_address(test_linode_id):
-    linode_id = test_linode_id
+def test_view_an_ip_address(get_linode_id):
+    linode_id = get_linode_id
     linode_ipv4 = exec_test_command(
         [
             "linode-cli",
@@ -121,8 +121,8 @@ def test_view_an_ip_address(test_linode_id):
     ), f"`interface_id` is not None or int: {data['interface_id']}"
 
 
-def test_allocate_additional_private_ipv4_address(test_linode_id):
-    linode_id = test_linode_id
+def test_allocate_additional_private_ipv4_address(get_linode_id):
+    linode_id = get_linode_id
 
     result = exec_test_command(
         BASE_CMDS["networking"]
@@ -186,9 +186,9 @@ def test_update_reserved_ip_tags(create_reserved_ip):
     assert result["tags"] == ["updated", "updated2"]
 
 
-def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
+def test_create_reserved_ip_assigned(create_reserved_ip, get_linode_id):
     res_ip_data = create_reserved_ip
-    linode_id = test_linode_id
+    linode_id = get_linode_id
 
     exec_test_command(
         BASE_CMDS["networking"]
@@ -282,8 +282,8 @@ def test_get_reserved_ips_list(create_reserved_ip):
     assert all(item == "True" for item in result)
 
 
-def test_update_ephemeral_to_reserved(test_linode_id):
-    linode_id = test_linode_id
+def test_update_ephemeral_to_reserved(get_linode_id):
+    linode_id = get_linode_id
 
     ephemeral_ip = exec_test_command(
         BASE_CMDS["linodes"]
@@ -323,9 +323,9 @@ def test_update_ephemeral_to_reserved(test_linode_id):
 
 
 def test_share_ipv4_address(
-    test_linode_id_shared_ipv4, monkeypatch: MonkeyPatch
+        get_linode_ids_shared_ipv4, monkeypatch: MonkeyPatch
 ):
-    target_linode, parent_linode = test_linode_id_shared_ipv4
+    target_linode, parent_linode = get_linode_ids_shared_ipv4
     monkeypatch.setenv("LINODE_CLI_API_VERSION", "v4beta")
 
     # Allocate an IPv4 address on the parent Linode

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -152,11 +152,9 @@ def test_allocate_additional_private_ipv4_address(test_linode_id):
 @pytest.mark.smoke
 @pytest.mark.parametrize(
     "create_reserved_ip, expected",
-    [
-        ("test", ["test"]),
-        (None, [])
-    ],
-    indirect=["create_reserved_ip"])
+    [("test", ["test"]), (None, [])],
+    indirect=["create_reserved_ip"],
+)
 def test_create_reserved_ip(create_reserved_ip, expected):
     res_ip_data = create_reserved_ip
     headers = list(res_ip_data.keys())
@@ -173,7 +171,8 @@ def test_update_reserved_ip_tags(create_reserved_ip):
 
     result = json.loads(
         exec_test_command(
-            BASE_CMDS["networking"] + [
+            BASE_CMDS["networking"]
+            + [
                 "reserved-ip-update",
                 "--tags",
                 "updated",
@@ -208,7 +207,8 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
 
     result = json.loads(
         exec_test_command(
-            BASE_CMDS["linodes"] + [
+            BASE_CMDS["linodes"]
+            + [
                 "ip-view",
                 linode_id,
                 res_ip_data["address"],
@@ -226,7 +226,12 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
 
 
 def test_get_reserved_ip_types():
-    headers_exp = ["id", "label", "price.hourly", "price.monthly"] # , "region_prices"]
+    headers_exp = [
+        "id",
+        "label",
+        "price.hourly",
+        "price.monthly",
+    ]  # , "region_prices"]
     command = BASE_CMDS["networking"] + [
         "reserved-ip-types-list",
         "--text",
@@ -245,7 +250,8 @@ def test_get_reserved_ip_view(create_reserved_ip):
     res_ip_data = create_reserved_ip
     result = json.loads(
         exec_test_command(
-            BASE_CMDS["networking"] + [
+            BASE_CMDS["networking"]
+            + [
                 "reserved-ip-view",
                 res_ip_data["address"],
                 "--json",

--- a/tests/integration/networking/test_networking.py
+++ b/tests/integration/networking/test_networking.py
@@ -27,11 +27,10 @@ RESERVED_IP_HEADERS = [
     "linode_id",
     "interface_id",
     "reserved",
+    "gateway",
+    "prefix",
+    "subnet_mask",
     "tags",
-    # "gateway",
-    # "prefix",
-    # "subnet_mask",
-    # "vpc_nat_1_1",
 ]
 
 
@@ -62,7 +61,6 @@ def verify_reserved_ip(result):
     assert result["region"] == DEFAULT_REGION
     assert not result["linode_id"]
     assert result["reserved"] == True
-    # assert not result["assigned_entity.label"]
 
 
 def test_display_ips_for_available_linodes(test_linode_id):
@@ -223,27 +221,32 @@ def test_create_reserved_ip_assigned(create_reserved_ip, test_linode_id):
     assert result["linode_id"] == int(linode_id)
     assert result["reserved"] == True
     assert "tags" not in headers
+    assert "assigned_entity" in headers
 
 
 def test_get_reserved_ip_types():
     headers_exp = [
         "id",
         "label",
-        "price.hourly",
-        "price.monthly",
-    ]  # , "region_prices"]
-    command = BASE_CMDS["networking"] + [
-        "reserved-ip-types-list",
-        "--text",
-        "--delimiter",
-        ",",
+        "price",
+        "region_prices",
     ]
-    headers, values = get_command_heads_and_vals(command)
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["networking"]
+            + [
+                "reserved-ip-types-list",
+                "--json",
+            ]
+        )
+    )[0]
+    headers = list(result.keys())
+    prices = [result["price"]["hourly"], result["price"]["monthly"]]
 
     assert_headers_in_lines(headers_exp, [headers])
-    assert values[0] == "reserved-ipv4"
-    assert values[1] == "Reserved IPv4"
-    assert any(price != 0 for price in values[2:4])
+    assert result["id"] == "reserved-ipv4"
+    assert result["label"] == "Reserved IPv4"
+    assert any(price != 0 for price in prices)
 
 
 def test_get_reserved_ip_view(create_reserved_ip):

--- a/tests/integration/tags/test_tags.py
+++ b/tests/integration/tags/test_tags.py
@@ -58,18 +58,19 @@ def test_create_tag_for_reserved_ip(create_reserved_ip):
             "--label",
             tag_name,
             "--reserved_ipv4_addresses",
-            reserved_ip[0]
+            reserved_ip[0],
         ]
     )
 
     result = exec_test_command(
-        BASE_CMDS["networking"] + [
+        BASE_CMDS["networking"]
+        + [
             "reserved-ip-view",
             reserved_ip[0],
             "--text",
             "--no-headers",
             "--format",
-            "tags"
+            "tags",
         ]
     )
 

--- a/tests/integration/tags/test_tags.py
+++ b/tests/integration/tags/test_tags.py
@@ -8,7 +8,9 @@ from tests.integration.helpers import (
     exec_test_command,
     get_random_text,
 )
-from tests.integration.networking.fixtures import create_reserved_ip
+from tests.integration.networking.fixtures import (  # noqa: F401
+    create_reserved_ip,
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/tags/test_tags.py
+++ b/tests/integration/tags/test_tags.py
@@ -8,6 +8,7 @@ from tests.integration.helpers import (
     exec_test_command,
     get_random_text,
 )
+from tests.integration.networking.fixtures import create_reserved_ip
 
 
 @pytest.fixture(scope="session")
@@ -42,3 +43,35 @@ def test_fail_to_create_tag_shorter_than_three_char():
     )
     assert "Request failed: 400" in result
     assert "Length must be 3-50 characters" in result
+
+
+def test_create_tag_for_reserved_ip(create_reserved_ip):
+    _, reserved_ip = create_reserved_ip
+    tag_name = get_random_text(5) + "-tag"
+
+    exec_test_command(
+        BASE_CMDS["tags"]
+        + [
+            "create",
+            "--label",
+            tag_name,
+            "--reserved_ipv4_addresses",
+            reserved_ip[0]
+        ]
+    )
+
+    result = exec_test_command(
+        BASE_CMDS["networking"] + [
+            "reserved-ip-view",
+            reserved_ip[0],
+            "--text",
+            "--no-headers",
+            "--format",
+            "tags"
+        ]
+    )
+
+    assert result == tag_name
+
+    # TODO: GET tags/{label} and DELETE tags/{label} missed or not implemented at all
+    # delete_target_id("tags", tag_name)

--- a/tests/integration/tags/test_tags.py
+++ b/tests/integration/tags/test_tags.py
@@ -1,20 +1,24 @@
+import json
+import time
+
 import pytest
 
 from linodecli.exit_codes import ExitCodes
 from tests.integration.helpers import (
     BASE_CMDS,
+    assert_headers_in_lines,
     delete_target_id,
     exec_failing_test_command,
     exec_test_command,
     get_random_text,
 )
 from tests.integration.networking.fixtures import (  # noqa: F401
-    create_reserved_ip,
+    create_reserved_ip
 )
 
 
 @pytest.fixture(scope="session")
-def test_tag_instance():
+def create_tag_instance():
     unique_tag = get_random_text(5) + "-tag"
 
     exec_test_command(
@@ -26,13 +30,38 @@ def test_tag_instance():
 
     delete_target_id("tags", unique_tag)
 
+@pytest.fixture
+def create_tag_instance_for_reserved_ip(create_reserved_ip):
+    res_ip_data = create_reserved_ip
+    tag_label = get_random_text(5) + "-tag"
 
-@pytest.mark.smoke
-def test_view_unique_tag(test_tag_instance):
+    exec_test_command(
+        BASE_CMDS["tags"]
+        + [
+            "create",
+            "--label",
+            tag_label,
+            "--reserved_ipv4_addresses",
+            res_ip_data["address"],
+        ]
+    )
+
+    yield res_ip_data, tag_label
+
     result = exec_test_command(
         BASE_CMDS["tags"] + ["list", "--text", "--no-headers"]
     )
-    assert test_tag_instance in result
+
+    if tag_label in result:
+        delete_target_id("tags", tag_label)
+
+
+@pytest.mark.smoke
+def test_view_unique_tag(create_tag_instance):
+    result = exec_test_command(
+        BASE_CMDS["tags"] + ["list", "--text", "--no-headers"]
+    )
+    assert create_tag_instance in result
 
 
 @pytest.mark.skip(reason="BUG = TPT-3650")
@@ -47,34 +76,35 @@ def test_fail_to_create_tag_shorter_than_three_char():
     assert "Length must be 3-50 characters" in result
 
 
-def test_create_tag_for_reserved_ip(create_reserved_ip):
-    _, reserved_ip = create_reserved_ip
-    tag_name = get_random_text(5) + "-tag"
+def test_create_delete_tag_for_reserved_ip(create_tag_instance_for_reserved_ip):
+    res_ip_data, tag_label = create_tag_instance_for_reserved_ip
+
+    result = json.loads(
+        exec_test_command(
+            BASE_CMDS["tags"] + [
+                "get-tagged-objects",
+                tag_label,
+                "--json",
+            ]
+        )
+    )[0]
+    headers = list(result.keys())
+
+    assert_headers_in_lines(["data", "type"], [headers])
+    assert result["data"]["address"] == res_ip_data["address"]
+    assert result["data"]["reserved"] == True
+    assert len(result["data"]["tags"]) == 1
+    assert result["data"]["tags"][0] == tag_label
+    assert result["type"] == "reserved_ipv4_address"
 
     exec_test_command(
-        BASE_CMDS["tags"]
-        + [
-            "create",
-            "--label",
-            tag_name,
-            "--reserved_ipv4_addresses",
-            reserved_ip[0],
+        BASE_CMDS["tags"] + [
+            "delete",
+            tag_label,
         ]
     )
 
     result = exec_test_command(
-        BASE_CMDS["networking"]
-        + [
-            "reserved-ip-view",
-            reserved_ip[0],
-            "--text",
-            "--no-headers",
-            "--format",
-            "tags",
-        ]
+        BASE_CMDS["tags"] + ["list", "--text", "--no-headers"]
     )
-
-    assert result == tag_name
-
-    # TODO: GET tags/{label} and DELETE tags/{label} missed or not implemented at all
-    # delete_target_id("tags", tag_name)
+    assert tag_label not in result

--- a/tests/integration/tags/test_tags.py
+++ b/tests/integration/tags/test_tags.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 import pytest
 
@@ -13,7 +12,7 @@ from tests.integration.helpers import (
     get_random_text,
 )
 from tests.integration.networking.fixtures import (  # noqa: F401
-    create_reserved_ip
+    create_reserved_ip,
 )
 
 
@@ -29,6 +28,7 @@ def create_tag_instance():
     yield unique_tag
 
     delete_target_id("tags", unique_tag)
+
 
 @pytest.fixture
 def create_tag_instance_for_reserved_ip(create_reserved_ip):
@@ -81,7 +81,8 @@ def test_create_delete_tag_for_reserved_ip(create_tag_instance_for_reserved_ip):
 
     result = json.loads(
         exec_test_command(
-            BASE_CMDS["tags"] + [
+            BASE_CMDS["tags"]
+            + [
                 "get-tagged-objects",
                 tag_label,
                 "--json",
@@ -98,7 +99,8 @@ def test_create_delete_tag_for_reserved_ip(create_tag_instance_for_reserved_ip):
     assert result["type"] == "reserved_ipv4_address"
 
     exec_test_command(
-        BASE_CMDS["tags"] + [
+        BASE_CMDS["tags"]
+        + [
             "delete",
             tag_label,
         ]


### PR DESCRIPTION
## 📝 Description

Integration tests verifying Reserved IPs CLI commands

NOTE:
[PR](https://git.source.akamai.com/projects/TECHDOCS/repos/akamai-api-inventory/pull-requests/2707/overview) with openapi.json for Reserved IPs is already merged, however openapi.json file is not updated yet in `linode-api-openapi` repo so CLI can be build locally only using the latest openapi.json taken from the PR mentioned above

## ✔️ How to Test

`make test-int TEST_SUITE=networking TEST_ARGS="-k reserved"`
`make test-int TEST_SUITE=tags TEST_ARGS="-k reserved"`