### PR TITLE
Using official naming conventions; use only login-action for OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: OIDC connections
-        id: docker_oidc
-        uses: docker/oidc-action@v1
-        with:
-          connection-id: ${{ vars.DOCKER_OIDC_CONNECTION_ID }}
-          expires-in: 1800
-
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
-          username: ${{ vars.DOCKER_ORGANIZATION_NAME }}
-          password: ${{ steps.docker_oidc.outputs.token }}
+          username: ${{ vars.DOCKERHUB_ORGANIZATION }}
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+          DOCKERHUB_OIDC_EXPIREIN: 1800
 
       # This is necessary as we want to ensure that version tags
       # are properly formatted before passing them into the


### PR DESCRIPTION
- Using docker official naming conventions for var names
- Use only one action for logging int via OIDC