### PR TITLE
TPT-4557: Add security release label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -26,6 +26,9 @@
 - name: breaking-change
   description: for breaking changes in the changelog.
   color: ff0000
+- name: security
+  description: for security fixes and improvements in the changelog.
+  color: AA1111
 - name: ignore-for-release
   description: PRs you do not want to render in the changelog
   color: 7b8eac

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,6 +9,9 @@ changelog:
     - title: ⚠️ Breaking Change
       labels:
         - breaking-change
+    - title: 🔒 Security Fixes
+      labels:
+        - security
     - title: 🐛 Bug Fixes
       labels:
         - bugfix


### PR DESCRIPTION
## 📝 Description

Add a consistent `security` label and security-fixes category to generated release notes.