### PR TITLE
TPT-4626: Parser fix for unknown nested-list objects

### DIFF
--- a/linodecli/baked/response.py
+++ b/linodecli/baked/response.py
@@ -316,8 +316,15 @@ class OpenAPIResponse:
             for cur in json:
                 # Get the nested list using the path
                 nlist_path = cur
+
                 for p in path_parts:
                     nlist_path = nlist_path.get(p)
+
+                # To avoid errors when nested list is not documented in
+                # the OpenAPI spec, but it is present in the API response
+                if nlist_path is None:
+                    continue
+
                 nlist = nlist_path
 
                 # For each item in the nested list,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -21,6 +21,60 @@ class TestResponse:
             {"_split": "cool", "foo": 321},
         ]
 
+    def test_model_fix_json_nested_skips_unexpected_path(
+        self, list_operation_for_response_test
+    ):
+        model = list_operation_for_response_test.response_model
+        model.nested_list = "engines.foo, engines.bar"
+
+        result = model.fix_json(
+            [
+                {
+                    "id": "id-number-1",
+                    "engines": {
+                        "foo": [{"quantity": 1}, {"quantity": 2}],
+                        "bar": [{"quantity": 3}],
+                    },
+                },
+                {
+                    "id": "id-number-2",
+                    "engines": {
+                        "foo": [{"quantity": 4}],
+                    },
+                },
+                {
+                    "id": "id-number-3",
+                    "engines": {
+                        "xyz": [{"quantity": 5}],
+                    },
+                }
+            ]
+        )
+        result = sorted(result, key=lambda x: x["id"])
+
+        assert result == [
+            {
+                "id": "id-number-1",
+                "_split": "foo",
+                "engines": {"quantity": 1},
+            },
+            {
+                "id": "id-number-1",
+                "_split": "foo",
+                "engines": {"quantity": 2},
+            },
+            {
+                "id": "id-number-1",
+                "_split": "bar",
+                "engines": {"quantity": 3},
+            },
+            {
+                "id": "id-number-2",
+                "_split": "foo",
+                "engines": {"quantity": 4},
+            },
+        ]
+
     def test_attr_get_value(self, list_operation_for_response_test):
         model = {"data": {"foo": {"bar": "cool"}}}
         attr = list_operation_for_response_test.response_model.attrs[0]

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -47,7 +47,7 @@ class TestResponse:
                     "engines": {
                         "xyz": [{"quantity": 5}],
                     },
-                }
+                },
             ]
         )
         result = sorted(result, key=lambda x: x["id"])


### PR DESCRIPTION
## 📝 Description

API response parser fix for unexpected nested-list objects

## ✔️ How to Test
ENV: Prod
OpenAPI spec: latest

`make test-unit`

`make test-int TEST_CASE=test_databases_types`
`make test-int TEST_CASE=test_databases_type_view`