### PR TITLE
TPT-4466: Dynamically get LKE standard version for testing

### DIFF
--- a/tests/integration/lke/helpers.py
+++ b/tests/integration/lke/helpers.py
@@ -76,6 +76,22 @@ def get_lke_enterprise_id():
     return enterprise_ti.get("id")
 
 
+def get_lke_standard_id():
+    standard_versions_list = exec_test_command(
+        BASE_CMDS["lke"]
+        + [
+            "versions-list",
+            "--json",
+        ]
+    )
+
+    parsed = json.loads(standard_versions_list)
+
+    standard_ti = parsed[0]
+
+    return standard_ti.get("id")
+
+
 def get_cluster_id(label: str):
     cluster_id = exec_test_command(
         [

--- a/tests/integration/lke/test_lke_enterprise.py
+++ b/tests/integration/lke/test_lke_enterprise.py
@@ -11,7 +11,11 @@ from tests.integration.helpers import (
     get_random_region_with_caps,
     get_random_text,
 )
-from tests.integration.lke.helpers import get_cluster_id, get_lke_enterprise_id
+from tests.integration.lke.helpers import (
+    get_cluster_id,
+    get_lke_enterprise_id,
+    get_lke_standard_id,
+)
 
 
 def test_enterprise_tier_available_in_types(monkeypatch: MonkeyPatch):
@@ -116,6 +120,7 @@ def test_lke_tiered_versions_list():
 
 def test_lke_tiered_versions_view():
     enterprise_id = get_lke_enterprise_id()
+    standard_id = get_lke_standard_id()
     enterprise_tier_info = exec_test_command(
         BASE_CMDS["lke"]
         + [
@@ -138,7 +143,7 @@ def test_lke_tiered_versions_view():
         + [
             "tiered-version-view",
             "standard",
-            "1.33",
+            standard_id,
             "--json",
         ]
     )


### PR DESCRIPTION
## 📝 Description

Dynamically select a standard LKE version for the get version test so a retired version won't cause a test failure.

## Testing
```bash
pytest tests/integration/lke/test_lke_enterprise.py -k test_lke_tiered_versions_view
```