### PR TITLE
TPT-4560: Add merge readiness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch: null
   push:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 jobs:
   docker-build:
     runs-on: ubuntu-latest
@@ -57,6 +58,18 @@ jobs:
 
       - name: run linter
         run: make lint
+
+      - name: Check Merge Readiness
+        if: github.event_name == 'pull_request'
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+
+          if echo "$LABELS" | grep -q "do-not-merge"; then
+            echo "This PR is labeled as 'do-not-merge' so please make sure it is ready."
+            exit 1
+          else
+            exit 0
+          fi
 
   unit-tests-on-ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,10 @@ jobs:
         run: make lint
 
       - name: Check Merge Readiness
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'do-not-merge')
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-
-          if echo "$LABELS" | grep -q "do-not-merge"; then
-            echo "This PR is labeled as 'do-not-merge' so please make sure it is ready."
-            exit 1
-          else
-            exit 0
-          fi
-
+          echo "::error::This PR is labeled 'do-not-merge'."
+          exit 1
   unit-tests-on-ubuntu:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-name: labeler
+name: Labeler
 
 on:
   push:
@@ -11,16 +11,16 @@ on:
     paths:
       - '.github/labels.yml'
       - '.github/workflows/labeler.yml'
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v7
-      -
-        name: Run Labeler
+
+      - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -29,3 +29,15 @@ jobs:
           exclude: |
             help*
             *issue
+
+      - name: Check Merge Readiness
+        if: github.event_name == 'pull_request'
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          
+          if echo "$LABELS" | grep -q "do-not-merge"; then
+            echo "This PR is labeled as 'do-not-merge' so please make sure it is ready."
+            exit 1
+          else
+            exit 0
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,6 @@ on:
     paths:
       - '.github/labels.yml'
       - '.github/workflows/labeler.yml'
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   labeler:
@@ -29,15 +28,3 @@ jobs:
           exclude: |
             help*
             *issue
-
-      - name: Check Merge Readiness
-        if: github.event_name == 'pull_request'
-        run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          
-          if echo "$LABELS" | grep -q "do-not-merge"; then
-            echo "This PR is labeled as 'do-not-merge' so please make sure it is ready."
-            exit 1
-          else
-            exit 0
-          fi


### PR DESCRIPTION
## 📝 Description

Added extra step in `ci.yml` workflow to verify if the PR is ready for merging (i.e. it doesn't have a `do-not-merge` label) and fail the workflow otherwise.

Notes:
- the workflow activates when PR labels are modified
- the workflow depends on `do-not-merge` label presence (it fails when the label has been added)

## ✔️ How to Test

Please play with PR's labels on the right and check Labeler workflow status below
