### PR TITLE
TPT-4457: Add integration tests for RDMA interfaces

### DIFF
--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -23,7 +23,6 @@ def get_test_vpc_w_subnet():
 @pytest.fixture
 def get_test_vpc_wo_subnet():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
-
     label = get_random_text(5) + "-label"
 
     vpc_id = exec_test_command(
@@ -78,13 +77,13 @@ def get_test_vpc_w_rdma_type():
 @pytest.fixture
 def get_test_subnet(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
-    subnet_label = get_random_text(5) + "-label"
-    res = exec_test_command(
+    label = get_random_text(5) + "-label"
+    subnet_id = exec_test_command(
         BASE_CMDS["vpcs"]
         + [
             "subnet-create",
             "--label",
-            subnet_label,
+            label,
             "--ipv4",
             "10.0.0.0/24",
             vpc_id,
@@ -92,9 +91,31 @@ def get_test_subnet(get_test_vpc_wo_subnet):
             "--no-headers",
             "--delimiter=,",
         ]
-    )
+    ).split(",")[0]
 
-    yield res, subnet_label
+    yield vpc_id, subnet_id
+
+
+@pytest.fixture
+def get_test_subnet_w_rdma_type(get_test_vpc_w_rdma_type):
+    vpc_id = get_test_vpc_w_rdma_type
+    label = get_random_text(5) + "-test-rdma-subnet"
+    subnet_id = exec_test_command(
+        BASE_CMDS["vpcs"]
+        + [
+            "subnet-create",
+            "--label",
+            label,
+            "--ipv4",
+            "10.0.0.0/24",
+            vpc_id,
+            "--text",
+            "--no-headers",
+            "--delimiter=,",
+        ]
+    ).split(",")[0]
+
+    yield vpc_id, subnet_id
 
 
 @pytest.fixture

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -11,7 +11,7 @@ from tests.integration.helpers import (
 
 
 @pytest.fixture
-def test_vpc_w_subnet():
+def get_test_vpc_w_subnet():
     vpc_json = create_vpc_w_subnet()
     vpc_id = str(vpc_json["id"])
 
@@ -21,7 +21,7 @@ def test_vpc_w_subnet():
 
 
 @pytest.fixture
-def test_vpc_wo_subnet():
+def get_test_vpc_wo_subnet():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
 
     label = get_random_text(5) + "-label"
@@ -48,8 +48,8 @@ def test_vpc_wo_subnet():
 
 
 @pytest.fixture
-def test_subnet(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def get_test_subnet(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     subnet_label = get_random_text(5) + "-label"
     res = exec_test_command(
         BASE_CMDS["vpcs"]

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -33,8 +33,8 @@ def get_test_vpc_wo_subnet():
             label,
             "--region",
             region,
-            # "--ipv6.range",    TODO: Uncomment after VPC Dual Stack is ready to ship
-            # "auto",
+            "--ipv6.range",
+            "auto",
             "--no-headers",
             "--text",
             "--format=id",

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -33,8 +33,8 @@ def get_test_vpc_wo_subnet():
             label,
             "--region",
             region,
-            "--ipv6.range",
-            "auto",
+            # "--ipv6.range",    TODO: Uncomment after VPC Dual Stack is ready to ship
+            # "auto",
             "--no-headers",
             "--text",
             "--format=id",

--- a/tests/integration/vpc/conftest.py
+++ b/tests/integration/vpc/conftest.py
@@ -48,6 +48,34 @@ def get_test_vpc_wo_subnet():
 
 
 @pytest.fixture
+def get_test_vpc_w_rdma_type():
+    # GPUDirect RDMA capability not available for now
+    # region = get_random_region_with_caps(required_capabilities=["VPCs", "GPUDirect RDMA"])
+    region = get_random_region_with_caps(required_capabilities=["VPCs"])
+    label = get_random_text(5) + "-test-rdma-vpc"
+
+    vpc_id = exec_test_command(
+        BASE_CMDS["vpcs"]
+        + [
+            "create",
+            "--label",
+            label,
+            "--region",
+            region,
+            "--vpc_type",
+            "rdma",
+            "--no-headers",
+            "--text",
+            "--format=id",
+        ]
+    )
+
+    yield vpc_id
+
+    delete_target_id(target="vpcs", id=vpc_id)
+
+
+@pytest.fixture
 def get_test_subnet(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     subnet_label = get_random_text(5) + "-label"

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -431,7 +431,9 @@ def test_get_vpc_default_ranges():
     headers = ["default_ipv4_ranges", "forbidden_ipv4_ranges"]
 
     result = json.loads(
-        exec_test_command(BASE_CMD + ["default-ranges-all-list", "--json"])
+        exec_test_command(
+            BASE_CMDS["vpcs"] + ["default-ranges-all-list", "--json"]
+        )
     )[0]
 
     assert all(header in result.keys() for header in headers)
@@ -490,7 +492,7 @@ def test_vpc_update_with_ipv4(create_vpc_with_ipv4, updated):
 
 def test_vpc_with_forbidden_ipv4_fail():
     forbidden_ipv4 = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "default-ranges-all-list",
             "--text",

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -16,10 +16,6 @@ HEADERS_VPC = ["id", "label", "description", "region", "vpc_type"]
 HEADERS_SUBNET = ["id", "label", "ipv4", "vpc_type"]
 
 
-# TODO: Remove this variable and @pytest.mark.skipif once VPC Dual Stack is ready to ship
-disable_vpc_dual_stack_tests = True
-
-
 def get_vpcs_list(params: str = None):
     params = params.split() if params else []
     command = BASE_CMDS["vpcs"] + ["ls", "--text"] + params
@@ -270,9 +266,6 @@ def test_fails_to_update_vpc_subnet_w_invalid_label(get_test_vpc_w_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
-@pytest.mark.skipif(
-    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
-)
 def test_create_vpc_with_ipv6_auto():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-vpc"
@@ -303,9 +296,6 @@ def test_create_vpc_with_ipv6_auto():
 
 
 @pytest.mark.parametrize("prefix_len", ["52"])
-@pytest.mark.skipif(
-    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
-)
 def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + f"-vpc{prefix_len}"
@@ -333,12 +323,9 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     assert ipv6_range.endswith(f"/{prefix_len}")
 
 
-@pytest.mark.skipif(
-    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
-)
 def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
-    subnet_label = get_random_text(5) + "-ipv6subnet"
+    subnet_label = get_random_text(5) + "-ipv6-subnet"
 
     res = exec_test_command(
         BASE_CMDS["vpcs"]
@@ -372,9 +359,6 @@ def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
     assert "/" in ipv6_range, f"Unexpected IPv6 CIDR format: {ipv6_range}"
 
 
-@pytest.mark.skipif(
-    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
-)
 def test_fails_to_create_vpc_with_invalid_ipv6_range():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-invalidvpc"
@@ -410,9 +394,6 @@ def test_list_vpc_ip_address():
         assert header in lines[0]
 
 
-@pytest.mark.skipif(
-    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
-)
 def test_list_vpc_ipv6s_address():
 
     res = exec_test_command(
@@ -431,7 +412,9 @@ def test_get_vpc_default_ranges():
     headers = ["default_ipv4_ranges", "forbidden_ipv4_ranges"]
 
     result = json.loads(
-        exec_test_command(BASE_CMD + ["default-ranges-all-list", "--json"])
+        exec_test_command(
+            BASE_CMDS["vpcs"] + ["default-ranges-all-list", "--json"]
+        )
     )[0]
 
     assert all(header in result.keys() for header in headers)
@@ -490,7 +473,7 @@ def test_vpc_update_with_ipv4(create_vpc_with_ipv4, updated):
 
 def test_vpc_with_forbidden_ipv4_fail():
     forbidden_ipv4 = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "default-ranges-all-list",
             "--text",

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -173,6 +173,7 @@ def test_subnet_with_rdma_type_vpc(get_test_subnet_w_rdma_type):
     assert output["vpc_type"] == "rdma"
 
 
+@pytest.mark.skip(reason="Defect: ARB-8019")
 def test_fails_to_create_vpc_invalid_label():
     invalid_label = "invalid_label"
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
@@ -203,6 +204,7 @@ def test_fails_to_create_vpc_duplicate_label(get_test_vpc_wo_subnet):
     assert "Label must be unique among your VPCs" in res
 
 
+@pytest.mark.skip(reason="Defect: ARB-8019")
 def test_fails_to_update_vpc_invalid_label(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     invalid_label = "invalid_label"
@@ -216,6 +218,7 @@ def test_fails_to_update_vpc_invalid_label(get_test_vpc_wo_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
+@pytest.mark.skip(reason="Defect: ARB-8019")
 def test_fails_to_create_vpc_subnet_w_invalid_label(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     invalid_label = "invalid_label"
@@ -237,6 +240,7 @@ def test_fails_to_create_vpc_subnet_w_invalid_label(get_test_vpc_wo_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
+@pytest.mark.skip(reason="Defect: ARB-8019")
 def test_fails_to_update_vpc_subnet_w_invalid_label(get_test_vpc_w_subnet):
     vpc_id = get_test_vpc_w_subnet
 

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -13,7 +13,8 @@ from tests.integration.helpers import (
 )
 
 BASE_CMD = ["linode-cli", "vpcs"]
-VPC_HEADERS = ["id", "label", "description", "region", "vpc_type"]
+HEADERS_VPC = ["id", "label", "description", "region", "vpc_type"]
+HEADERS_SUBNET = ["id", "label", "ipv4", "vpc_type"]
 
 
 # TODO: Remove this variable and @pytest.mark.skipif once VPC Dual Stack is ready to ship
@@ -22,14 +23,29 @@ disable_vpc_dual_stack_tests = True
 
 def get_vpcs_list(params: str = None):
     params = params.split() if params else []
-    command = BASE_CMDS["vpcs"] + ["ls", "--text"] + params
-
+    command = BASE_CMD + ["ls", "--text"] + params
     return exec_test_command(command)
 
 
 def get_vpc_view(vpc_id: int = None):
     return json.loads(
-        exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
+        exec_test_command(
+            BASE_CMD + ["view", vpc_id, "--json"]
+        )
+    )[0]
+
+
+def get_subnets_list(vpc_id: int, params: str = None):
+    params = params.split() if params else []
+    command = BASE_CMD + ["subnets-list", vpc_id] + params
+    return exec_test_command(command)
+
+
+def get_subnet_view(vpc_id: int, subnet_id: int):
+    return json.loads(
+        exec_test_command(
+            BASE_CMD + ["subnet-view", vpc_id, subnet_id, "--json"]
+        )
     )[0]
 
 
@@ -37,7 +53,7 @@ def test_list_vpcs(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     output = get_vpcs_list("--page-size 100")
 
-    assert all(header in output for header in VPC_HEADERS)
+    assert all(header in output for header in HEADERS_VPC)
     assert vpc_id in output
 
 
@@ -45,6 +61,7 @@ def test_view_vpc(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     output = get_vpc_view(vpc_id)
 
+    assert all([header in output.keys() for header in HEADERS_VPC])
     assert str(output["id"]) == vpc_id
     assert output["vpc_type"] == "regular"
 
@@ -83,7 +100,7 @@ def test_vpc_with_rdma_type(get_test_vpc_w_rdma_type):
     vpc_id = get_test_vpc_w_rdma_type
 
     output = get_vpcs_list("--page-size 100")
-    assert all(header in output for header in VPC_HEADERS)
+    assert all(header in output for header in HEADERS_VPC)
     assert vpc_id in output
 
     output = get_vpcs_list("--page-size 100 --format=vpc_type --no-headers")
@@ -97,41 +114,23 @@ def test_vpc_with_rdma_type(get_test_vpc_w_rdma_type):
 def test_list_subnets(get_test_vpc_w_subnet):
     vpc_id = get_test_vpc_w_subnet
 
-    res = exec_test_command(
-        BASE_CMD + ["subnets-list", vpc_id, "--text", "--delimiter=,"]
-    )
+    output = get_subnets_list(vpc_id, "--text --delimiter=,").splitlines()
+    assert all(header in output[0] for header in HEADERS_SUBNET)
 
-    lines = res.splitlines()
-
-    headers = ["id", "label", "ipv4"]
-
-    for header in headers:
-        assert header in lines[0]
-
-    for line in lines[1:]:
+    for line in output[1:]:
         assert re.match(
-            r"^(\d+),(\w+),(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d+)$", line
+            r"^(\d+),(\w+),(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d+),(\w+)$",
+            line,
         ), "String format does not match"
 
 
-def test_view_subnet(get_test_vpc_wo_subnet, get_test_subnet):
-    # note calling test_subnet fixture will add subnet to test_vpc_wo_subnet
-    res, label = get_test_subnet
+def test_view_subnet(get_test_subnet):
+    vpc_id, subnet_id = get_test_subnet
+    output = get_subnet_view(vpc_id, subnet_id)
 
-    res = res.split(",")
-
-    vpc_subnet_id = res[0]
-
-    vpc_id = get_test_vpc_wo_subnet
-
-    output = exec_test_command(
-        BASE_CMDS["vpcs"] + ["subnet-view", vpc_id, vpc_subnet_id, "--text"]
-    )
-
-    headers = ["id", "label", "ipv4"]
-    for header in headers:
-        assert header in output
-    assert vpc_subnet_id in output
+    assert all(header in output.keys() for header in HEADERS_SUBNET)
+    assert str(output["id"]) == subnet_id
+    assert output["vpc_type"] == "regular"
 
 
 @pytest.mark.smoke
@@ -160,6 +159,21 @@ def test_update_subnet(get_test_vpc_w_subnet):
     )
 
     assert new_label == updated_label
+
+
+def test_subnet_with_rdma_type_vpc(get_test_subnet_w_rdma_type):
+    vpc_id, subnet_id = get_test_subnet_w_rdma_type
+
+    output = get_subnets_list(vpc_id)
+    assert all(header in output for header in HEADERS_SUBNET)
+    assert subnet_id in output
+
+    output = get_subnets_list(vpc_id, "--format=vpc_type --no-headers")
+    assert any(["rdma" in output.split()])
+
+    output = get_subnet_view(vpc_id, subnet_id)
+    assert str(output["id"]) == subnet_id
+    assert output["vpc_type"] == "rdma"
 
 
 def test_fails_to_create_vpc_invalid_label():

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 import pytest
@@ -10,6 +11,7 @@ from tests.integration.helpers import (
     exec_test_command,
     get_random_region_with_caps,
     get_random_text,
+    wait_for_condition,
 )
 
 HEADERS_VPC = ["id", "label", "description", "region", "vpc_type"]
@@ -427,6 +429,10 @@ def test_list_vpc_ipv6s_address():
         assert header in lines[0]
 
 
+@pytest.mark.skipif(
+    os.environ.get("LINODE_CLI_API_VERSION", None) != "v4beta",
+    reason="At the moment default-ranges-all-list command is available on beta env only",
+)
 def test_get_vpc_default_ranges():
     headers = ["default_ipv4_ranges", "forbidden_ipv4_ranges"]
 
@@ -452,10 +458,15 @@ def test_get_vpc_default_ranges():
 def test_vpc_with_ipv4(create_vpc_with_ipv4, expected):
     vpc_id = create_vpc_with_ipv4
 
-    result = exec_test_command(
-        BASE_CMDS["vpcs"] + ["list", "--text", "--format=id", "--no-headers"]
-    )
-    assert vpc_id in result.splitlines()
+    def vpc_ready():
+        vpc_ids = exec_test_command(
+            BASE_CMDS["vpcs"]
+            + ["list", "--text", "--format=id", "--no-headers"]
+        ).splitlines()
+
+        return vpc_id in vpc_ids
+
+    wait_for_condition(3, 30, vpc_ready)
 
     result = json.loads(
         exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
@@ -490,6 +501,10 @@ def test_vpc_update_with_ipv4(create_vpc_with_ipv4, updated):
     assert result["ipv4"][0]["range"] == updated
 
 
+@pytest.mark.skipif(
+    os.environ.get("LINODE_CLI_API_VERSION", None) != "v4beta",
+    reason="At the moment default-ranges-all-list command is available on beta env only",
+)
 def test_vpc_with_forbidden_ipv4_fail():
     forbidden_ipv4 = exec_test_command(
         BASE_CMDS["vpcs"]

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -19,8 +19,8 @@ BASE_CMD = ["linode-cli", "vpcs"]
 disable_vpc_dual_stack_tests = True
 
 
-def test_list_vpcs(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_list_vpcs(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     res = exec_test_command(BASE_CMDS["vpcs"] + ["ls", "--text"])
     headers = ["id", "label", "description", "region"]
 
@@ -29,8 +29,8 @@ def test_list_vpcs(test_vpc_wo_subnet):
     assert vpc_id in res
 
 
-def test_view_vpc(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_view_vpc(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
 
     res = exec_test_command(
         BASE_CMDS["vpcs"] + ["view", vpc_id, "--text", "--no-headers"]
@@ -40,8 +40,8 @@ def test_view_vpc(test_vpc_wo_subnet):
 
 
 @pytest.mark.smoke
-def test_update_vpc(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_update_vpc(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
 
     new_label = get_random_text(5) + "label"
 
@@ -69,8 +69,8 @@ def test_update_vpc(test_vpc_wo_subnet):
     assert "new description" in description
 
 
-def test_list_subnets(test_vpc_w_subnet):
-    vpc_id = test_vpc_w_subnet
+def test_list_subnets(get_test_vpc_w_subnet):
+    vpc_id = get_test_vpc_w_subnet
 
     res = exec_test_command(
         BASE_CMD + ["subnets-list", vpc_id, "--text", "--delimiter=,"]
@@ -89,15 +89,15 @@ def test_list_subnets(test_vpc_w_subnet):
         ), "String format does not match"
 
 
-def test_view_subnet(test_vpc_wo_subnet, test_subnet):
+def test_view_subnet(get_test_vpc_wo_subnet, get_test_subnet):
     # note calling test_subnet fixture will add subnet to test_vpc_wo_subnet
-    res, label = test_subnet
+    res, label = get_test_subnet
 
     res = res.split(",")
 
     vpc_subnet_id = res[0]
 
-    vpc_id = test_vpc_wo_subnet
+    vpc_id = get_test_vpc_wo_subnet
 
     output = exec_test_command(
         BASE_CMDS["vpcs"] + ["subnet-view", vpc_id, vpc_subnet_id, "--text"]
@@ -110,8 +110,8 @@ def test_view_subnet(test_vpc_wo_subnet, test_subnet):
 
 
 @pytest.mark.smoke
-def test_update_subnet(test_vpc_w_subnet):
-    vpc_id = test_vpc_w_subnet
+def test_update_subnet(get_test_vpc_w_subnet):
+    vpc_id = get_test_vpc_w_subnet
 
     new_label = get_random_text(5) + "label"
 
@@ -150,8 +150,8 @@ def test_fails_to_create_vpc_invalid_label():
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
-def test_fails_to_create_vpc_duplicate_label(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_fails_to_create_vpc_duplicate_label(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     label = exec_test_command(
         BASE_CMD + ["view", vpc_id, "--text", "--no-headers", "--format=label"]
     )
@@ -165,8 +165,8 @@ def test_fails_to_create_vpc_duplicate_label(test_vpc_wo_subnet):
     assert "Label must be unique among your VPCs" in res
 
 
-def test_fails_to_update_vpc_invalid_label(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_fails_to_update_vpc_invalid_label(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     invalid_label = "invalid_label"
 
     res = exec_failing_test_command(
@@ -178,8 +178,8 @@ def test_fails_to_update_vpc_invalid_label(test_vpc_wo_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
-def test_fails_to_create_vpc_subnet_w_invalid_label(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_fails_to_create_vpc_subnet_w_invalid_label(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     invalid_label = "invalid_label"
 
     res = exec_failing_test_command(
@@ -199,8 +199,8 @@ def test_fails_to_create_vpc_subnet_w_invalid_label(test_vpc_wo_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
-def test_fails_to_update_vpc_subnet_w_invalid_label(test_vpc_w_subnet):
-    vpc_id = test_vpc_w_subnet
+def test_fails_to_update_vpc_subnet_w_invalid_label(get_test_vpc_w_subnet):
+    vpc_id = get_test_vpc_w_subnet
 
     invalid_label = "invalid_label"
 
@@ -294,8 +294,8 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
 @pytest.mark.skipif(
     disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
 )
-def test_create_subnet_with_ipv6_auto(test_vpc_wo_subnet):
-    vpc_id = test_vpc_wo_subnet
+def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
+    vpc_id = get_test_vpc_wo_subnet
     subnet_label = get_random_text(5) + "-ipv6subnet"
 
     res = exec_test_command(

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -16,6 +16,10 @@ HEADERS_VPC = ["id", "label", "description", "region", "vpc_type"]
 HEADERS_SUBNET = ["id", "label", "ipv4", "vpc_type"]
 
 
+# TODO: Remove this variable and @pytest.mark.skipif once VPC Dual Stack is ready to ship
+disable_vpc_dual_stack_tests = True
+
+
 def get_vpcs_list(params: str = None):
     params = params.split() if params else []
     command = BASE_CMDS["vpcs"] + ["ls", "--text"] + params
@@ -266,6 +270,9 @@ def test_fails_to_update_vpc_subnet_w_invalid_label(get_test_vpc_w_subnet):
     assert "Must only use ASCII letters, numbers, and dashes" in res
 
 
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_vpc_with_ipv6_auto():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-vpc"
@@ -296,6 +303,9 @@ def test_create_vpc_with_ipv6_auto():
 
 
 @pytest.mark.parametrize("prefix_len", ["52"])
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + f"-vpc{prefix_len}"
@@ -323,9 +333,12 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     assert ipv6_range.endswith(f"/{prefix_len}")
 
 
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
-    subnet_label = get_random_text(5) + "-ipv6-subnet"
+    subnet_label = get_random_text(5) + "-ipv6subnet"
 
     res = exec_test_command(
         BASE_CMDS["vpcs"]
@@ -359,6 +372,9 @@ def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
     assert "/" in ipv6_range, f"Unexpected IPv6 CIDR format: {ipv6_range}"
 
 
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_fails_to_create_vpc_with_invalid_ipv6_range():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
     label = get_random_text(5) + "-invalidvpc"
@@ -394,6 +410,9 @@ def test_list_vpc_ip_address():
         assert header in lines[0]
 
 
+@pytest.mark.skipif(
+    disable_vpc_dual_stack_tests, reason="Dual-stack tests disabled"
+)
 def test_list_vpc_ipv6s_address():
 
     res = exec_test_command(
@@ -412,9 +431,7 @@ def test_get_vpc_default_ranges():
     headers = ["default_ipv4_ranges", "forbidden_ipv4_ranges"]
 
     result = json.loads(
-        exec_test_command(
-            BASE_CMDS["vpcs"] + ["default-ranges-all-list", "--json"]
-        )
+        exec_test_command(BASE_CMD + ["default-ranges-all-list", "--json"])
     )[0]
 
     assert all(header in result.keys() for header in headers)
@@ -473,7 +490,7 @@ def test_vpc_update_with_ipv4(create_vpc_with_ipv4, updated):
 
 def test_vpc_with_forbidden_ipv4_fail():
     forbidden_ipv4 = exec_test_command(
-        BASE_CMDS["vpcs"]
+        BASE_CMD
         + [
             "default-ranges-all-list",
             "--text",

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -12,7 +12,6 @@ from tests.integration.helpers import (
     get_random_text,
 )
 
-BASE_CMD = ["linode-cli", "vpcs"]
 HEADERS_VPC = ["id", "label", "description", "region", "vpc_type"]
 HEADERS_SUBNET = ["id", "label", "ipv4", "vpc_type"]
 
@@ -23,28 +22,26 @@ disable_vpc_dual_stack_tests = True
 
 def get_vpcs_list(params: str = None):
     params = params.split() if params else []
-    command = BASE_CMD + ["ls", "--text"] + params
+    command = BASE_CMDS["vpcs"] + ["ls", "--text"] + params
     return exec_test_command(command)
 
 
 def get_vpc_view(vpc_id: int = None):
     return json.loads(
-        exec_test_command(
-            BASE_CMD + ["view", vpc_id, "--json"]
-        )
+        exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
     )[0]
 
 
 def get_subnets_list(vpc_id: int, params: str = None):
     params = params.split() if params else []
-    command = BASE_CMD + ["subnets-list", vpc_id] + params
+    command = BASE_CMDS["vpcs"] + ["subnets-list", vpc_id] + params
     return exec_test_command(command)
 
 
 def get_subnet_view(vpc_id: int, subnet_id: int):
     return json.loads(
         exec_test_command(
-            BASE_CMD + ["subnet-view", vpc_id, subnet_id, "--json"]
+            BASE_CMDS["vpcs"] + ["subnet-view", vpc_id, subnet_id, "--json"]
         )
     )[0]
 
@@ -88,7 +85,7 @@ def test_update_vpc(get_test_vpc_wo_subnet):
     )
 
     description = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + ["view", vpc_id, "--text", "--no-headers", "--format=description"]
     )
 
@@ -145,7 +142,7 @@ def test_update_subnet(get_test_vpc_w_subnet):
     )
 
     updated_label = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "subnet-update",
             vpc_id,
@@ -181,7 +178,8 @@ def test_fails_to_create_vpc_invalid_label():
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
 
     res = exec_failing_test_command(
-        BASE_CMD + ["create", "--label", invalid_label, "--region", region],
+        BASE_CMDS["vpcs"]
+        + ["create", "--label", invalid_label, "--region", region],
         ExitCodes.REQUEST_FAILED,
     )
 
@@ -192,12 +190,13 @@ def test_fails_to_create_vpc_invalid_label():
 def test_fails_to_create_vpc_duplicate_label(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
     label = exec_test_command(
-        BASE_CMD + ["view", vpc_id, "--text", "--no-headers", "--format=label"]
+        BASE_CMDS["vpcs"]
+        + ["view", vpc_id, "--text", "--no-headers", "--format=label"]
     )
     region = get_random_region_with_caps(required_capabilities=["VPCs"])
 
     res = exec_failing_test_command(
-        BASE_CMD + ["create", "--label", label, "--region", region],
+        BASE_CMDS["vpcs"] + ["create", "--label", label, "--region", region],
         ExitCodes.REQUEST_FAILED,
     )
 
@@ -209,7 +208,7 @@ def test_fails_to_update_vpc_invalid_label(get_test_vpc_wo_subnet):
     invalid_label = "invalid_label"
 
     res = exec_failing_test_command(
-        BASE_CMD + ["update", vpc_id, "--label", invalid_label],
+        BASE_CMDS["vpcs"] + ["update", vpc_id, "--label", invalid_label],
         ExitCodes.REQUEST_FAILED,
     )
 
@@ -222,7 +221,7 @@ def test_fails_to_create_vpc_subnet_w_invalid_label(get_test_vpc_wo_subnet):
     invalid_label = "invalid_label"
 
     res = exec_failing_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "subnet-create",
             "--label",
@@ -244,12 +243,12 @@ def test_fails_to_update_vpc_subnet_w_invalid_label(get_test_vpc_w_subnet):
     invalid_label = "invalid_label"
 
     subnet_id = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + ["subnets-list", vpc_id, "--text", "--format=id", "--no-headers"]
     )
 
     res = exec_failing_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "subnet-update",
             vpc_id,
@@ -275,7 +274,7 @@ def test_create_vpc_with_ipv6_auto():
     label = get_random_text(5) + "-vpc"
 
     res = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "create",
             "--label",
@@ -308,7 +307,7 @@ def test_create_vpc_with_custom_ipv6_prefix_length(prefix_len):
     label = get_random_text(5) + f"-vpc{prefix_len}"
 
     res = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "create",
             "--label",
@@ -338,7 +337,7 @@ def test_create_subnet_with_ipv6_auto(get_test_vpc_wo_subnet):
     subnet_label = get_random_text(5) + "-ipv6subnet"
 
     res = exec_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "subnet-create",
             "--label",
@@ -377,7 +376,7 @@ def test_fails_to_create_vpc_with_invalid_ipv6_range():
     label = get_random_text(5) + "-invalidvpc"
 
     res = exec_failing_test_command(
-        BASE_CMD
+        BASE_CMDS["vpcs"]
         + [
             "create",
             "--label",
@@ -396,7 +395,7 @@ def test_fails_to_create_vpc_with_invalid_ipv6_range():
 def test_list_vpc_ip_address():
 
     res = exec_test_command(
-        BASE_CMD + ["ips-all-list", "--text", "--delimiter=,"]
+        BASE_CMDS["vpcs"] + ["ips-all-list", "--text", "--delimiter=,"]
     )
 
     lines = res.splitlines()
@@ -413,7 +412,7 @@ def test_list_vpc_ip_address():
 def test_list_vpc_ipv6s_address():
 
     res = exec_test_command(
-        BASE_CMD + ["ipv6s-all-list", "--text", "--delimiter=,"]
+        BASE_CMDS["vpcs"] + ["ipv6s-all-list", "--text", "--delimiter=,"]
     )
 
     lines = res.splitlines()

--- a/tests/integration/vpc/test_vpc.py
+++ b/tests/integration/vpc/test_vpc.py
@@ -13,30 +13,40 @@ from tests.integration.helpers import (
 )
 
 BASE_CMD = ["linode-cli", "vpcs"]
+VPC_HEADERS = ["id", "label", "description", "region", "vpc_type"]
 
 
 # TODO: Remove this variable and @pytest.mark.skipif once VPC Dual Stack is ready to ship
 disable_vpc_dual_stack_tests = True
 
 
+def get_vpcs_list(params: str = None):
+    params = params.split() if params else []
+    command = BASE_CMDS["vpcs"] + ["ls", "--text"] + params
+
+    return exec_test_command(command)
+
+
+def get_vpc_view(vpc_id: int = None):
+    return json.loads(
+        exec_test_command(BASE_CMDS["vpcs"] + ["view", vpc_id, "--json"])
+    )[0]
+
+
 def test_list_vpcs(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
-    res = exec_test_command(BASE_CMDS["vpcs"] + ["ls", "--text"])
-    headers = ["id", "label", "description", "region"]
+    output = get_vpcs_list("--page-size 100")
 
-    for header in headers:
-        assert header in res
-    assert vpc_id in res
+    assert all(header in output for header in VPC_HEADERS)
+    assert vpc_id in output
 
 
 def test_view_vpc(get_test_vpc_wo_subnet):
     vpc_id = get_test_vpc_wo_subnet
+    output = get_vpc_view(vpc_id)
 
-    res = exec_test_command(
-        BASE_CMDS["vpcs"] + ["view", vpc_id, "--text", "--no-headers"]
-    )
-
-    assert vpc_id in res
+    assert str(output["id"]) == vpc_id
+    assert output["vpc_type"] == "regular"
 
 
 @pytest.mark.smoke
@@ -67,6 +77,21 @@ def test_update_vpc(get_test_vpc_wo_subnet):
 
     assert new_label == updated_label
     assert "new description" in description
+
+
+def test_vpc_with_rdma_type(get_test_vpc_w_rdma_type):
+    vpc_id = get_test_vpc_w_rdma_type
+
+    output = get_vpcs_list("--page-size 100")
+    assert all(header in output for header in VPC_HEADERS)
+    assert vpc_id in output
+
+    output = get_vpcs_list("--page-size 100 --format=vpc_type --no-headers")
+    assert any(["rdma" in output.split()])
+
+    output = get_vpc_view(vpc_id)
+    assert str(output["id"]) == vpc_id
+    assert output["vpc_type"] == "rdma"
 
 
 def test_list_subnets(get_test_vpc_w_subnet):


### PR DESCRIPTION
## 📝 Description

Added integration tests for RDMA interfaces and refactored existing ones

**RDMA functionality is available on DevCloud only at the moment**

Notes:
1. [PR](https://git.source.akamai.com/projects/TECHDOCS/repos/akamai-api-inventory/pull-requests/2762/overview) with openapi.json is already merged, however openapi.json file is not updated yet in linode-api-openapi repo so CLI can be build locally only using the latest openapi.json taken from the PR mentioned above
2. Some tests have been marked as **skipped** due to ongoing API defect `ARB-8019`

## ✔️ How to Test

`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_list_vpcs"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_view_vpc"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_vpc_with_rdma_type"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_list_subnets"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_view_subnet"`
`make test-int TEST_SUITE=vpc TEST_ARGS="-k test_subnet_with_rdma_type_vpc"`
