### PR TITLE
TPT-4475: Add integration tests for Configurable VPC top-level IPv4 Prefixes

### DIFF
--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -67,3 +67,24 @@ def test_subnet(test_vpc_wo_subnet):
     )
 
     yield res, subnet_label
+
+
+@pytest.fixture
+def create_vpc_with_ipv4(request):
+    params = getattr(request, "param", None)
+    params = params.split(" ") if params else []
+    region = get_random_region_with_caps(
+        required_capabilities=["VPCs", "Custom VPC IPv4 Ranges"]
+    )
+    label = get_random_text(5) + "-label"
+
+    vpc_id = exec_test_command(
+        BASE_CMDS["vpcs"]
+        + ["create", "--label", label, "--region", region]
+        + params
+        + ["--no-headers", "--text", "--format=id"]
+    )
+
+    yield vpc_id
+
+    delete_target_id(target="vpcs", id=vpc_id)

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -72,7 +72,7 @@ def test_subnet(test_vpc_wo_subnet):
 @pytest.fixture
 def create_vpc_with_ipv4(request):
     params = getattr(request, "param", None)
-    params = params.split(" ") if params else []
+    params = params.split() if params else []
     region = get_random_region_with_caps(
         required_capabilities=["VPCs", "Custom VPC IPv4 Ranges"]
     )

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -383,3 +383,76 @@ def test_list_vpc_ipv6s_address():
 
     for header in headers:
         assert header in lines[0]
+
+
+def test_get_vpc_default_ranges():
+    headers = ["default_ipv4_ranges", "forbidden_ipv4_ranges"]
+
+    result = json.loads(
+        exec_test_command(BASE_CMD + ["default-ranges-all-list", "--json"])
+    )[0]
+
+    assert all(header in result.keys() for header in headers)
+    assert isinstance(result[headers[0]], list)
+    assert isinstance(result[headers[1]], list)
+
+
+@pytest.mark.parametrize(
+    "create_vpc_with_ipv4, expected",
+    [
+        ("--ipv4.range 10.0.0.0/8", 1),
+        ("--ipv4.range 10.0.0.0/8 --ipv4.range 192.168.0.0/17", 2),
+    ],
+    indirect=["create_vpc_with_ipv4"],
+)
+def test_vpc_with_ipv4(create_vpc_with_ipv4, expected):
+    vpc_id = create_vpc_with_ipv4
+
+    result = exec_test_command(
+        BASE_CMDS["vpcs"] + ["list", "--text", "--format=id", "--no-headers"]
+    )
+    assert vpc_id in result
+
+    result = json.loads(
+        exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
+    )[0]
+    assert len(result["ipv4"]) == expected
+
+
+def test_vpc_with_forbidden_ipv4_fail():
+    forbidden_ipv4 = exec_test_command(
+        BASE_CMD
+        + [
+            "default-ranges-all-list",
+            "--text",
+            "--no-headers",
+            "--format=forbidden_ipv4_ranges",
+        ]
+    ).split(" ")[0]
+
+    region = get_random_region_with_caps(
+        required_capabilities=["VPCs", "Custom VPC IPv4 Ranges"]
+    )
+    label = get_random_text(5) + "-label"
+
+    result = exec_failing_test_command(
+        BASE_CMDS["vpcs"]
+        + [
+            "create",
+            "--label",
+            label,
+            "--region",
+            region,
+            "--ipv4.range",
+            forbidden_ipv4,
+            "--text",
+            "--no-headers",
+        ],
+        ExitCodes.REQUEST_FAILED,
+    )
+
+    assert "Request failed: 400" in result
+    assert (
+        f"The IPv4 range {forbidden_ipv4} overlaps with the forbidden IPv4 range {forbidden_ipv4}"
+        in result
+    )

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -411,7 +411,7 @@ def test_vpc_with_ipv4(create_vpc_with_ipv4, expected):
     result = exec_test_command(
         BASE_CMDS["vpcs"] + ["list", "--text", "--format=id", "--no-headers"]
     )
-    assert vpc_id in result
+    assert vpc_id in result.splitlines()
 
     result = json.loads(
         exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
@@ -428,7 +428,7 @@ def test_vpc_with_forbidden_ipv4_fail():
             "--no-headers",
             "--format=forbidden_ipv4_ranges",
         ]
-    ).split(" ")[0]
+    ).split()[0]
 
     region = get_random_region_with_caps(
         required_capabilities=["VPCs", "Custom VPC IPv4 Ranges"]

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -419,6 +419,33 @@ def test_vpc_with_ipv4(create_vpc_with_ipv4, expected):
     assert len(result["ipv4"]) == expected
 
 
+@pytest.mark.parametrize(
+    "create_vpc_with_ipv4, updated",
+    [
+        ("--ipv4.range 10.0.0.0/8", "192.168.0.0/17"),
+    ],
+    indirect=["create_vpc_with_ipv4"],
+)
+def test_vpc_update_with_ipv4(create_vpc_with_ipv4, updated):
+    vpc_id = create_vpc_with_ipv4
+
+    exec_test_command(
+        BASE_CMDS["vpcs"]
+        + [
+            "update",
+            vpc_id,
+            "--ipv4.range",
+            updated,
+        ]
+    )
+
+    result = json.loads(
+        exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
+    )[0]
+    assert len(result["ipv4"]) == 1
+    assert result["ipv4"][0]["range"] == updated
+
+
 def test_vpc_with_forbidden_ipv4_fail():
     forbidden_ipv4 = exec_test_command(
         BASE_CMD


### PR DESCRIPTION
## 📝 Description

Added intergration tests for configurable VPC IPv4

NOTE:
[PR](https://git.source.akamai.com/projects/TECHDOCS/repos/akamai-api-inventory/pull-requests/2731/overview) with openapi.json is already merged, however openapi.json file is not updated yet in linode-api-openapi repo so CLI can be build locally only using the latest openapi.json taken from the PR mentioned above

## ✔️ How to Test

`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_get_vpc_default_ranges"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_vpc_with_ipv4"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_vpc_update_with_ipv4"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_vpc_with_forbidden_ipv4_fail"`
