### PR TITLE
TPT-4613: Remove unsupported parameters from test_interface_settings_update

### DIFF
--- a/linodecli/completion.py
+++ b/linodecli/completion.py
@@ -94,10 +94,12 @@ complete -F _linode_cli linode
 complete -F _linode_cli lin"""
     )
 
-    command_template = Template("""$command)
+    command_template = Template(
+        """$command)
         COMPREPLY=( $(compgen -W "$actions --help" -- ${cur}) )
         return 0
-        ;;""")
+        ;;"""
+    )
 
     command_blocks = [
         command_template.safe_substitute(

--- a/linodecli/completion.py
+++ b/linodecli/completion.py
@@ -94,12 +94,10 @@ complete -F _linode_cli linode
 complete -F _linode_cli lin"""
     )
 
-    command_template = Template(
-        """$command)
+    command_template = Template("""$command)
         COMPREPLY=( $(compgen -W "$actions --help" -- ${cur}) )
         return 0
-        ;;"""
-    )
+        ;;""")
 
     command_blocks = [
         command_template.safe_substitute(

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -214,11 +214,12 @@ def _get_token_terminal(base_url: str) -> Tuple[str, str]:
     :returns: A tuple containing the user's username and token.
     :rtype: Tuple[str, str]
     """
-    print(f"""
-First, we need a Personal Access Token.  To get one, please visit
-{TOKEN_GENERATION_URL} and click
-"Create a Personal Access Token".  The CLI needs access to everything
-on your account to work correctly.""")
+    print(
+        "First, we need a Personal Access Token.  To get one, please visit\n"
+        f"{TOKEN_GENERATION_URL} and click\n"
+        '"Create a Personal Access Token".  The CLI needs access to everything\n'
+        "on your account to work correctly."
+    )
 
     while True:
         token = input("Personal Access Token: ")
@@ -327,13 +328,15 @@ def _handle_oauth_callback() -> str:
     # figure out the URL to direct the user to and print out the prompt
     # pylint: disable-next=line-too-long
     url = f"https://login.linode.com/oauth/authorize?client_id={OAUTH_CLIENT_ID}&response_type=token&scopes=*&redirect_uri=http://localhost:{serv.server_address[1]}"
-    print(f"""A browser should open directing you to this URL to authenticate:
+    print(
+        f"""A browser should open directing you to this URL to authenticate:
 
 {url}
 
 If you are not automatically directed there, please copy/paste the link into your browser
 to continue..
-""")
+"""
+    )
 
     webbrowser.open(url)
 

--- a/linodecli/configuration/auth.py
+++ b/linodecli/configuration/auth.py
@@ -328,15 +328,13 @@ def _handle_oauth_callback() -> str:
     # figure out the URL to direct the user to and print out the prompt
     # pylint: disable-next=line-too-long
     url = f"https://login.linode.com/oauth/authorize?client_id={OAUTH_CLIENT_ID}&response_type=token&scopes=*&redirect_uri=http://localhost:{serv.server_address[1]}"
-    print(
-        f"""A browser should open directing you to this URL to authenticate:
+    print(f"""A browser should open directing you to this URL to authenticate:
 
 {url}
 
 If you are not automatically directed there, please copy/paste the link into your browser
 to continue..
-"""
-    )
+""")
 
     webbrowser.open(url)
 

--- a/linodecli/configuration/helpers.py
+++ b/linodecli/configuration/helpers.py
@@ -97,9 +97,10 @@ def _check_browsers() -> bool:
 
     # pylint: disable-next=protected-access
     if not KNOWN_GOOD_BROWSERS.intersection(webbrowser._tryorder):
-        print("""
-This tool defaults to web-based authentication,
-however no known-working browsers were found.""")
+        print(
+            "This tool defaults to web-based authentication,\n"
+            "however no known-working browsers were found."
+        )
         while True:
             r = input("Try it anyway? [y/N]: ")
             if r.lower() in "yn ":

--- a/tests/integration/linodes/test_linode_interfaces.py
+++ b/tests/integration/linodes/test_linode_interfaces.py
@@ -146,10 +146,6 @@ def test_interface_settings_update(
                 interface_id,
                 "--default_route.ipv6_interface_id",
                 interface_id,
-                "--default_route.ipv4_eligible_interface_ids",
-                interface_id,
-                "--default_route.ipv6_eligible_interface_ids",
-                interface_id,
                 "--json",
             ]
         )


### PR DESCRIPTION
## 📝 Description

`ipv4_eligible_interface_ids` and `ipv6_eligible_interface_ids` attributes are not supported in request. Removing them from test.

## ✔️ How to Test
```bash
pytest tests/integration/linodes/test_linode_interfaces.py -k test_interface_settings_update
```