### PR TITLE
TPT-4494: Support CFW protocol "ALL" / numeric

### DIFF
--- a/tests/integration/firewalls/fixtures.py
+++ b/tests/integration/firewalls/fixtures.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from tests.integration.helpers import (
@@ -58,3 +60,31 @@ def firewall_protocol_all():
     yield firewall_id
 
     delete_target_id(target="firewalls", id=firewall_id)
+
+
+@pytest.fixture(scope="session")
+def firewall_protocol_numeric_and_all():
+    response = json.loads(
+        exec_test_command(
+            BASE_CMDS["firewalls"]
+            + [
+                "create",
+                "--label",
+                "fw-test-" + get_random_text(5),
+                "--rules.inbound_policy",
+                "DROP",
+                "--rules.inbound",
+                '[{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT", "label": "protocol_ALL_test"}]',
+                "--rules.outbound_policy",
+                "ACCEPT",
+                "--rules.outbound",
+                '[{"protocol": "40", "addresses": {"ipv4": ["198.51.100.0/24"]}, "action": "ACCEPT", "label": "protocol_numeric_test"}, '
+                '{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT", "label": "protocol_ALL_test"}]',
+                "--json",
+            ]
+        )
+    )
+
+    yield response
+
+    delete_target_id(target="firewalls", id=str(response[0]["id"]))

--- a/tests/integration/firewalls/fixtures.py
+++ b/tests/integration/firewalls/fixtures.py
@@ -32,3 +32,29 @@ def firewall_id():
     yield firewall_id
 
     delete_target_id(target="firewalls", id=firewall_id)
+
+
+@pytest.fixture(scope="session")
+def firewall_protocol_all():
+    firewall_id = exec_test_command(
+        BASE_CMDS["firewalls"]
+        + [
+            "create",
+            "--label",
+            "fw-test-" + get_random_text(5),
+            "--rules.outbound_policy",
+            "ACCEPT",
+            "--rules.outbound",
+            '[{"protocol": "ALL", "addresses": {"ipv4": ["198.51.100.0/24"]}, "action": "ACCEPT", "label": "protocol_ALL_test"}]',
+            "--rules.inbound_policy",
+            "DROP",
+            "--text",
+            "--no-headers",
+            "--format",
+            "id",
+        ]
+    )
+
+    yield firewall_id
+
+    delete_target_id(target="firewalls", id=firewall_id)

--- a/tests/integration/firewalls/test_firewalls.py
+++ b/tests/integration/firewalls/test_firewalls.py
@@ -8,6 +8,7 @@ from linodecli.exit_codes import ExitCodes
 from tests.integration.firewalls.fixtures import (  # noqa: F401
     FIREWALL_LABEL,
     firewall_id,
+    firewall_protocol_all,
 )
 from tests.integration.helpers import (
     BASE_CMDS,
@@ -275,3 +276,18 @@ def test_firewall_template_view(monkeypatch: MonkeyPatch):
         assert template["rules"]["outbound_policy"] == "ACCEPT"
         assert isinstance(template["rules"]["inbound"], list)
         assert isinstance(template["rules"]["outbound"], list)
+
+
+def test_create_and_read_firewall_protocol_all(firewall_protocol_all):
+    output = json.loads(
+        exec_test_command(
+            BASE_CMDS["firewalls"]
+            + [
+                "rules-list",
+                firewall_protocol_all,
+                "--json",
+            ]
+        )
+    )
+    assert output[0]["outbound"][0]["protocol"] == "ALL"
+    assert output[0]["outbound"][0]["addresses"]["ipv4"] == ["198.51.100.0/24"]

--- a/tests/integration/firewalls/test_firewalls.py
+++ b/tests/integration/firewalls/test_firewalls.py
@@ -8,7 +8,6 @@ from linodecli.exit_codes import ExitCodes
 from tests.integration.firewalls.fixtures import (  # noqa: F401
     FIREWALL_LABEL,
     firewall_id,
-    firewall_protocol_all,
 )
 from tests.integration.helpers import (
     BASE_CMDS,
@@ -276,18 +275,3 @@ def test_firewall_template_view(monkeypatch: MonkeyPatch):
         assert template["rules"]["outbound_policy"] == "ACCEPT"
         assert isinstance(template["rules"]["inbound"], list)
         assert isinstance(template["rules"]["outbound"], list)
-
-
-def test_create_and_read_firewall_protocol_all(firewall_protocol_all):
-    output = json.loads(
-        exec_test_command(
-            BASE_CMDS["firewalls"]
-            + [
-                "rules-list",
-                firewall_protocol_all,
-                "--json",
-            ]
-        )
-    )
-    assert output[0]["outbound"][0]["protocol"] == "ALL"
-    assert output[0]["outbound"][0]["addresses"]["ipv4"] == ["198.51.100.0/24"]

--- a/tests/integration/firewalls/test_firewalls_rules.py
+++ b/tests/integration/firewalls/test_firewalls_rules.py
@@ -3,6 +3,8 @@ import re
 
 from tests.integration.firewalls.fixtures import (  # noqa: F401
     firewall_id,
+    firewall_protocol_all,
+    firewall_protocol_numeric_and_all,
 )
 from tests.integration.helpers import (
     BASE_CMDS,
@@ -280,3 +282,65 @@ def test_list_rules_json_format(firewall_id):
         )
     )
     assert result[0]["inbound"][0]["label"] == "rules-list-test"
+
+
+def test_create_firewall_protocol_numeric_and_all(
+    firewall_protocol_numeric_and_all,
+):
+    output = firewall_protocol_numeric_and_all[0]
+    assert output["status"] == "enabled"
+    assert output["rules"]["inbound_policy"] == "DROP"
+    assert output["rules"]["inbound"][0]["action"] == "ACCEPT"
+    assert output["rules"]["inbound"][0]["protocol"] == "ALL"
+    assert output["rules"]["inbound"][0]["addresses"]["ipv4"] == ["0.0.0.0/0"]
+    assert output["rules"]["outbound_policy"] == "ACCEPT"
+    assert output["rules"]["outbound"][0]["action"] == "ACCEPT"
+    assert output["rules"]["outbound"][0]["protocol"] == "40"
+    assert output["rules"]["outbound"][0]["addresses"]["ipv4"] == [
+        "198.51.100.0/24"
+    ]
+    assert output["rules"]["outbound"][1]["action"] == "ACCEPT"
+    assert output["rules"]["outbound"][1]["protocol"] == "ALL"
+    assert output["rules"]["outbound"][1]["addresses"]["ipv4"] == ["0.0.0.0/0"]
+    assert output["rules"]["version"] == 1
+
+
+def test_firewall_protocol_all_get_rules_list(firewall_protocol_all):
+    output = json.loads(
+        exec_test_command(
+            BASE_CMDS["firewalls"]
+            + [
+                "rules-list",
+                firewall_protocol_all,
+                "--json",
+            ]
+        )
+    )
+    assert len(output[0]["inbound"]) == 0
+    assert output[0]["inbound_policy"] == "DROP"
+    assert output[0]["outbound_policy"] == "ACCEPT"
+    assert output[0]["outbound"][0]["action"] == "ACCEPT"
+    assert output[0]["outbound"][0]["protocol"] == "ALL"
+    assert output[0]["outbound"][0]["addresses"]["ipv4"] == ["198.51.100.0/24"]
+    assert output[0]["version"] == 1
+
+
+def test_firewall_protocol_all_get_version_view(firewall_protocol_all):
+    output = json.loads(
+        exec_test_command(
+            BASE_CMDS["firewalls"]
+            + [
+                "version-view",
+                firewall_protocol_all,
+                "1",
+                "--json",
+            ]
+        )
+    )
+    assert len(output[0]["inbound"]) == 0
+    assert output[0]["inbound_policy"] == "DROP"
+    assert output[0]["outbound_policy"] == "ACCEPT"
+    assert output[0]["outbound"][0]["action"] == "ACCEPT"
+    assert output[0]["outbound"][0]["protocol"] == "ALL"
+    assert output[0]["outbound"][0]["addresses"]["ipv4"] == ["198.51.100.0/24"]
+    assert output[0]["version"] == 1


### PR DESCRIPTION
## ✔️ How to Test

NOTE: This feature is not yet generally available. See TPT-4469 for required test environment information.

> make test-int TEST_ARGS="-k test_create_firewall_protocol_numeric_and_all"
> make test-int TEST_ARGS="-k test_firewall_protocol_all_get_rules_list"
> make test-int TEST_ARGS="-k test_firewall_protocol_all_get_version_view"